### PR TITLE
812: release action

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -7,48 +7,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Check Master Integrity
+    name: Check Master integrity
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
-      - name: Set up java environment
-        uses: actions/setup-java@v1
-        with: # running setup-java
-          java-version: "17" # LTS version
-          architecture: x64
-
-      - name: Cache Maven packages
-        uses: actions/cache@v1
+      - uses: actions/setup-java@v3
+        name: set java and maven cache
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
-
-      - name: Get version
-        run: |
-          echo "VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
-          echo "Version is $VERSION"
-        id: get_version
-
-      - name: Set up snapshot forgerock maven repository
-        if: contains( env.VERSION, 'SNAPSHOT')
-        uses: actions/setup-java@v1
-        with: # running setup-java and overwrites the settings.xml
-          java-version: "17" # LTS version
+          distribution: 'adopt'
+          java-version: '17'
           architecture: x64
-          server-id: maven.forgerock.org-community-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_REPO_USERNAME # env variable for username in deploy
-          server-password: MAVEN_REPO_TOKEN # env variable for token in deploy
-
-      - name: Check integrity # build the project
-        run: mvn -B clean verify --file pom.xml # this command executes each default lifecycle phase in order (validate, compile, test, package, etc), before executing verify.
+          cache: 'maven'
 
       - name: Release snapshot package to forgerock maven snapshot repository
-        if: contains(env.VERSION, 'SNAPSHOT')
-        run: mvn -B deploy --file pom.xml
-        env:
-          MAVEN_REPO_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
-          MAVEN_REPO_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+        run: mvn -B deploy --file pom.xml -DaltDeploymentRepository=snapshot::default::"https://${{ secrets.FR_ARTIFACTORY_USER }}:${{ secrets.FR_ARTIFACTORY_TOKEN }}@maven.forgerock.org/artifactory/community/"
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,25 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Check PR integrity
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
+        name: set java and maven cache
         with:
-          java-version: "17" # LTS version
+          distribution: 'adopt'
+          java-version: '17'
           architecture: x64
+          cache: 'maven'
 
-      - name: Cache Maven packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
-
-      - name: Check Copyright
-        run: mvn -B com.mycila:license-maven-plugin:check --file pom.xml
-
-      - name: Build
-        run: |
-          mvn -B clean verify --file pom.xml
+      - name: Build and Test
+        run: mvn -B clean package --file pom.xml
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,112 @@
-name: Publish package to the ForgeRock artifactory
+name: create_release_workflow
+run-name: Create release final::${{ inputs.is_final_release }} candidate::${{ inputs.candidate_number }}
+# **What it does**:
+# Reuse workflow 'prepare-release' from parent: update versions, create tag and release branch with release versions
+# Build the maven project as release version and publish the artifact in forgerock maven repo
+# **Artifacts**: java libraries and bill of materials
+# **Artifact repository**: https://maven.forgerock.org/artifactory/community/com/forgerock/sapi/gateway/
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Release notes"
+        required: false
+        type: string
+        default: ''
+      is_final_release:
+        description: "Is a final release, otherwise will be a 'rc' (release candidate)"
+        required: false
+        type: boolean
+        default: false
+      candidate_number:
+        description: "Provide the candidate sequence number (default: 1)"
+        required: false
+        type: string
+        default: 1
+env:
+  GH_TOKEN: ${{ github.token }}
+  GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+  GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+  GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+
 jobs:
-  publish:
+
+  release_prepare: # prepare for a release in scm, creates the tag and release branch with the proper release versions
+    name: Call release prepare
+    # uses: ./.github/workflows/release-prepare.yml # same repository
+    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-prepare.yml@issue/812-action-release-prepare-workflow
+    with:
+      is_final_release: ${{ inputs.is_final_release }}
+      candidate_number: ${{ inputs.candidate_number }}
+    secrets: # inherit only when is the same repository
+      GPG_PRIVATE_KEY_BOT: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
+      GPG_KEY_PASSPHRASE_BOT: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
+      GIT_COMMIT_USERNAME_BOT: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
+      GIT_COMMIT_AUTHOR_EMAIL_BOT: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
+
+  release_perform:
     runs-on: ubuntu-latest
-    name: Deploy release
+    name: Build and publish the release
+    needs: release_prepare
     steps:
-      - uses: actions/checkout@v2
+      - name: outputs context
+        run: |
+          echo "release ref: ${{ needs.release_prepare.outputs.release_ref }}"
+          echo "release_branch: ${{ needs.release_prepare.outputs.release_branch }}"
+          echo "tag_ref: ${{ needs.release_prepare.outputs.tag_ref }}"
+
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v3
+        id: checkout
+        name: checkout master
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ needs.release_prepare.outputs.release_branch }}
 
-      - name: Set up forgerock maven repository
-        uses: actions/setup-java@v1
-        with: # running setup-java and overwrites the settings.xml
-          java-version: "17" # LTS version
+      # https://github.com/crazy-max/ghaction-import-gpg
+      # https://httgp.com/signing-commits-in-github-actions/
+      - name: Import GPG key
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - uses: actions/setup-java@v3
+        id: maven
+        name: set java and maven cache
+        with:
+          distribution: 'adopt'
+          java-version: '14'
           architecture: x64
-          server-id: maven.forgerock.org-community # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username in deploy
-          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+          cache: 'maven'
 
-      - name: Set up snapshot forgerock maven repository
-        if: contains(github.ref, 'SNAPSHOT')
-        uses: actions/setup-java@v1
-        with: # running setup-java and overwrites the settings.xml
-          java-version: "14"
-          architecture: x64
-          server-id: maven.forgerock.org-community-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
-          server-username: MAVEN_USERNAME # env variable for username in deploy
-          server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+      - name: Deploy release
+        id: deploy
+        run: |
+          mvn clean deploy -DaltDeploymentRepository=release::default::"https://${{ secrets.FR_ARTIFACTORY_USER }}:${{ secrets.FR_ARTIFACTORY_TOKEN }}@maven.forgerock.org/artifactory/community/"
 
-      - name: Release package
-        run: mvn -B deploy --file pom.xml
-        env:
-          MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+      - name: Create github release
+        id: release
+        if: ${{ steps.deploy.outcome }} == 'success'
+        run: |
+          # Create a release from input tag
+          gh release create --draft --verify-tag ${{ needs.release_prepare.outputs.tag_ref }} -t "${{ needs.release_prepare.outputs.release_ref }}" --notes "${{ inputs.notes }}"
+
+      - name: Prepare next development iteration
+        id: prepare_next_dev
+        if: ${{ steps.release.outcome }} == 'success'
+        run: |
+          mvn versions:set -DnextSnapshot # set the next snapshot version
+          mvn versions:update-parent -DallowSnapshots # set the latest snapshot
+          mvn versions:commit # confirm the changes and remove pom backups
+          git add .
+          git commit -m "Prepare the next development iteration"
+          git push origin HEAD:${{ needs.release_prepare.outputs.release_branch }}
+
+      - name: create pull request
+        if: ${{ steps.prepare_next_dev.outcome }} == 'success'
+        run: |
+          gh pr create -H ${{ needs.release_prepare.outputs.release_branch }} -B master --title "Release ${{ needs.release_prepare.outputs.release_ref }} created" --body "- Prepare the next development iteration"

--- a/pom.xml
+++ b/pom.xml
@@ -40,15 +40,6 @@
         <java.version>11</java.version>
     </properties>
 
-    <scm>
-        <connection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk-common.git
-        </connection>
-        <developerConnection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk-common.git
-        </developerConnection>
-        <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common.git</url>
-        <tag>HEAD</tag>
-    </scm>
-
     <modules>
         <module>secure-api-gateway-ob-uk-common-bom</module>
         <module>secure-api-gateway-ob-uk-common-shared</module>
@@ -56,19 +47,6 @@
         <module>secure-api-gateway-ob-uk-common-datamodel</module>
         <module>secure-api-gateway-ob-uk-common-error</module>
     </modules>
-
-    <distributionManagement>
-        <repository>
-            <id>maven.forgerock.org-community</id>
-            <name>maven.forgerock.org-releases</name>
-            <url>https://maven.forgerock.org/artifactory/community</url>
-        </repository>
-        <snapshotRepository>
-            <id>maven.forgerock.org-community-snapshots</id>
-            <name>maven.forgerock.org-snapshots</name>
-            <url>https://maven.forgerock.org/artifactory/community</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <repositories>
         <repository>

--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -81,26 +81,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <distributionManagement>
-        <repository>
-            <id>maven.forgerock.org-community</id>
-            <name>maven.forgerock.org-releases</name>
-            <url>https://maven.forgerock.org:443/repo/community</url>
-        </repository>
-        <snapshotRepository>
-            <id>maven.forgerock.org-community-snapshots</id>
-            <name>maven.forgerock.org-snapshots</name>
-            <url>https://maven.forgerock.org:443/repo/community</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <scm>
-        <connection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk-common.git
-        </connection>
-        <developerConnection>scm:git:git@github.com:SecureApiGateway/secure-api-gateway-ob-uk-common.git
-        </developerConnection>
-        <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common.git</url>
-        <tag>HEAD</tag>
-    </scm>
-
 </project>


### PR DESCRIPTION
## Description
This changes provide a way to create a release of the artifacts created in this repository
### How works? 
The release action call the reusable action `prepare release` that lives in a parent repository
- The prepare release workflow will create a tag from `master` and a branch with the release versions: 
    - Creates a tag with master current version and the short has commit (to permits run the action multiple times without failures) 
    - Updates the parent version from snapshot to the latest release 
    - Remove the snapshot version from modules - 
    - Creates a release branch

When finish the reusable workflow `release prepare` the `release` workflow will do:
- Build and publish the artifacts (release version or release candidates)
- Create a release draft in github
- Update the branch with the next snapshot versions for the next development iteration
- Creates a PR to merge the release branch into master
### Changes
- Added release workflow caller
- Updated merge workflow
- Updated pr workflow
- Delete unused sections in pom file
- Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/812