### PR TITLE
812: release action

### DIFF
--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -39,7 +39,18 @@
         <url>http://www.forgerock.org</url>
     </organization>
 
-    <inceptionYear>2020</inceptionYear>
+<!--    <inceptionYear>2020</inceptionYear>-->
+    <properties>
+        <!-- property to run individualy the module with no license issues -->
+        <legal.path.header>../legal/LICENSE-HEADER.txt</legal.path.header>
+    </properties>
+
+    <parent>
+        <groupId>com.forgerock.sapi.gateway</groupId>
+        <artifactId>secure-api-gateway-ob-uk-common</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
The BOM module needs to be built and deployed in the same way that the other modules are built fixing the pom with the parent reference, without the parent reference and properties the version updates goals are not applied in the BOM module, and always the same SNAPSHOT version is published instead of the release version (no snapshot)

- Added parent reference and module properties to BOM pom module