### PR TITLE
812: release action prepare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>0.9.0-rc.1</version>
+        <version>0.9.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Avoid release candidates versions
- Bumped gateway-parent version release 0.9.0

Issue: https://github.com/secureapigateway/secureapigateway/issues/812