### PR TITLE
927: Update versions ready for v1.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>0.9.1</version>
+        <version>1.0.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Use v1.0.0 of parent

Issue: https://github.com/secureapigateway/secureapigateway/issues/927