### PR TITLE
947: validate initiation object date times

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 package uk.org.openbanking.jackson;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.IOException;
-
-import static uk.org.openbanking.jackson.DateTimeSerializer.DATE_TIME_FORMATTER;
 
 public class DateTimeDeserializer extends StdDeserializer<DateTime> {
 
@@ -37,6 +38,6 @@ public class DateTimeDeserializer extends StdDeserializer<DateTime> {
     public DateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
         String date = jsonParser.getText();
-        return DateTime.parse(date, DATE_TIME_FORMATTER);
+        return ISODateTimeFormat.dateTimeParser().parseDateTime(date).withZone(DateTimeZone.UTC);
     }
 }

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 package uk.org.openbanking.jackson;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.IOException;
 
 public class DateTimeSerializer extends StdSerializer<DateTime> {
-
-    public static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ");
 
     public DateTimeSerializer() {
         this(null);
@@ -39,6 +37,6 @@ public class DateTimeSerializer extends StdSerializer<DateTime> {
     @Override
     public void serialize(DateTime dateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
             throws IOException {
-        jsonGenerator.writeObject(DATE_TIME_FORMATTER.print(dateTime));
+        jsonGenerator.writeObject(dateTime.toDateTimeISO().withZone(DateTimeZone.UTC).toString());
     }
 }

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.format.ISODateTimeFormat;
 
 import java.io.IOException;
 


### PR DESCRIPTION
To compare datetimes between different objects using the equals method the date time must have the same chronology, instant and Time zone
- Modified date times deserializer and serializer to use UTC time zone offset and ISO date time, joda date time parser not needs an ISO date formatter because is supported by default.
Issue: https://github.com/secureapigateway/secureapigateway/issues/947