### PR TITLE
983: Adding OBRIErrorType.REQUEST_VRP_CONTROL_PARAMETER_CURRENCY_MISMATCH

### DIFF
--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -714,7 +714,7 @@ public enum OBRIErrorType {
     REQUEST_VRP_CONTROL_PARAMETER_CURRENCY_MISMATCH(
             HttpStatus.BAD_REQUEST,
             OBStandardErrorCodes1.UK_OBIE_RULES_FAILS_CONTROL_PARAMETERS,
-            "The currency of payment initiation field '%s' must match the currency of consent control parameter field '%s'"),
+            "The currency of field '%s' must match the currency of consent control parameter field '%s'"),
 
     REQUEST_VRP_CONTROL_PARAMETERS_PAYMENT_PERIODIC_LIMIT_BREACH(
             HttpStatus.BAD_REQUEST,

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -710,7 +710,11 @@ public enum OBRIErrorType {
     REQUEST_VRP_CONTROL_PARAMETERS_RULES(
             HttpStatus.BAD_REQUEST,
             OBStandardErrorCodes1.UK_OBIE_RULES_FAILS_CONTROL_PARAMETERS,
-            "The field '%s' breach a limitation set by '%s'"),
+            "The field '%s' breaches a limitation set by '%s'"),
+    REQUEST_VRP_CONTROL_PARAMETER_CURRENCY_MISMATCH(
+            HttpStatus.BAD_REQUEST,
+            OBStandardErrorCodes1.UK_OBIE_RULES_FAILS_CONTROL_PARAMETERS,
+            "The currency of payment initiation field '%s' must match the currency of consent control parameter field '%s'"),
 
     REQUEST_VRP_CONTROL_PARAMETERS_PAYMENT_PERIODIC_LIMIT_BREACH(
             HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
New error type for when a domestic VRP payment amount currency does not match the currency of the control parameters.

Fixing type in REQUEST_VRP_CONTROL_PARAMETERS_RULES error message.

This is required to build this PR in RS: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/pull/175

https://github.com/SecureApiGateway/SecureApiGateway/issues/983