### PR TITLE
981 build BigDecimals with scale and rounding mode for dataFactories 

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.payment.*;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class OBExchangeRateTestDataFactory {
 
@@ -28,7 +29,7 @@ public class OBExchangeRateTestDataFactory {
     public static OBWriteInternational2DataInitiationExchangeRateInformation aValidOBWriteInternational2DataInitiationExchangeRateInformation() {
         return (new OBWriteInternational2DataInitiationExchangeRateInformation())
                 .unitCurrency(CURRENCY)
-                .exchangeRate(BigDecimal.TEN)
+                .exchangeRate(BigDecimal.TEN.setScale(4, RoundingMode.HALF_EVEN))
                 .rateType(OBExchangeRateType2Code.AGREED)
                 .contractIdentification(CONTRACT_IDENTIFICATION);
     }
@@ -36,7 +37,7 @@ public class OBExchangeRateTestDataFactory {
     public static OBWriteInternational3DataInitiationExchangeRateInformation aValidOBWriteInternational3DataInitiationExchangeRateInformation() {
         return (new OBWriteInternational3DataInitiationExchangeRateInformation())
                 .unitCurrency(CURRENCY)
-                .exchangeRate(BigDecimal.TEN)
+                .exchangeRate(BigDecimal.TEN.setScale(4, RoundingMode.HALF_EVEN))
                 .rateType(OBExchangeRateType2Code.AGREED)
                 .contractIdentification(CONTRACT_IDENTIFICATION);
     }
@@ -44,7 +45,7 @@ public class OBExchangeRateTestDataFactory {
     public static OBWriteInternationalConsentResponse4DataExchangeRateInformation aValidOBWriteInternationalConsentResponse4DataExchangeRateInformation() {
         return (new OBWriteInternationalConsentResponse4DataExchangeRateInformation())
                 .unitCurrency(CURRENCY)
-                .exchangeRate(BigDecimal.TEN)
+                .exchangeRate(BigDecimal.TEN.setScale(4, RoundingMode.HALF_EVEN))
                 .rateType(OBExchangeRateType2Code.AGREED)
                 .contractIdentification(CONTRACT_IDENTIFICATION)
                 .expirationDateTime(DateTime.now().plusDays(1));
@@ -53,7 +54,7 @@ public class OBExchangeRateTestDataFactory {
     public static OBWriteInternationalConsentResponse6DataExchangeRateInformation aValidOBWriteInternationalConsentResponse6DataExchangeRateInformation() {
         return (new OBWriteInternationalConsentResponse6DataExchangeRateInformation())
                 .unitCurrency(CURRENCY)
-                .exchangeRate(BigDecimal.TEN)
+                .exchangeRate(BigDecimal.TEN.setScale(4, RoundingMode.HALF_EVEN))
                 .rateType(OBExchangeRateType2Code.AGREED)
                 .contractIdentification(CONTRACT_IDENTIFICATION)
                 .expirationDateTime(DateTime.now().plusDays(1));
@@ -62,7 +63,7 @@ public class OBExchangeRateTestDataFactory {
     public static OBExchangeRate1 aValidOBExchangeRate1() {
         return (new OBExchangeRate1())
                 .unitCurrency(CURRENCY)
-                .exchangeRate(BigDecimal.TEN)
+                .exchangeRate(BigDecimal.TEN.setScale(4, RoundingMode.HALF_EVEN))
                 .rateType(OBExchangeRateType2Code.AGREED)
                 .contractIdentification(CONTRACT_IDENTIFICATION);
     }

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
@@ -23,6 +23,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 import uk.org.openbanking.datamodel.payment.*;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent4DataAuthorisation;
@@ -35,7 +36,13 @@ import static uk.org.openbanking.testsupport.payment.OBWriteDomesticScaSupportDa
 public class OBWriteFileConsentTestDataFactory {
 
     public static OBWriteFileConsent3 aValidOBWriteFileConsent3(String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        return new OBWriteFileConsent3().data(aValidOBWriteFileConsent3Data(fileType, fileHash, numberOfTransactions, controlSum));
+        return new OBWriteFileConsent3().data(aValidOBWriteFileConsent3Data(
+                        fileType,
+                        fileHash,
+                        numberOfTransactions,
+                        controlSum.setScale(4, RoundingMode.HALF_EVEN)
+                )
+        );
     }
 
     public static OBWriteFileConsent3 aValidOBWriteFileConsent3MandatoryFields(String fileType, String fileHash) {
@@ -44,7 +51,14 @@ public class OBWriteFileConsentTestDataFactory {
 
     public static OBWriteFileConsent3Data aValidOBWriteFileConsent3Data(String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
         return new OBWriteFileConsent3Data()
-                .initiation(aValidOBWriteFile2DataInitiation(fileType, fileHash, numberOfTransactions, controlSum, DateTime.now()))
+                .initiation(aValidOBWriteFile2DataInitiation(
+                                fileType,
+                                fileHash,
+                                numberOfTransactions,
+                                controlSum.setScale(4, RoundingMode.HALF_EVEN),
+                                DateTime.now()
+                        )
+                )
                 .authorisation(aValidOBWriteDomesticConsent4DataAuthorisation())
                 .scASupportData(aValidOBSCASupportData1());
     }
@@ -66,7 +80,7 @@ public class OBWriteFileConsentTestDataFactory {
                 .fileHash(fileHash)
                 .fileReference("GB2OK238")
                 .numberOfTransactions(numberOfTransactions)
-                .controlSum(controlSum)
+                .controlSum(controlSum.setScale(4, RoundingMode.HALF_EVEN))
                 .requestedExecutionDateTime(requestedExecutionDateTime)
                 .localInstrument("UK.OBIE.CHAPS")
                 .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
@@ -85,7 +99,12 @@ public class OBWriteFileConsentTestDataFactory {
     public static final String CHARGE_CURRENCY = "GBP";
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4(String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(IntentType.PAYMENT_FILE_CONSENT.generateIntentId())
@@ -103,7 +122,12 @@ public class OBWriteFileConsentTestDataFactory {
     }
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4MandatoryFields(String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(IntentType.PAYMENT_FILE_CONSENT.generateIntentId())
@@ -112,7 +136,12 @@ public class OBWriteFileConsentTestDataFactory {
     }
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4(String consentId, String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(consentId)
@@ -134,7 +163,12 @@ public class OBWriteFileConsentTestDataFactory {
     }
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4MandatoryFields(String consentId, String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(consentId)
@@ -146,7 +180,12 @@ public class OBWriteFileConsentTestDataFactory {
     }
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4(String consentId, OBWriteFileConsentResponse4Data.StatusEnum status, String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(consentId)
@@ -168,7 +207,12 @@ public class OBWriteFileConsentTestDataFactory {
     }
 
     public static OBWriteFileConsentResponse4 aValidOBWriteFileConsentResponse4MandatoryFields(String consentId, OBWriteFileConsentResponse4Data.StatusEnum status, String fileType, String fileHash, String numberOfTransactions, BigDecimal controlSum) {
-        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(fileType, fileHash, numberOfTransactions, controlSum);
+        OBWriteFileConsent3 consent3 = aValidOBWriteFileConsent3(
+                fileType,
+                fileHash,
+                numberOfTransactions,
+                controlSum.setScale(4, RoundingMode.HALF_EVEN)
+        );
         return new OBWriteFileConsentResponse4()
                 .data(new OBWriteFileConsentResponse4Data()
                         .consentId(consentId)


### PR DESCRIPTION
~The components that deserialize/serialize and stores the consent as json object uses a mapper where the BigDecimals value differs from the request when a request is send to the RS backend.~ 
~The initiation equality verification fails because the bigDecimals between the initiation objects differs from submit payment request and consent retrieved from IDM where is stored in different precision format.~

~To cope that issue is provided a custom deserialization and serialization for the backend services to deserialize the BigDecimals object from the json payload always in the same way.~
~So that the equality verification of the initiation sections between payment submission and consent it's performed using the same BigDecimal precision format, either the request payload or the payload retrieved from IDM.~

- Updated datafactories to use the BigDecimals fiels with a specific scale and rounding mode
- Moved the Bigdecimal deserializer and serializer to RS

Issue: https://github.com/secureapigateway/secureapigateway/issues/981