### PR TITLE
1012: Fixing OBRIErrorType.CONSENT_STATUS_NOT_AUTHORISED msg to be generic

### DIFF
--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -194,7 +194,7 @@ public enum OBRIErrorType {
     CONSENT_STATUS_NOT_AUTHORISED(
             HttpStatus.BAD_REQUEST,
             OBStandardErrorCodes1.UK_OBIE_INVALID_CONSENT_STATUS,
-            "Confirmation is not allowed unless the consent status is Authorised. Currently, the consent is %s"),
+            "Action can only be performed on consents with status: Authorised. Currently, the consent is: %s"),
     PAYMENT_BALANCE_TRANSFER_INVALID_CREDITOR_ACCOUNT(
             HttpStatus.BAD_REQUEST,
             OBStandardErrorCodes1.UK_OBIE_FIELD_INVALID,


### PR DESCRIPTION
The message previously mentioned Confirmation i.e. Funds Confirmation. Making the error message more generic so that it can be applied to any scenario that requires a consent with status Authorised.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1012