### PR TITLE
1023: Adding a method to FRWriteDomesticConsentConverter to convert the FR type back to the OB type

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
@@ -17,6 +17,10 @@ package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper;
 
 import org.modelmapper.ModelMapper;
 
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPaymentRisk;
+
+import uk.org.openbanking.datamodel.common.OBRisk1;
+
 /**
  * This is used to wrap a singleton model mapper so config can be set in one place without requiring DI/Spring in a common lib.
  * It also allows null handling to be standard for OB classes and the map method to be static.
@@ -27,6 +31,10 @@ public class FRModelMapper {
     static {
         // Set project wide config here
         modelMapper.getConfiguration().setSkipNullEnabled(true);
+
+        // Custom mapping to handle OBRisk1 typo contractPresentInidicator property
+        modelMapper.createTypeMap(OBRisk1.class, FRPaymentRisk.class).addMapping(OBRisk1::getContractPresentInidicator, FRPaymentRisk::setContractPresentIndicator);
+        modelMapper.createTypeMap(FRPaymentRisk.class, OBRisk1.class).addMapping(FRPaymentRisk::getContractPresentIndicator, OBRisk1::setContractPresentInidicator);
     }
 
     /**

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverter.java
@@ -16,6 +16,7 @@
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.*;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRModelMapper;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsentData;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticDataInitiation;
@@ -204,5 +205,9 @@ public class FRWriteDomesticConsentConverter {
                 .creditorPostalAddress(FRPostalAddressConverter.toOBPostalAddress6(initiation.getCreditorPostalAddress()))
                 .remittanceInformation(FRRemittanceInformationConverter.toOBRemittanceInformation1(initiation.getRemittanceInformation()))
                 .supplementaryData(FRSupplementaryDataConverter.toOBSupplementaryData1(initiation.getSupplementaryData()));
+    }
+
+    public static OBWriteDomesticConsent4 toOBWriteDomesticConsent4(FRWriteDomesticConsent frConsent) {
+        return FRModelMapper.map(frConsent, OBWriteDomesticConsent4.class);
     }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.payment;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRWriteDomesticConsent;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+import uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory;
+
+class FRWriteDomesticConsentConverterTest {
+
+    @Test
+    public void testConvert() {
+        // Test converting from OB model to FR and back, verify we got back to the original object
+        final OBWriteDomesticConsent4 originalObConsent = OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4();
+        final FRWriteDomesticConsent frConsent = FRWriteDomesticConsentConverter.toFRWriteDomesticConsent(originalObConsent);
+        assertEquals(originalObConsent, FRWriteDomesticConsentConverter.toOBWriteDomesticConsent4(frConsent));
+    }
+
+}


### PR DESCRIPTION
Using the model mapper library to achieve this, as it cuts down the boilerplate code. Adding a custom type mapping definition to fix the issue with the typo in the OBRisk1.contractPresentInidicator property

https://github.com/SecureApiGateway/SecureApiGateway/issues/1023