### PR TITLE
1032: Adding FR data model classes for VRP consents

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConverters.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRModelMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+
+public class FRDomesticVRPConsentConverters {
+
+    public static FRDomesticVRPConsent toFRDomesticVRPConsent(OBDomesticVRPConsentRequest obConsent) {
+        return FRModelMapper.map(obConsent, FRDomesticVRPConsent.class);
+    }
+
+    public static OBDomesticVRPConsentRequest toOBDomesticVRPConsentRequest(FRDomesticVRPConsent frConsent) {
+        return FRModelMapper.map(frConsent, OBDomesticVRPConsentRequest.class);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPaymentRisk;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRDomesticVRPConsent {
+    private FRDomesticVRPConsentData data;
+    private FRPaymentRisk risk;
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRReadRefundAccount;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an equivalent object in the OB data model 'OBDomesticVRPDetailsData'. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
+ * versions of the Read/Write API.
+ *
+ * <p>
+ * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
+ * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRDomesticVRPConsentData {
+    private FRReadRefundAccount readRefundAccount;
+    private FRWriteDomesticVrpDataInitiation initiation;
+    private FRDomesticVRPControlParameters controlParameters;
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSupplementaryData;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
+ * versions of the Read/Write API.
+ *
+ * <p>
+ * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
+ * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRDomesticVRPControlParameters {
+    private List<String> vrpType;
+    private List<String> psuAuthenticationMethods;
+    private DateTime validFromDateTime;
+    private DateTime validToDateTime;
+    private FRAmount maximumIndividualAmount;
+    private List<FRPeriodicLimits> periodicLimits;
+    private FRSupplementaryData supplementaryData;
+    private List<FRVRPInteractionType> psUInteractionTypes;
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSupplementaryData;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
+ * versions of the Read/Write API.
+ *
+ * <p>
+ * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
+ * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
+ * </p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRPeriodicLimits {
+    private String amount;
+    private String currency;
+    private PeriodTypeEnum periodType;
+    private PeriodAlignmentEnum periodAlignment;
+    private FRSupplementaryData supplementaryData;
+    /**
+     * ^ Period type for this period limit
+     */
+    public enum PeriodTypeEnum {
+        DAY("Day"),
+
+        WEEK("Week"),
+
+        FORTNIGHT("Fortnight"),
+
+        MONTH("Month"),
+
+        HALF_YEAR("Half-year"),
+
+        YEAR("Year");
+
+        private String value;
+
+        PeriodTypeEnum(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static PeriodTypeEnum fromValue(String value) {
+            for (PeriodTypeEnum b : PeriodTypeEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+
+    /**
+     * ^ Specifies whether the period starts on the date of consent creation or lines up with a calendar
+     */
+    public enum PeriodAlignmentEnum {
+        CONSENT("Consent"),
+
+        CALENDAR("Calendar");
+
+        private String value;
+
+        PeriodAlignmentEnum(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @JsonCreator
+        public static PeriodAlignmentEnum fromValue(String value) {
+            for (PeriodAlignmentEnum b : PeriodAlignmentEnum.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum FRVRPInteractionType {
+    INSESSION("InSession"),
+
+    OFFSESSION("OffSession");
+
+    private final String value;
+
+    FRVRPInteractionType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FRVRPInteractionType fromValue(String value) {
+        for (FRVRPInteractionType b : FRVRPInteractionType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConvertersTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.vrp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.vrp.FRDomesticVRPConsent;
+
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPConsentRequest;
+import uk.org.openbanking.testsupport.vrp.OBDomesticVrpConsentRequestTestDataFactory;
+
+class FRDomesticVRPConsentConvertersTest {
+
+    @Test
+    void convertToFRRepresentation() {
+        // Convert from OB to FR type and back, verify we get back to the original object
+        final OBDomesticVRPConsentRequest obConsent = OBDomesticVrpConsentRequestTestDataFactory.aValidOBDomesticVRPConsentRequest();
+        final FRDomesticVRPConsent frDomesticVRPConsent = FRDomesticVRPConsentConverters.toFRDomesticVRPConsent(obConsent);
+        assertEquals(obConsent, FRDomesticVRPConsentConverters.toOBDomesticVRPConsentRequest(frDomesticVRPConsent));
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -59,8 +60,11 @@ public class OBDomesticVRPControlParameters {
     @Valid
     private List<OBVRPInteractionTypes> psUInteractionTypes = null;
 
+    /**
+     * Generated code editted to use common OBSupplementaryData1 type for this field
+     */
     @JsonProperty("SupplementaryData")
-    private Object supplementaryData;
+    private OBSupplementaryData1 supplementaryData;
 
     public OBDomesticVRPControlParameters validFromDateTime(DateTime validFromDateTime) {
         this.validFromDateTime = validFromDateTime;
@@ -250,7 +254,7 @@ public class OBDomesticVRPControlParameters {
         this.psUInteractionTypes = psUInteractionTypes;
     }
 
-    public OBDomesticVRPControlParameters supplementaryData(Object supplementaryData) {
+    public OBDomesticVRPControlParameters supplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
         return this;
     }
@@ -263,11 +267,11 @@ public class OBDomesticVRPControlParameters {
     @ApiModelProperty(value = "^ Additional information that can not be captured in the structured fields and/or any other specific block")
 
 
-    public Object getSupplementaryData() {
+    public OBSupplementaryData1 getSupplementaryData() {
         return supplementaryData;
     }
 
-    public void setSupplementaryData(Object supplementaryData) {
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
     }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.vrp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
+
+class OBDomesticVRPControlParametersTest {
+
+    /**
+     * Test OBDomesticVRPControlParameters.supplementaryData is the correct type.
+     *
+     * The code-gen by default produces a field of type Object, the generated code has been edited to use the
+     * common OBSupplementaryData1 type.
+     *
+     * If this test fails then update OBDomesticVRPControlParameters.supplementaryData field to be OBSupplementaryData1
+     */
+    @Test
+    void ensureSupplementaryDataFieldIsCorrectType() throws Exception {
+        final Field supplementaryDataField = OBDomesticVRPControlParameters.class.getDeclaredField("supplementaryData");
+        assertEquals(OBSupplementaryData1.class, supplementaryDataField.getType());
+    }
+
+}


### PR DESCRIPTION
FR data model classes for VRP consents are required in order to store them in the RCS Consent Store.

Adding FRDomesticVRPConsentConverters to handle conversion between FR and OB types.

Fixing OBDomesticVRPControlParameters generated code to use the OBSupplementaryData1 type for the supplementaryData field. This is for consistency with other payments which reuse this common type.

Adding OBDomesticVRPControlParametersTest to catch if the above change is clobbered by re-generating the code.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1032