### PR TITLE
1035: Removing extra information from UNAUTHORISED_ACCOUNT err msg

### DIFF
--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -124,7 +124,7 @@ public enum OBRIErrorType {
     UNAUTHORISED_ACCOUNT(
             HttpStatus.BAD_REQUEST,
             OBStandardErrorCodes1.UK_OBIE_FIELD_INVALID, // Based on expectation from OBIE Functional Conformance suite
-            "You are not authorised to access account '%s'. The account request '%s' only authorised the following accounts: '%s'"),
+            "You are not authorised to access account '%s'."),
 
     PERMISSIONS_INVALID(
             HttpStatus.FORBIDDEN,


### PR DESCRIPTION
The extra information is leaking the accountIds that have been consented to in the error msg.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1035