### PR TITLE
1084: funds confirmation consent

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverter.java
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.fund;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsentData;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper.FRModelMapper;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsent;
 import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
 
 import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAccountIdentifierConverter.toFRAccountIdentifier;
 
 public class FRFundsConfirmationConsentConverter {
 
-    public static FRFundsConfirmationConsentData toFRFundsConfirmationConsentData(OBFundsConfirmationConsent1 obFundsConfirmationConsent) {
-        return obFundsConfirmationConsent == null ? null : FRFundsConfirmationConsentData.builder()
-                .expirationDateTime(obFundsConfirmationConsent.getData().getExpirationDateTime())
-                .debtorAccount(toFRAccountIdentifier(obFundsConfirmationConsent.getData().getDebtorAccount()))
-                .build();
+    public static FRFundsConfirmationConsent toFRFundsConfirmationConsent(OBFundsConfirmationConsent1 obFundsConfirmationConsent) {
+        return FRModelMapper.map(obFundsConfirmationConsent, FRFundsConfirmationConsent.class);
+    }
+
+    public static OBFundsConfirmationConsent1 toOBFundsConfirmationConsent1(FRFundsConfirmationConsent fundsConfirmationConsent) {
+        return FRModelMapper.map(fundsConfirmationConsent, OBFundsConfirmationConsent1.class);
     }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConverter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.fund;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationData;
 import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
@@ -38,7 +38,7 @@ public class FRModelMapper {
     }
 
     /**
-     * Recommended to only use this for classes with identical members (of which there are many in OB SDK!) with default mapping bwhaciour as this
+     * Recommended to only use this for classes with identical members (of which there are many in OB SDK!) with default mapping behaviour as this
      * avoids a lot of complexity and errors from mapping configs.
      * @param source Source
      * @param clazz Target type

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRFundsConfirmationConsent {
+    private FRFundsConfirmationConsentData data;
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.funds;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.funds.FRFundsConfirmationConsent;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+
+
+import org.junit.jupiter.api.Test;
+import uk.org.openbanking.datamodel.common.OBCashAccount3;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsent1;
+import uk.org.openbanking.datamodel.fund.OBFundsConfirmationConsentData1;
+
+/**
+ * Unit test for {@link FRFundsConfirmationConsentConverter}
+ */
+public class FRFundsConfirmationConsentConverterTest {
+
+    @Test
+    void testConvert() {
+        OBFundsConfirmationConsent1 fundsConfirmationConsent1 = new OBFundsConfirmationConsent1()
+                .data(new OBFundsConfirmationConsentData1()
+                        .debtorAccount(new OBCashAccount3()
+                                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                                .identification("40400422390112")
+                                .name("Mrs B Smith")
+                        )
+                        .expirationDateTime(DateTime.now().plusDays(30))
+                );
+        final FRFundsConfirmationConsent frFundsConfirmationConsent = FRFundsConfirmationConsentConverter.toFRFundsConfirmationConsent(fundsConfirmationConsent1);
+        Assertions.assertThat(FRFundsConfirmationConsentConverter.toOBFundsConfirmationConsent1(frFundsConfirmationConsent));
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
@@ -42,6 +42,6 @@ public class FRFundsConfirmationConsentConverterTest {
                         .expirationDateTime(DateTime.now().plusDays(30))
                 );
         final FRFundsConfirmationConsent frFundsConfirmationConsent = FRFundsConfirmationConsentConverter.toFRFundsConfirmationConsent(fundsConfirmationConsent1);
-        Assertions.assertThat(FRFundsConfirmationConsentConverter.toOBFundsConfirmationConsent1(frFundsConfirmationConsent));
+        Assertions.assertThat(FRFundsConfirmationConsentConverter.toOBFundsConfirmationConsent1(frFundsConfirmationConsent)).isEqualTo(fundsConfirmationConsent1);
     }
 }


### PR DESCRIPTION
- Created `FRFundsConfirmationConsent` object to wrap the `FRFundsConfirmationConsentData`
- Fix typo in `FRModelMapper`
- Upgrade `FRFundsConfirmationConsentConverter`
- Fix funds package
- Added test coverage for funds confirmation converter

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1084