### PR TITLE
958: Making IDEMPOTENCY_KEY_REQUEST_BODY_CHANGED error more concise

### DIFF
--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -79,7 +79,7 @@ public enum OBRIErrorType {
     IDEMPOTENCY_KEY_REQUEST_BODY_CHANGED(
             HttpStatus.BAD_REQUEST,
             ErrorCode.FR_OBRI_IDEMPOTENCY_KEY_REQUEST_BODY_CHANGED,
-            "The provided Idempotency Key: '%s' header matched a previous request but the request body has been changed. The previous request body with id: '%s' was '%s'. The request body you submitted was: '%s'"),
+            "The provided Idempotency Key: '%s' header matched a previous request but the request body has been changed."),
     DETACHED_JWS_INVALID(
             HttpStatus.UNAUTHORIZED,
             ErrorCode.OBRI_DETACHED_JWS_INVALID,


### PR DESCRIPTION
https://github.com/SecureApiGateway/SecureApiGateway/issues/958