### PR TITLE
1095: Error codes for File Payments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-common</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <name>Secure API Gateway common and shared libraries for Open Banking UK specs</name>
     <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common</url>
 

--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-common-bom</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <name>secure-api-gateway-ob-uk-common-bom</name>
 
     <description>
@@ -47,7 +47,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-datamodel/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-error/pom.xml
+++ b/secure-api-gateway-ob-uk-common-error/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
@@ -80,8 +80,10 @@ public enum ErrorCode implements StandardErrorCode {
     OBRI_REQUEST_FILE_INVALID_XML("OBRI.Request.Object.file.invalid.xml"),
     OBRI_REQUEST_FILE_MISSING_XML_ELEMENT("OBRI.Request.Object.file.missing.xml.element"),
     OBRI_REQUEST_FILE_INVALID_JSON("OBRI.Request.Object.file.invalid.json"),
+    OBRI_REQUEST_FILE_INVALID("OBRI.Request.Object.file.invalid"),
     OBRI_REQUEST_FILE_MISSING_JSON_ELEMENT("OBRI.Request.Object.file.missing.json.element"),
     OBRI_NO_FILE_FOR_CONSENT("OBRI.No.File.For.Consent"),
+    OBRI_REQUEST_FILE_TYPE_NOT_SUPPORTED("OBRI.Request.File.Payment.FileType.Not.Supported"),
 
     OBRI_SERVER_INTERNAL_ERROR("OBRI.Server.InternalError"),
     OBRI_REQUEST_UNDEFINED_ERROR_YET("OBRI.Request.ErrorUnknown"),

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -417,14 +417,16 @@ public enum OBRIErrorType {
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_FILE_EMPTY,
             "The file received is empty."),
-    REQUEST_FILE_XML_INVALID(
+    REQUEST_FILE_TYPE_NOT_SUPPORTED(
             HttpStatus.BAD_REQUEST,
-            ErrorCode.OBRI_REQUEST_FILE_INVALID_XML,
-            "The file received was not parsable as valid XML. Reason %s"),
-    REQUEST_FILE_JSON_INVALID(
+            ErrorCode.OBRI_REQUEST_FILE_TYPE_NOT_SUPPORTED,
+            "The Payment FileType: '%s' is not supported"
+    ),
+    REQUEST_FILE_INVALID(
             HttpStatus.BAD_REQUEST,
-            ErrorCode.OBRI_REQUEST_FILE_INVALID_JSON,
-            "The file received was not parsable as valid JSON. Reason %s"),
+            ErrorCode.OBRI_REQUEST_FILE_INVALID,
+            "The Payment file uploaded is invalid - reason: %s"
+    ),
     FILE_PAYMENT_REPORT_NOT_READY(
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_FILE_INVALID_JSON,

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-shared/pom.xml
+++ b/secure-api-gateway-ob-uk-common-shared/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Replacing REQUEST_FILE_XML_INVALID/REQUEST_FILE_JSON_INVALID OBRIErrorTypes with generic: REQUEST_FILE_INVALID
- Adding REQUEST_FILE_TYPE_NOT_SUPPORTED OBRIErrorType
- Bumping version to 1.0.7-SNAPSHOT to avoid breaking compilation of RS master branch
  - Required to build: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/pull/227

https://github.com/SecureApiGateway/SecureApiGateway/issues/1095