### PR TITLE
863: Adding FapiInteractionIdFilter which stores the x-fapi-interaction-id header value in the logging context (MDC)

### DIFF
--- a/secure-api-gateway-ob-uk-common-shared/pom.xml
+++ b/secure-api-gateway-ob-uk-common-shared/pom.xml
@@ -43,8 +43,8 @@
         <!-- ForgeRock dependencies -->
         <!-- Spring -->
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -58,6 +58,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.assertj</groupId>
@@ -70,8 +74,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.uk.common.shared.spring.web.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.MDC;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter which stores the x-fapi-interaction-id header value in the {@link MDC} log context.
+ *
+ * This means that the x-fapi-interaction-id will be present in each log message for a request, which allows requests to
+ * be traced through the system.
+ */
+public class FapiInteractionIdFilter extends OncePerRequestFilter {
+
+    public static final String X_FAPI_INTERACTION_ID = "x-fapi-interaction-id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String xFapiInteractionId = request.getHeader(X_FAPI_INTERACTION_ID);
+        if (StringUtils.hasText(xFapiInteractionId)) {
+            MDC.put(X_FAPI_INTERACTION_ID, xFapiInteractionId);
+        }
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(X_FAPI_INTERACTION_ID);
+        }
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.uk.common.shared.spring.web.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+class FapiInteractionIdFilterTest {
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockFilterChain chain;
+    private FapiInteractionIdFilter filter;
+    private String xFapiInteractionIdFromMdc;
+
+    @BeforeEach
+    void setup() {
+        this.request = new MockHttpServletRequest();
+        this.response = new MockHttpServletResponse();
+        
+        // Filter to use in the onward chain which simply captures the interactionId from MDC
+        final OncePerRequestFilter captureFapiInteractionIdFilter = new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+                xFapiInteractionIdFromMdc = MDC.get(FapiInteractionIdFilter.X_FAPI_INTERACTION_ID);
+            }
+        };
+        this.chain = new MockFilterChain(new HttpServlet(){}, captureFapiInteractionIdFilter);
+        this.filter = new FapiInteractionIdFilter();
+    }
+
+    @Test
+    void testDoesNothingIfNoFapiIdHeader() throws Exception {
+        this.filter.doFilter(this.request, this.response, this.chain);
+        assertThat(MDC.get(FapiInteractionIdFilter.X_FAPI_INTERACTION_ID)).isNull();
+        assertThat(xFapiInteractionIdFromMdc).isNull();
+    }
+
+    @Test
+    void  testStoreFapiIdHeaderInMdc() throws Exception {
+        final String testInteractionId = "test-1234";
+        request.addHeader(FapiInteractionIdFilter.X_FAPI_INTERACTION_ID, testInteractionId);
+        this.filter.doFilter(this.request, this.response, this.chain);
+
+        // Verify that the interactionId was found in the MDC when calling other filters
+        assertThat(xFapiInteractionIdFromMdc).isEqualTo(testInteractionId);
+
+        // Verify MDC is cleared once filter returns
+        assertThat(MDC.get(FapiInteractionIdFilter.X_FAPI_INTERACTION_ID)).isNull();
+    }
+
+}


### PR DESCRIPTION
Spring applications can install the FapInteractionIdFilter and be able to trace requests through the system using the x-fapi-interaction-id (if they log the MDC values with each log message).

https://github.com/SecureApiGateway/SecureApiGateway/issues/863