### PR TITLE
863: Adding FapiInteractionIdContext which manages storing an x-fapi-interaction-id in a ThreadLocal

### DIFF
--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.uk.common.shared.fapi;
+
+import java.util.Optional;
+
+/**
+ * This class manages storing/retrieving an x-fapi-interaction-id using a {@link ThreadLocal}.
+ *
+ * This is a similar approach to {@link org.slf4j.MDC}, it allows the x-fapi-interaction-id to be propagated through
+ * the system so that it can be used for tracing purposes. If, as part of processing a request, the system needs to make
+ * a HTTP call then the same x-fapi-interaction-id can be set in the HTTP header of that request.
+ */
+public class FapiInteractionIdContext {
+
+    private static final ThreadLocal<String> THREAD_LOCAL_INTERACTION_ID = new ThreadLocal<>();
+
+    /**
+     * @param fapiInteractionId value to store in the ThreadLocal context.
+     */
+    public static void setFapiInteractionId(String fapiInteractionId) {
+        THREAD_LOCAL_INTERACTION_ID.set(fapiInteractionId);
+    }
+
+    /**
+     * @return an Optional which may contain an x-fapi-interaction-id if one has previously been configured via
+     * the {@link this#setFapiInteractionId(String)}. May be empty if set has not been called for this thread OR
+     * a previously set value has been removed by calling thos#removeFapiInteractionId
+     */
+    public static Optional<String> getFapiInteractionId() {
+        return Optional.ofNullable(THREAD_LOCAL_INTERACTION_ID.get());
+    }
+
+    /**
+     * Clears any value stored in the ThreadLocal context
+     */
+    public static void removeFapiInteractionId() {
+        THREAD_LOCAL_INTERACTION_ID.remove();
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
@@ -26,27 +26,29 @@ import org.slf4j.MDC;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.forgerock.sapi.gateway.uk.common.shared.api.meta.obie.OBHeaders;
+import com.forgerock.sapi.gateway.uk.common.shared.fapi.FapiInteractionIdContext;
+
 /**
- * Filter which stores the x-fapi-interaction-id header value in the {@link MDC} log context.
+ * Filter which stores the x-fapi-interaction-id header value in the {@link MDC} log context and {@link FapiInteractionIdContext}
  *
  * This means that the x-fapi-interaction-id will be present in each log message for a request, which allows requests to
  * be traced through the system.
  */
 public class FapiInteractionIdFilter extends OncePerRequestFilter {
 
-    public static final String X_FAPI_INTERACTION_ID = "x-fapi-interaction-id";
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        final String xFapiInteractionId = request.getHeader(X_FAPI_INTERACTION_ID);
+        final String xFapiInteractionId = request.getHeader(OBHeaders.X_FAPI_INTERACTION_ID);
         if (StringUtils.hasText(xFapiInteractionId)) {
-            MDC.put(X_FAPI_INTERACTION_ID, xFapiInteractionId);
+            MDC.put(OBHeaders.X_FAPI_INTERACTION_ID, xFapiInteractionId);
+            FapiInteractionIdContext.setFapiInteractionId(xFapiInteractionId);
         }
         try {
             filterChain.doFilter(request, response);
         } finally {
-            MDC.remove(X_FAPI_INTERACTION_ID);
+            MDC.remove(OBHeaders.X_FAPI_INTERACTION_ID);
+            FapiInteractionIdContext.removeFapiInteractionId();
         }
     }
-
 }

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.uk.common.shared.fapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FapiInteractionIdContextTest {
+
+    @BeforeEach
+    void beforeEach() {
+        FapiInteractionIdContext.removeFapiInteractionId();
+    }
+
+    @Test
+    void testUsingContextFromSingleThread() {
+        verifyEmptyContext();
+
+        // Set
+        final String interactionId = UUID.randomUUID().toString();
+        setContext(interactionId);
+
+        // Overwrite
+        final String anotherInteractionId = "another-id";
+        setContext(anotherInteractionId);
+
+        // Clear
+        clearContext();
+    }
+
+    @Test
+    void testUsingContextFromMultipleThreads() throws Exception {
+        final ExecutorService executorService = Executors.newFixedThreadPool(32);
+        try {
+            final List<Future<Void>> testTaskFutures = executorService.invokeAll(Collections.nCopies(128, () -> {
+                final String interactionId = UUID.randomUUID().toString();
+                setContext(interactionId);
+
+                // Simulate doing some work
+                Thread.sleep(1);
+
+                verifyContextContainsId(interactionId);
+                clearContext();
+
+                return null;
+            }));
+
+            for (Future<Void> testTaskFuture : testTaskFutures) {
+                testTaskFuture.get();
+            }
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    private static void verifyEmptyContext() {
+        assertThat(FapiInteractionIdContext.getFapiInteractionId()).isEmpty();
+    }
+
+    private static void setContext(String interactionId) {
+        FapiInteractionIdContext.setFapiInteractionId(interactionId);
+        verifyContextContainsId(interactionId);
+    }
+
+    private static void verifyContextContainsId(String interactionId) {
+        assertThat(FapiInteractionIdContext.getFapiInteractionId()).isPresent().contains(interactionId);
+    }
+
+    private static void clearContext() {
+        FapiInteractionIdContext.removeFapiInteractionId();
+        assertThat(FapiInteractionIdContext.getFapiInteractionId()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
FapiInteractionIdContext allows the x-fapi-interaction-id to be propagated to HTTP requests being made by the system, so that the same id can be used to trace the request across multiple systems.

Updating FapiInteractionIdFilter to manage the id in the context (as well as in MDC).

This PR: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/187 demonstrates how the context can be used to set the x-fapi-interaction-id in HTTP Requests.

https://github.com/SecureApiGateway/SecureApiGateway/issues/863