### PR TITLE
1223: Remove guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -46,10 +46,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>


### PR DESCRIPTION
Removing guava dependency from the pom as it is not being used.

Bumping to latest parent version (which has also removed guava).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1223