### PR TITLE
1234: Spring Boot 2.7.18 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-common</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>Secure API Gateway common and shared libraries for Open Banking UK specs</name>
     <url>https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common</url>
 
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -22,7 +22,7 @@
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-common-bom</artifactId>
     <packaging>pom</packaging>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>secure-api-gateway-ob-uk-common-bom</name>
 
     <description>
@@ -47,7 +47,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-datamodel/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-error/pom.xml
+++ b/secure-api-gateway-ob-uk-common-error/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ob-uk-common-shared/pom.xml
+++ b/secure-api-gateway-ob-uk-common-shared/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-ob-uk-common</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Updating parent pom version to 2.3.0-SNAPSHOT to pickup Spring Boot upgrade to 2.7.18.

Bumping project version to 2.3.0-SNAPSHOT to match parent, and prepare for next release.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1234