### PR TITLE
1238: Updating copyright header of all files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-datamodel/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountBeneficiary.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountRisk.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountRisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountServicer.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountServicer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountWithBalance.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountWithBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditDebitIndicator.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditDebitIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditLine.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCurrencyExchange.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCurrencyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRDirectDebitData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRDirectDebitData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalPermissionsCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalPermissionsCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalRequestStatusCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalRequestStatusCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRFinancialAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRFinancialAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRLinks.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMeta.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FROfferData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FROfferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRPartyData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRPartyData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadDataResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadDataResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRScheduledPaymentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRScheduledPaymentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStandingOrderData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStandingOrderData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStatementData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStatementData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRTransactionData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRTransactionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAccountIdentifier.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAccountIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAmount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRCharge.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRCharge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRChargeBearerType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRChargeBearerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataSCASupportData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataSCASupportData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalExtendedAccountTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalExtendedAccountTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPaymentContextCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPaymentContextCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialAgent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialCreditor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRInstructionPriority.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRInstructionPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPaymentRisk.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPaymentRisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPermission.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRResponseDataRefund.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRResponseDataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSubmissionStatus.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSubmissionStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSupplementaryData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSupplementaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRAccountBeneficiaryConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRAccountBeneficiaryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRAccountServicerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRAccountServicerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCashBalanceConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCashBalanceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCreditDebitIndicatorConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCreditDebitIndicatorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCurrencyExchangeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCurrencyExchangeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRDirectDebitConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRDirectDebitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalPermissionsCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalPermissionsCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalRequestStatusCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalRequestStatusCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRFinancialAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRFinancialAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FROfferConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FROfferConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRPartyConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRPartyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRProductConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRProductConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentResponseConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadResponseConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRStatementConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRStatementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRTransactionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRTransactionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRAccountIdentifierConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRAccountIdentifierConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRAmountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRChargeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRChargeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRExternalExtendedAccountTypeCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRExternalExtendedAccountTypeCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRFinancialInstrumentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRFinancialInstrumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRLinksConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRLinksConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRMetaConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRMetaConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FROBExternalPaymentContext1CodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FROBExternalPaymentContext1CodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRPostalAddressConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRPostalAddressConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRemittanceInformationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRemittanceInformationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRResponseDataRefundConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRResponseDataRefundConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRisk1DeliveryAddressConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRisk1DeliveryAddressConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRiskConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRiskConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRSubmissionStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRSubmissionStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRSupplementaryDataConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRSupplementaryDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FRCallbackUrlConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FRCallbackUrlConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FREventPollingConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FREventPollingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FREventSubscriptionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/event/FREventSubscriptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRChargeBearerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRChargeBearerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRDataAuthorisationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRDataAuthorisationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRDataSCASupportDataConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRDataSCASupportDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRExchangeRateConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRExchangeRateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRInstructionPriorityConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRInstructionPriorityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRPermissionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRPermissionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRReadRefundAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRReadRefundAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRScheduledPaymentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRScheduledPaymentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVrpConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVrpConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRVrpInteractionTypesConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRVrpInteractionTypesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRAddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfoAddress.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfoAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FRCallbackUrlData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FRCallbackUrlData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessage.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessages.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPolling.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPolling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPollingError.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPollingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventSubscriptionData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventSubscriptionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRDomesticDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRDomesticDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFilePayment.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFilePayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFundsConfirmationResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFundsConfirmationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalResponseDataRefund.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalResponseDataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomestic.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomestic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataFile.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomestic.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomestic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFile.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternational.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternational.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/tpp/Tpp.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/tpp/Tpp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpInstruction.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequestData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionTypes.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRWriteDomesticVrpDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRWriteDomesticVrpDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRChargeConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRChargeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRLinksConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRLinksConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRiskConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRiskConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/funds/FRFundsConfirmationConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticScheduledConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteFileConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalScheduledConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVRPConsentConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVrpConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/vrp/FRDomesticVrpConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRFinancialAgentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRFinancialAgentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountBeneficiaryTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountBeneficiaryTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountWithBalanceTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountWithBalanceTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRCashBalanceTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRCashBalanceTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRDirectDebitDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRDirectDebitDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRFinancialAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRFinancialAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FROfferDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FROfferDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRPartyDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRPartyDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRScheduledPaymentDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRScheduledPaymentDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStandingOrderDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStandingOrderDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStatementDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStatementDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRTransactionDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRTransactionDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRPaymentRiskTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRPaymentRiskTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRWriteDomesticDataInitiationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRWriteDomesticDataInitiationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/tpp/TppTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/tpp/TppTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/pom.xml
+++ b/secure-api-gateway-ob-uk-common-error/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmp.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/FileParseException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/FileParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorResponseException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorResponseCategory.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorResponseCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmpTest.java
+++ b/secure-api-gateway-ob-uk-common-error/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCA.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAOtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAOtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccountStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccountStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductSegment1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductSegment1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBalanceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBalanceType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiaryType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiaryType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashBalance1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashBalance1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditLine1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditLine1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBDirectDebit1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBDirectDebit1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEntryStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEntryStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEquivalentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEquivalentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountSubType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountSubType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalCardAuthorisationType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalCardAuthorisationType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalCardSchemeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalCardSchemeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalDirectDebitStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalDirectDebitStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalFinancialInstitutionIdentification2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalFinancialInstitutionIdentification2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalLimitType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalLimitType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalOfferType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalOfferType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPartyType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPartyType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPermissions1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPermissions1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalProductType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalProductType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalProductType2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalProductType2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalScheduleType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalScheduleType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStandingOrderStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStandingOrderStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementAmountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementAmountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementBenefitType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementBenefitType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementDateTimeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementDateTimeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementInterestType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementInterestType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementRateType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementRateType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementValueType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementValueType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeApplicableRange1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeApplicableRange1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeCategory1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeCategory1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeCap1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeCap1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeDetail1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeDetail1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFrequency1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFrequency1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestCalculationMethod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestCalculationMethod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestDestination1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestDestination1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestFixedVariableType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestFixedVariableType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeCap1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeCap1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeDetail1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeDetail1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBand1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBand1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBandSet1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBandSet1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMinMaxType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMinMaxType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOffer1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOffer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeesAndCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeesAndCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductSegment1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductSegment1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraft1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraft1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeChargeCap1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeChargeCap1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesChargeDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesChargeDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierBand1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierBand1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierbandSet1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierbandSet1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductSegment1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductSegment1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2Address.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPeriod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPeriod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPostalAddress8.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPostalAddress8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalance.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataCreditLine.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataCreditLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataBeneficiary1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataBeneficiary1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataDirectDebit1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataDirectDebit1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataProduct1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataProduct1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataDirectDebit.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataDirectDebit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataPreviousPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataPreviousPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebit.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataFee.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOffer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1DataParty.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1DataParty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProduct.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadRequest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadRequest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRelationship1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRelationship1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepayment1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepayment1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentAmountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentAmountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeCap1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeCap1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeDetail1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeDetail1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFrequency1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFrequency1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentHoliday1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentHoliday1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefit.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTime.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFee.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRate.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValue.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementAmount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementBenefit1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementBenefit1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementDateTime1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementDateTime1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementRate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementRate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementValue1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementValue1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTariffType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTariffType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandSet1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandSet1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3ProprietaryBankTransactionCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3ProprietaryBankTransactionCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5ProprietaryBankTransactionCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5ProprietaryBankTransactionCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionMutability1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionMutability1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBand.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBandSet.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBandSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/PCA.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/PCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Links.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Meta.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBActiveOrHistoricCurrencyAndAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBAddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccountCreditor3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccountCreditor3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBChargeBearerType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBChargeBearerType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification3Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification3Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification4Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalAccountIdentification4Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalFinancialInstitutionIdentification4Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalFinancialInstitutionIdentification4Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalLocalInstrument1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalLocalInstrument1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalPaymentContext1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalPaymentContext1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalRequestStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalRequestStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalStatus2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalStatus2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBPostalAddress6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBPostalAddress6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1DeliveryAddress.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1DeliveryAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBSupplementaryData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBSupplementaryData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBVRPAuthenticationMethods.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBVRPAuthenticationMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBVRPConsentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBVRPConsentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/AddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/AddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/CustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/CustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/CustomerInfoAddress.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/CustomerInfoAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/ReadCustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/customerinfo/ReadCustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPI.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksAccount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksEventNotification3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksEventNotification3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksEventNotification4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksEventNotification4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksFundsConfirmation3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksFundsConfirmation3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksPayment4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksVrpPayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinksVrpPayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBError1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBError1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBErrorResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBErrorResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBStandardErrorCodes1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBStandardErrorCodes1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/StandardErrorCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/StandardErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrl1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrl1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponseData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponseData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponseData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponseData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEvent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEvent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventLink1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventLink1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventNotification1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventNotification1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1SetErrs.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1SetErrs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPollingResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPollingResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventResourceUpdate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventResourceUpdate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubject1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubject1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1DataEventSubscription.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1DataEventSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBCashAccountDebtor4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBCashAccountDebtor4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBExternalRequestStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBExternalRequestStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1DataInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1DataInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentDataResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentDataResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationDataResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationDataResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAppliedAuthenticationApproachEnum.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAppliedAuthenticationApproachEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAuthorisation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAuthorisation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBBranchAndFinancialInstitutionIdentification3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBBranchAndFinancialInstitutionIdentification3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountCreditor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountCreditor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2Amount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2Amount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDebtorIdentification1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDebtorIdentification1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2InstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2InstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FinalPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FinalPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FirstPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FirstPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3RecurringPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3RecurringPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRateType2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRateType2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalAuthorisation1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalAuthorisation1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalConsentStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalConsentStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalConsentStatus2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalConsentStatus2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalPermissions2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalPermissions2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFundsAvailableResult1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFundsAvailableResult1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInitiation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInitiation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBMultiAuthorisation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBMultiAuthorisation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPartyIdentification43.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPartyIdentification43.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSetup1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSetup1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSetupResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSetupResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSubmission1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSubmission1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSubmissionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPaymentDataSubmissionResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPriority2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPriority2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBReadRefundAccountEnum.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBReadRefundAccountEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRemittanceInformation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRemittanceInformation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRequestedSCAExemptionTypeEnum.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRequestedSCAExemptionTypeEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBTransactionIndividualStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBTransactionIndividualStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataSCASupportData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataSCASupportData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataSCASupportData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataSCASupportData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3DataCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3DataCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4DataCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4DataCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5DataCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5DataCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataPaymentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataPaymentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsetup/OBPaymentSetup1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsetup/OBPaymentSetup1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsetup/OBPaymentSetupResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsetup/OBPaymentSetupResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsubmission/OBPaymentSubmission1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsubmission/OBPaymentSubmission1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsubmission/OBPaymentSubmissionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/paymentsubmission/OBPaymentSubmissionResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBeneficiaryConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBeneficiaryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBCashAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBCashAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBProductConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBProductConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBTransactionConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBTransactionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/ConverterHelper.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/ConverterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelper.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtil.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCashAccountDebtorWithName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCashAccountDebtorWithName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCharge2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCharge2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersPeriodicLimits.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersPeriodicLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataPaymentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataPaymentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiationRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiationRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInstruction.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseDataCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseDataCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBExternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBExternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBExternalPaymentChargeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBExternalPaymentChargeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBPAFundsAvailableResult1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBPAFundsAvailableResult1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPInteractionTypes.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPInteractionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateFormat.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Deserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Serializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Deserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Serializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Deserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Serializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtilTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBConsentAuthorisationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBConsentAuthorisationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBInternationalIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBInternationalIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBPostalAddress6TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBPostalAddress6TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBRisk1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBRisk1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/ConstantsVrpTestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/ConstantsVrpTestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpCommonTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpCommonTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVrpRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/pom.xml
+++ b/secure-api-gateway-ob-uk-common-shared/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequency.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRQuarterType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRQuarterType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBConstants.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBGroupName.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBGroupName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBHeaders.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBJoseHeaderClaims.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBJoseHeaderClaims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersion.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/share/IntentType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/share/IntentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claim.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claims.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtils.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/DateToUTCDateTimeConverter.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/DateToUTCDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/DateToUTCDateTimeConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/DateToUTCDateTimeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Applying latest copyright header which includes 2024 in the range.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1238