### PR TITLE
1244: Remove springfox dependency

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -70,8 +70,12 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
         </dependency>
         <!-- Bean Validation API support -->
         <dependency>


### PR DESCRIPTION
springfox is not being used, it is only required as it transitively pulls in the swagger-annotations dependency required by our code.

Removing springfox and adding swagger-annotations.

Adding spring-boot-starter-web dependency as this was also being pulled in transitively by springfox and is needed for the Validated annotations.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1244