### PR TITLE
1243: Re-gen accounts code with updated code-gen config

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCashBalanceConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRCashBalanceConverter.java
@@ -30,6 +30,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAmou
 import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
 import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInner;
 import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerCreditLineInner;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerCreditLineInnerType;
 
 public class FRCashBalanceConverter {
 
@@ -61,8 +62,8 @@ public class FRCashBalanceConverter {
                 .amount(FRAmountConverter.toOBReadBalance1DataAmount1(creditLine.getAmount()));
     }
 
-    public static OBReadBalance1DataBalanceInnerCreditLineInner.TypeEnum toOBReadBalance1DataCreditLineType(FRCreditLine.FRLimitType type) {
-        return type == null ? null : OBReadBalance1DataBalanceInnerCreditLineInner.TypeEnum.valueOf(type.name());
+    public static OBReadBalance1DataBalanceInnerCreditLineInnerType toOBReadBalance1DataCreditLineType(FRCreditLine.FRLimitType type) {
+        return type == null ? null : OBReadBalance1DataBalanceInnerCreditLineInnerType.valueOf(type.name());
     }
 
     // OB to FR
@@ -96,7 +97,7 @@ public class FRCashBalanceConverter {
                 .build();
     }
 
-    public static FRCreditLine.FRLimitType toFRLimitType(OBReadBalance1DataBalanceInnerCreditLineInner.TypeEnum type) {
+    public static FRCreditLine.FRLimitType toFRLimitType(OBReadBalance1DataBalanceInnerCreditLineInnerType type) {
         return type == null ? null : FRCreditLine.FRLimitType.valueOf(type.name());
     }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalPermissionsCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRExternalPermissionsCodeConverter.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRExternalPermissionsCode;
 
-import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
 
 public class FRExternalPermissionsCodeConverter {
 

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FROfferConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FROfferConverter.java
@@ -19,7 +19,7 @@ import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FROfferData;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRAmountConverter;
 
 import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner;
-import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInner.OfferTypeEnum;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerOfferType;
 
 public class FROfferConverter {
 
@@ -41,8 +41,8 @@ public class FROfferConverter {
                 .fee(FRAmountConverter.toOBReadOffer1DataFee(offerData.getFee()));
     }
 
-    public static OfferTypeEnum toOBReadOffer1DataOfferType(FROfferData.FROfferType offerType) {
-        return offerType == null ? null : OfferTypeEnum.valueOf(offerType.name());
+    public static OBReadOffer1DataOfferInnerOfferType toOBReadOffer1DataOfferType(FROfferData.FROfferType offerType) {
+        return offerType == null ? null : OBReadOffer1DataOfferInnerOfferType.valueOf(offerType.name());
     }
 
     // OB to FR
@@ -63,7 +63,7 @@ public class FROfferConverter {
                 .build();
     }
 
-    public static FROfferData.FROfferType toFROfferType(OfferTypeEnum offerType) {
+    public static FROfferData.FROfferType toFROfferType(OBReadOffer1DataOfferInnerOfferType offerType) {
         return offerType == null ? null : FROfferData.FROfferType.valueOf(offerType.name());
     }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRTransactionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRTransactionConverter.java
@@ -31,6 +31,8 @@ import uk.org.openbanking.datamodel.account.OBEntryStatus1Code;
 import uk.org.openbanking.datamodel.account.OBMerchantDetails1;
 import uk.org.openbanking.datamodel.account.OBTransaction6;
 import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1;
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1AuthorisationType;
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1CardSchemeName;
 import uk.org.openbanking.datamodel.account.OBTransactionCashBalance;
 import uk.org.openbanking.datamodel.account.OBTransactionMutability1Code;
 import uk.org.openbanking.datamodel.account.ProprietaryBankTransactionCodeStructure1;
@@ -106,12 +108,12 @@ public class FRTransactionConverter {
                 .merchantCategoryCode(merchantDetails.getMerchantCategoryCode());
     }
 
-    public static OBTransactionCardInstrument1.CardSchemeNameEnum toOBTransactionCardInstrument1CardSchemeName(FRTransactionData.FRCardScheme cardSchemeName) {
-        return cardSchemeName == null ? null : OBTransactionCardInstrument1.CardSchemeNameEnum.valueOf(cardSchemeName.name());
+    public static OBTransactionCardInstrument1CardSchemeName toOBTransactionCardInstrument1CardSchemeName(FRTransactionData.FRCardScheme cardSchemeName) {
+        return cardSchemeName == null ? null : OBTransactionCardInstrument1CardSchemeName.valueOf(cardSchemeName.name());
     }
 
-    public static OBTransactionCardInstrument1.AuthorisationTypeEnum toOBTransactionCardInstrument1AuthorisationType(FRTransactionData.FRCardAuthorisationType authorisationType) {
-        return authorisationType == null ? null : OBTransactionCardInstrument1.AuthorisationTypeEnum.valueOf(authorisationType.name());
+    public static OBTransactionCardInstrument1AuthorisationType toOBTransactionCardInstrument1AuthorisationType(FRTransactionData.FRCardAuthorisationType authorisationType) {
+        return authorisationType == null ? null : OBTransactionCardInstrument1AuthorisationType.valueOf(authorisationType.name());
     }
 
     // OB to FR
@@ -191,11 +193,11 @@ public class FRTransactionConverter {
                 .build();
     }
 
-    public static FRTransactionData.FRCardScheme toFRCardScheme(OBTransactionCardInstrument1.CardSchemeNameEnum cardSchemeName) {
+    public static FRTransactionData.FRCardScheme toFRCardScheme(OBTransactionCardInstrument1CardSchemeName cardSchemeName) {
         return cardSchemeName == null ? null : FRTransactionData.FRCardScheme.valueOf(cardSchemeName.name());
     }
 
-    public static FRTransactionData.FRCardAuthorisationType toFRCardAuthorisationType(OBTransactionCardInstrument1.AuthorisationTypeEnum authorisationType) {
+    public static FRTransactionData.FRCardAuthorisationType toFRCardAuthorisationType(OBTransactionCardInstrument1AuthorisationType authorisationType) {
         return authorisationType == null ? null : FRTransactionData.FRCardAuthorisationType.valueOf(authorisationType.name());
     }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/account/FRReadConsentConverterTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRReadConsent;
 
-import uk.org.openbanking.datamodel.account.OBExternalPermissions1Code;
+import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
 import uk.org.openbanking.datamodel.account.OBReadConsent1;
 import uk.org.openbanking.datamodel.account.OBReadConsent1Data;
 import uk.org.openbanking.datamodel.account.OBRisk2;

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -202,13 +202,13 @@
                                         Links=Links,
                                         Meta=Meta,
                                         OBRisk1=OBRisk1,
+                                        OBRisk2=OBRisk2,
                                         OBRisk1_DeliveryAddress=OBRisk1DeliveryAddress,
                                         OBRisk1_PaymentContextCode=OBRisk1PaymentContextCode,
                                         OBSupplementaryData1=OBSupplementaryData1,
                                         OBError1=OBError1,
                                         OBErrorResponse1=OBErrorResponse1,
                                         OBCashAccount3=OBCashAccount3,
-                                        OBExternalRequestStatus1Code=OBExternalRequestStatus1Code,
                                         OBActiveOrHistoricCurrencyAndAmount=OBActiveOrHistoricCurrencyAndAmount,
                                         OBPostalAddress6=OBPostalAddress6,
                                         OBChargeBearerType1Code=OBChargeBearerType1Code,
@@ -223,6 +223,8 @@
                                         OBDomesticVRPConsentResponse_Data_DebtorAccount=OBCashAccountDebtorWithName,
                                         OBDomesticVRPConsentResponse_Data_ReadRefundAccount=OBReadRefundAccount,
                                         OBWriteDomesticConsent4_Data_ReadRefundAccount=OBReadRefundAccount,
+                                        OBReadConsentResponse1_Data_Status=OBExternalRequestStatus1Code,
+                                        OBReadConsent1_Data_Permissions_inner=OBExternalPermissions1Code,
                                     </schemaMappings>
                                     <!-- Map types which are not generating to their fully qualified class name to use
                                          in the import statements.
@@ -248,6 +250,7 @@
                                         OBExternalStatus2Code=uk.org.openbanking.datamodel.common.OBExternalStatus2Code,
                                         OBReadRefundAccount=uk.org.openbanking.datamodel.common.OBReadRefundAccount,
                                         OBAddressTypeCode=uk.org.openbanking.datamodel.common.OBAddressTypeCode,
+                                        OBExternalPermissions1Code=uk.org.openbanking.datamodel.common.OBExternalPermissions1Code
                                     </importMappings>
                                     <configOptions>
                                         <useSpringBoot3>true</useSpringBoot3>

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/AgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/AgreementPeriod.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Specifies the period of a fixed length overdraft agreement
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum AgreementPeriod {
+
+    DAY("Day"),
+
+    HALF_YEAR("Half Year"),
+
+    MONTH("Month"),
+
+    QUARTER("Quarter"),
+
+    WEEK("Week"),
+
+    YEAR("Year");
+
+    private String value;
+
+    AgreementPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static AgreementPeriod fromValue(String value) {
+        for (AgreementPeriod b : AgreementPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency {
+
+    DAILY("Daily"),
+
+    HALFYEARLY("HalfYearly"),
+
+    MONTHLY("Monthly"),
+
+    OTHER("Other"),
+
+    QUARTERLY("Quarterly"),
+
+    PERSTATEMENTDATE("PerStatementDate"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency fromValue(String value) {
+        for (ApplicationFrequency b : ApplicationFrequency.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency1.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Frequency at which the overdraft charge is applied to the account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency1 {
+
+    ONCLOSING("OnClosing"),
+
+    ONOPENING("OnOpening"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONANNIVERSARY("OnAnniversary"),
+
+    OTHER("Other"),
+
+    PERHUNDREDPOUNDS("PerHundredPounds"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency1 fromValue(String value) {
+        for (ApplicationFrequency1 b : ApplicationFrequency1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency2.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How frequently the fee/charge is applied to the account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency2 {
+
+    ONCLOSING("OnClosing"),
+
+    ONOPENING("OnOpening"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONANNIVERSARY("OnAnniversary"),
+
+    OTHER("Other"),
+
+    PERHUNDREDPOUNDS("PerHundredPounds"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency2(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency2 fromValue(String value) {
+        for (ApplicationFrequency2 b : ApplicationFrequency2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency3.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency3 {
+
+    PERACADEMICTERM("PerAcademicTerm"),
+
+    DAILY("Daily"),
+
+    HALFYEARLY("HalfYearly"),
+
+    MONTHLY("Monthly"),
+
+    OTHER("Other"),
+
+    QUARTERLY("Quarterly"),
+
+    PERSTATEMENTDATE("PerStatementDate"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency3(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency3 fromValue(String value) {
+        for (ApplicationFrequency3 b : ApplicationFrequency3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency4.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Frequency at which the overdraft charge is applied to the account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency4 {
+
+    ACCOUNTCLOSING("AccountClosing"),
+
+    ACCOUNTOPENING("AccountOpening"),
+
+    ACADEMICTERM("AcademicTerm"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
+
+    OTHER("Other"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency4(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency4 fromValue(String value) {
+        for (ApplicationFrequency4 b : ApplicationFrequency4.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ApplicationFrequency5.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How frequently the fee/charge is applied to the account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum ApplicationFrequency5 {
+
+    ACCOUNTCLOSING("AccountClosing"),
+
+    ACCOUNTOPENING("AccountOpening"),
+
+    ACADEMICTERM("AcademicTerm"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
+
+    OTHER("Other"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    ApplicationFrequency5(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static ApplicationFrequency5 fromValue(String value) {
+        for (ApplicationFrequency5 b : ApplicationFrequency5.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BankInterestRateType.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum BankInterestRateType {
+
+    GROSS("Gross"),
+
+    OTHER("Other");
+
+    private String value;
+
+    BankInterestRateType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static BankInterestRateType fromValue(String value) {
+        for (BankInterestRateType b : BankInterestRateType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BankInterestRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BankInterestRateType1.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum BankInterestRateType1 {
+
+    LINKEDBASERATE("LinkedBaseRate"),
+
+    GROSS("Gross"),
+
+    NET("Net"),
+
+    OTHER("Other");
+
+    private String value;
+
+    BankInterestRateType1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static BankInterestRateType1 fromValue(String value) {
+        for (BankInterestRateType1 b : BankInterestRateType1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is credit interest calculated for the account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency {
+
+    DAILY("Daily"),
+
+    HALFYEARLY("HalfYearly"),
+
+    MONTHLY("Monthly"),
+
+    OTHER("Other"),
+
+    QUARTERLY("Quarterly"),
+
+    PERSTATEMENTDATE("PerStatementDate"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency fromValue(String value) {
+        for (CalculationFrequency b : CalculationFrequency.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency1.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is the overdraft fee/charge calculated for the account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency1 {
+
+    ONCLOSING("OnClosing"),
+
+    ONOPENING("OnOpening"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONANNIVERSARY("OnAnniversary"),
+
+    OTHER("Other"),
+
+    PERHUNDREDPOUNDS("PerHundredPounds"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency1 fromValue(String value) {
+        for (CalculationFrequency1 b : CalculationFrequency1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency2.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How frequently the fee/charge is calculated
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency2 {
+
+    ONCLOSING("OnClosing"),
+
+    ONOPENING("OnOpening"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONANNIVERSARY("OnAnniversary"),
+
+    OTHER("Other"),
+
+    PERHUNDREDPOUNDS("PerHundredPounds"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency2(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency2 fromValue(String value) {
+        for (CalculationFrequency2 b : CalculationFrequency2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency3.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is credit interest calculated for the account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency3 {
+
+    PERACADEMICTERM("PerAcademicTerm"),
+
+    DAILY("Daily"),
+
+    HALFYEARLY("HalfYearly"),
+
+    MONTHLY("Monthly"),
+
+    OTHER("Other"),
+
+    QUARTERLY("Quarterly"),
+
+    PERSTATEMENTDATE("PerStatementDate"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency3(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency3 fromValue(String value) {
+        for (CalculationFrequency3 b : CalculationFrequency3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency4.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How often is the overdraft fee/charge calculated for the account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency4 {
+
+    ACCOUNTCLOSING("AccountClosing"),
+
+    ACCOUNTOPENING("AccountOpening"),
+
+    ACADEMICTERM("AcademicTerm"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
+
+    OTHER("Other"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency4(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency4 fromValue(String value) {
+        for (CalculationFrequency4 b : CalculationFrequency4.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationFrequency5.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * How frequently the fee/charge is calculated
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationFrequency5 {
+
+    ACCOUNTCLOSING("AccountClosing"),
+
+    ACCOUNTOPENING("AccountOpening"),
+
+    ACADEMICTERM("AcademicTerm"),
+
+    CHARGINGPERIOD("ChargingPeriod"),
+
+    DAILY("Daily"),
+
+    PERITEM("PerItem"),
+
+    MONTHLY("Monthly"),
+
+    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
+
+    OTHER("Other"),
+
+    PERHOUR("PerHour"),
+
+    PEROCCURRENCE("PerOccurrence"),
+
+    PERSHEET("PerSheet"),
+
+    PERTRANSACTION("PerTransaction"),
+
+    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
+
+    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
+
+    QUARTERLY("Quarterly"),
+
+    SIXMONTHLY("SixMonthly"),
+
+    STATEMENTMONTHLY("StatementMonthly"),
+
+    WEEKLY("Weekly"),
+
+    YEARLY("Yearly");
+
+    private String value;
+
+    CalculationFrequency5(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationFrequency5 fromValue(String value) {
+        for (CalculationFrequency5 b : CalculationFrequency5.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CalculationMethod.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Methods of calculating interest
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CalculationMethod {
+
+    COMPOUND("Compound"),
+
+    SIMPLEINTEREST("SimpleInterest");
+
+    private String value;
+
+    CalculationMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CalculationMethod fromValue(String value) {
+        for (CalculationMethod b : CalculationMethod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CappingPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CappingPeriod.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Period e.g. day, week, month etc. for which the fee/charge is capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CappingPeriod {
+
+    DAY("Day"),
+
+    HALF_YEAR("Half Year"),
+
+    MONTH("Month"),
+
+    QUARTER("Quarter"),
+
+    WEEK("Week"),
+
+    YEAR("Year");
+
+    private String value;
+
+    CappingPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CappingPeriod fromValue(String value) {
+        for (CappingPeriod b : CappingPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CappingPeriod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CappingPeriod1.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Period e.g. day, week, month etc. for which the fee/charge is capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum CappingPeriod1 {
+
+    ACADEMICTERM("AcademicTerm"),
+
+    DAY("Day"),
+
+    HALF_YEAR("Half Year"),
+
+    MONTH("Month"),
+
+    QUARTER("Quarter"),
+
+    WEEK("Week"),
+
+    YEAR("Year");
+
+    private String value;
+
+    CappingPeriod1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static CappingPeriod1 fromValue(String value) {
+        for (CappingPeriod1 b : CappingPeriod1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
@@ -35,83 +35,86 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class CreditInterest {
 
-  @Valid
-  private List<@Valid TierBandSetInner> tierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid TierBandSetInner> tierBandSet = new ArrayList<>();
 
-  public CreditInterest() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public CreditInterest(List<@Valid TierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  public CreditInterest tierBandSet(List<@Valid TierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-    return this;
-  }
-
-  public CreditInterest addTierBandSetItem(TierBandSetInner tierBandSetItem) {
-    if (this.tierBandSet == null) {
-      this.tierBandSet = new ArrayList<>();
+    public CreditInterest() {
+        super();
     }
-    this.tierBandSet.add(tierBandSetItem);
-    return this;
-  }
 
-  /**
-   * The group of tiers or bands for which credit interest can be applied.
-   * @return tierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBandSet", description = "The group of tiers or bands for which credit interest can be applied.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandSet")
-  public List<@Valid TierBandSetInner> getTierBandSet() {
-    return tierBandSet;
-  }
-
-  public void setTierBandSet(List<@Valid TierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public CreditInterest(List<@Valid TierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public CreditInterest tierBandSet(List<@Valid TierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+        return this;
     }
-    CreditInterest creditInterest = (CreditInterest) o;
-    return Objects.equals(this.tierBandSet, creditInterest.tierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandSet);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class CreditInterest {\n");
-    sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public CreditInterest addTierBandSetItem(TierBandSetInner tierBandSetItem) {
+        if (this.tierBandSet == null) {
+            this.tierBandSet = new ArrayList<>();
+        }
+        this.tierBandSet.add(tierBandSetItem);
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The group of tiers or bands for which credit interest can be applied.
+     *
+     * @return tierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBandSet", description = "The group of tiers or bands for which credit interest can be applied.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandSet")
+    public List<@Valid TierBandSetInner> getTierBandSet() {
+        return tierBandSet;
+    }
+
+    public void setTierBandSet(List<@Valid TierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CreditInterest creditInterest = (CreditInterest) o;
+        return Objects.equals(this.tierBandSet, creditInterest.tierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CreditInterest {\n");
+        sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
@@ -37,83 +37,86 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class CreditInterest1 {
 
-  @Valid
-  private List<@Valid TierBandSetInner1> tierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid TierBandSetInner1> tierBandSet = new ArrayList<>();
 
-  public CreditInterest1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public CreditInterest1(List<@Valid TierBandSetInner1> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  public CreditInterest1 tierBandSet(List<@Valid TierBandSetInner1> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-    return this;
-  }
-
-  public CreditInterest1 addTierBandSetItem(TierBandSetInner1 tierBandSetItem) {
-    if (this.tierBandSet == null) {
-      this.tierBandSet = new ArrayList<>();
+    public CreditInterest1() {
+        super();
     }
-    this.tierBandSet.add(tierBandSetItem);
-    return this;
-  }
 
-  /**
-   * The group of tiers or bands for which credit interest can be applied.
-   * @return tierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBandSet", description = "The group of tiers or bands for which credit interest can be applied.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandSet")
-  public List<@Valid TierBandSetInner1> getTierBandSet() {
-    return tierBandSet;
-  }
-
-  public void setTierBandSet(List<@Valid TierBandSetInner1> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public CreditInterest1(List<@Valid TierBandSetInner1> tierBandSet) {
+        this.tierBandSet = tierBandSet;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public CreditInterest1 tierBandSet(List<@Valid TierBandSetInner1> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+        return this;
     }
-    CreditInterest1 creditInterest1 = (CreditInterest1) o;
-    return Objects.equals(this.tierBandSet, creditInterest1.tierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandSet);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class CreditInterest1 {\n");
-    sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public CreditInterest1 addTierBandSetItem(TierBandSetInner1 tierBandSetItem) {
+        if (this.tierBandSet == null) {
+            this.tierBandSet = new ArrayList<>();
+        }
+        this.tierBandSet.add(tierBandSetItem);
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The group of tiers or bands for which credit interest can be applied.
+     *
+     * @return tierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBandSet", description = "The group of tiers or bands for which credit interest can be applied.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandSet")
+    public List<@Valid TierBandSetInner1> getTierBandSet() {
+        return tierBandSet;
+    }
+
+    public void setTierBandSet(List<@Valid TierBandSetInner1> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CreditInterest1 creditInterest1 = (CreditInterest1) o;
+        return Objects.equals(this.tierBandSet, creditInterest1.tierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class CreditInterest1 {\n");
+        sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/DepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/DepositInterestAppliedCoverage.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Amount on which Interest applied.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum DepositInterestAppliedCoverage {
+
+    BANDED("Banded"),
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    DepositInterestAppliedCoverage(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static DepositInterestAppliedCoverage fromValue(String value) {
+        for (DepositInterestAppliedCoverage b : DepositInterestAppliedCoverage.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/DepositInterestAppliedCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/DepositInterestAppliedCoverage1.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Amount on which Interest applied.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum DepositInterestAppliedCoverage1 {
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    DepositInterestAppliedCoverage1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static DepositInterestAppliedCoverage1 fromValue(String value) {
+        for (DepositInterestAppliedCoverage1 b : DepositInterestAppliedCoverage1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Destination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Destination.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Describes whether accrued interest is payable only to the BCA or to another bank account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum Destination {
+
+    PAYAWAY("PayAway"),
+
+    SELFCREDIT("SelfCredit");
+
+    private String value;
+
+    Destination(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static Destination fromValue(String value) {
+        for (Destination b : Destination.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Destination1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Destination1.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Describes whether accrued interest is payable only to the PCA or to another bank account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum Destination1 {
+
+    PAYAWAY("PayAway"),
+
+    SELFCREDIT("SelfCredit");
+
+    private String value;
+
+    Destination1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static Destination1 fromValue(String value) {
+        for (Destination1 b : Destination1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
@@ -31,135 +31,139 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class FeeApplicableRange {
 
-  private String minimumAmount;
+    private String minimumAmount;
 
-  private String maximumAmount;
+    private String maximumAmount;
 
-  private String minimumRate;
+    private String minimumRate;
 
-  private String maximumRate;
+    private String maximumRate;
 
-  public FeeApplicableRange minimumAmount(String minimumAmount) {
-    this.minimumAmount = minimumAmount;
-    return this;
-  }
-
-  /**
-   * Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)
-   * @return minimumAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MinimumAmount", description = "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MinimumAmount")
-  public String getMinimumAmount() {
-    return minimumAmount;
-  }
-
-  public void setMinimumAmount(String minimumAmount) {
-    this.minimumAmount = minimumAmount;
-  }
-
-  public FeeApplicableRange maximumAmount(String maximumAmount) {
-    this.maximumAmount = maximumAmount;
-    return this;
-  }
-
-  /**
-   * Maximum Amount on which fee is applicable (where it is expressed as an amount)
-   * @return maximumAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MaximumAmount", description = "Maximum Amount on which fee is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaximumAmount")
-  public String getMaximumAmount() {
-    return maximumAmount;
-  }
-
-  public void setMaximumAmount(String maximumAmount) {
-    this.maximumAmount = maximumAmount;
-  }
-
-  public FeeApplicableRange minimumRate(String minimumRate) {
-    this.minimumRate = minimumRate;
-    return this;
-  }
-
-  /**
-   * Minimum rate on which fee/charge is applicable(where it is expressed as an rate)
-   * @return minimumRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MinimumRate", description = "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MinimumRate")
-  public String getMinimumRate() {
-    return minimumRate;
-  }
-
-  public void setMinimumRate(String minimumRate) {
-    this.minimumRate = minimumRate;
-  }
-
-  public FeeApplicableRange maximumRate(String maximumRate) {
-    this.maximumRate = maximumRate;
-    return this;
-  }
-
-  /**
-   * Maximum rate on which fee/charge is applicable(where it is expressed as an rate)
-   * @return maximumRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MaximumRate", description = "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaximumRate")
-  public String getMaximumRate() {
-    return maximumRate;
-  }
-
-  public void setMaximumRate(String maximumRate) {
-    this.maximumRate = maximumRate;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public FeeApplicableRange minimumAmount(String minimumAmount) {
+        this.minimumAmount = minimumAmount;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)
+     *
+     * @return minimumAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MinimumAmount", description = "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MinimumAmount")
+    public String getMinimumAmount() {
+        return minimumAmount;
     }
-    FeeApplicableRange feeApplicableRange = (FeeApplicableRange) o;
-    return Objects.equals(this.minimumAmount, feeApplicableRange.minimumAmount) &&
-        Objects.equals(this.maximumAmount, feeApplicableRange.maximumAmount) &&
-        Objects.equals(this.minimumRate, feeApplicableRange.minimumRate) &&
-        Objects.equals(this.maximumRate, feeApplicableRange.maximumRate);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(minimumAmount, maximumAmount, minimumRate, maximumRate);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class FeeApplicableRange {\n");
-    sb.append("    minimumAmount: ").append(toIndentedString(minimumAmount)).append("\n");
-    sb.append("    maximumAmount: ").append(toIndentedString(maximumAmount)).append("\n");
-    sb.append("    minimumRate: ").append(toIndentedString(minimumRate)).append("\n");
-    sb.append("    maximumRate: ").append(toIndentedString(maximumRate)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setMinimumAmount(String minimumAmount) {
+        this.minimumAmount = minimumAmount;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public FeeApplicableRange maximumAmount(String maximumAmount) {
+        this.maximumAmount = maximumAmount;
+        return this;
+    }
+
+    /**
+     * Maximum Amount on which fee is applicable (where it is expressed as an amount)
+     *
+     * @return maximumAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MaximumAmount", description = "Maximum Amount on which fee is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaximumAmount")
+    public String getMaximumAmount() {
+        return maximumAmount;
+    }
+
+    public void setMaximumAmount(String maximumAmount) {
+        this.maximumAmount = maximumAmount;
+    }
+
+    public FeeApplicableRange minimumRate(String minimumRate) {
+        this.minimumRate = minimumRate;
+        return this;
+    }
+
+    /**
+     * Minimum rate on which fee/charge is applicable(where it is expressed as an rate)
+     *
+     * @return minimumRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MinimumRate", description = "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MinimumRate")
+    public String getMinimumRate() {
+        return minimumRate;
+    }
+
+    public void setMinimumRate(String minimumRate) {
+        this.minimumRate = minimumRate;
+    }
+
+    public FeeApplicableRange maximumRate(String maximumRate) {
+        this.maximumRate = maximumRate;
+        return this;
+    }
+
+    /**
+     * Maximum rate on which fee/charge is applicable(where it is expressed as an rate)
+     *
+     * @return maximumRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MaximumRate", description = "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaximumRate")
+    public String getMaximumRate() {
+        return maximumRate;
+    }
+
+    public void setMaximumRate(String maximumRate) {
+        this.maximumRate = maximumRate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeeApplicableRange feeApplicableRange = (FeeApplicableRange) o;
+        return Objects.equals(this.minimumAmount, feeApplicableRange.minimumAmount) &&
+                Objects.equals(this.maximumAmount, feeApplicableRange.maximumAmount) &&
+                Objects.equals(this.minimumRate, feeApplicableRange.minimumRate) &&
+                Objects.equals(this.maximumRate, feeApplicableRange.maximumRate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumAmount, maximumAmount, minimumRate, maximumRate);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FeeApplicableRange {\n");
+        sb.append("    minimumAmount: ").append(toIndentedString(minimumAmount)).append("\n");
+        sb.append("    maximumAmount: ").append(toIndentedString(maximumAmount)).append("\n");
+        sb.append("    minimumRate: ").append(toIndentedString(minimumRate)).append("\n");
+        sb.append("    maximumRate: ").append(toIndentedString(maximumRate)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeCategory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeCategory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Categorisation of fees and charges into standard categories.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeCategory {
+
+    OTHER("Other"),
+
+    SERVICING("Servicing");
+
+    private String value;
+
+    FeeCategory(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeCategory fromValue(String value) {
+        for (FeeCategory b : FeeCategory.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeCapInner.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -40,371 +38,256 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class FeeChargeCapInner {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    OTHER("Other"),
-    
-    SERVICECACCOUNTFEE("ServiceCAccountFee"),
-    
-    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
-    
-    SERVICECACCOUNTFEEQUARTERLY("ServiceCAccountFeeQuarterly"),
-    
-    SERVICECFIXEDTARIFF("ServiceCFixedTariff"),
-    
-    SERVICECBUSIDEPACCBREAKAGE("ServiceCBusiDepAccBreakage"),
-    
-    SERVICECMINIMUMMONTHLYFEE("ServiceCMinimumMonthlyFee"),
-    
-    SERVICECOTHER("ServiceCOther");
+    @Valid
+    private List<@Valid FeeType2Inner> feeType = new ArrayList<>();
 
-    private String value;
+    private MinMaxType minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Float feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private CappingPeriod cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OtherFeeTypeInner> otherFeeType;
+
+    public FeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public FeeChargeCapInner(List<@Valid FeeType2Inner> feeType, MinMaxType minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public FeeChargeCapInner feeType(List<@Valid FeeType2Inner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public FeeChargeCapInner addFeeTypeItem(FeeType2Inner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Fee/charge type which is being capped
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid FeeType2Inner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid FeeType2Inner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public FeeChargeCapInner minMaxType(MinMaxType minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public MinMaxType getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(MinMaxType minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public FeeChargeCapInner feeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Float getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public FeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public FeeChargeCapInner cappingPeriod(CappingPeriod cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public CappingPeriod getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(CappingPeriod cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public FeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public FeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Free text for adding  extra details for fee charge cap
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Free text for adding  extra details for fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public FeeChargeCapInner otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public FeeChargeCapInner addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Other fee type code which is not available in the standard code set
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeeChargeCapInner feeChargeCapInner = (FeeChargeCapInner) o;
+        return Objects.equals(this.feeType, feeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, feeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, feeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, feeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, feeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, feeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, feeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  /**
-   * Min Max type
-   */
-  public enum MinMaxTypeEnum {
-    MINIMUM("Minimum"),
-    
-    MAXIMUM("Maximum");
-
-    private String value;
-
-    MinMaxTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MinMaxTypeEnum fromValue(String value) {
-      for (MinMaxTypeEnum b : MinMaxTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MinMaxTypeEnum minMaxType;
-
-  private Float feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   */
-  public enum CappingPeriodEnum {
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    CappingPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CappingPeriodEnum fromValue(String value) {
-      for (CappingPeriodEnum b : CappingPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CappingPeriodEnum cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OtherFeeTypeInner> otherFeeType;
-
-  public FeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public FeeChargeCapInner(List<FeeTypeEnum> feeType, MinMaxTypeEnum minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public FeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public FeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Fee/charge type which is being capped
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public FeeChargeCapInner minMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Min Max type
-   * @return minMaxType
-  */
-  @NotNull 
-  @Schema(name = "MinMaxType", description = "Min Max type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public MinMaxTypeEnum getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public FeeChargeCapInner feeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Float getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public FeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public FeeChargeCapInner cappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   * @return cappingPeriod
-  */
-  
-  @Schema(name = "CappingPeriod", description = "Period e.g. day, week, month etc. for which the fee/charge is capped", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public CappingPeriodEnum getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public FeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public FeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Free text for adding  extra details for fee charge cap
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Free text for adding  extra details for fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public FeeChargeCapInner otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public FeeChargeCapInner addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Other fee type code which is not available in the standard code set
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    FeeChargeCapInner feeChargeCapInner = (FeeChargeCapInner) o;
-    return Objects.equals(this.feeType, feeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, feeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, feeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, feeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, feeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, feeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, feeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class FeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeCapInner1.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -40,365 +38,256 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class FeeChargeCapInner1 {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    SERVICECACCOUNTFEE("ServiceCAccountFee"),
-    
-    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
-    
-    SERVICECOTHER("ServiceCOther"),
-    
-    OTHER("Other");
+    @Valid
+    private List<@Valid FeeType4Inner> feeType = new ArrayList<>();
 
-    private String value;
+    private MinMaxType1 minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Float feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private CappingPeriod1 cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OtherFeeTypeInner> otherFeeType;
+
+    public FeeChargeCapInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public FeeChargeCapInner1(List<@Valid FeeType4Inner> feeType, MinMaxType1 minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public FeeChargeCapInner1 feeType(List<@Valid FeeType4Inner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public FeeChargeCapInner1 addFeeTypeItem(FeeType4Inner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Fee/charge type which is being capped
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid FeeType4Inner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid FeeType4Inner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public FeeChargeCapInner1 minMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public MinMaxType1 getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public FeeChargeCapInner1 feeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Float getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public FeeChargeCapInner1 feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public FeeChargeCapInner1 cappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public CappingPeriod1 getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public FeeChargeCapInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public FeeChargeCapInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Free text for adding  extra details for fee charge cap
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Free text for adding  extra details for fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public FeeChargeCapInner1 otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public FeeChargeCapInner1 addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Other fee type code which is not available in the standard code set
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeeChargeCapInner1 feeChargeCapInner1 = (FeeChargeCapInner1) o;
+        return Objects.equals(this.feeType, feeChargeCapInner1.feeType) &&
+                Objects.equals(this.minMaxType, feeChargeCapInner1.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, feeChargeCapInner1.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, feeChargeCapInner1.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, feeChargeCapInner1.cappingPeriod) &&
+                Objects.equals(this.notes, feeChargeCapInner1.notes) &&
+                Objects.equals(this.otherFeeType, feeChargeCapInner1.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FeeChargeCapInner1 {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   */
-  public enum MinMaxTypeEnum {
-    MINIMUM("Minimum"),
-    
-    MAXIMUM("Maximum");
-
-    private String value;
-
-    MinMaxTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MinMaxTypeEnum fromValue(String value) {
-      for (MinMaxTypeEnum b : MinMaxTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MinMaxTypeEnum minMaxType;
-
-  private Float feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   */
-  public enum CappingPeriodEnum {
-    ACADEMICTERM("AcademicTerm"),
-    
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    CappingPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CappingPeriodEnum fromValue(String value) {
-      for (CappingPeriodEnum b : CappingPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CappingPeriodEnum cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OtherFeeTypeInner> otherFeeType;
-
-  public FeeChargeCapInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public FeeChargeCapInner1(List<FeeTypeEnum> feeType, MinMaxTypeEnum minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public FeeChargeCapInner1 feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public FeeChargeCapInner1 addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Fee/charge type which is being capped
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public FeeChargeCapInner1 minMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   * @return minMaxType
-  */
-  @NotNull 
-  @Schema(name = "MinMaxType", description = "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public MinMaxTypeEnum getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public FeeChargeCapInner1 feeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Float getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public FeeChargeCapInner1 feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public FeeChargeCapInner1 cappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   * @return cappingPeriod
-  */
-  
-  @Schema(name = "CappingPeriod", description = "Period e.g. day, week, month etc. for which the fee/charge is capped", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public CappingPeriodEnum getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public FeeChargeCapInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public FeeChargeCapInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Free text for adding  extra details for fee charge cap
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Free text for adding  extra details for fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public FeeChargeCapInner1 otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public FeeChargeCapInner1 addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Other fee type code which is not available in the standard code set
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    FeeChargeCapInner1 feeChargeCapInner1 = (FeeChargeCapInner1) o;
-    return Objects.equals(this.feeType, feeChargeCapInner1.feeType) &&
-        Objects.equals(this.minMaxType, feeChargeCapInner1.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, feeChargeCapInner1.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, feeChargeCapInner1.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, feeChargeCapInner1.cappingPeriod) &&
-        Objects.equals(this.notes, feeChargeCapInner1.notes) &&
-        Objects.equals(this.otherFeeType, feeChargeCapInner1.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class FeeChargeCapInner1 {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeDetailInner.java
@@ -15,21 +15,41 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.ApplicationFrequency2;
+import uk.org.openbanking.datamodel.account.CalculationFrequency2;
+import uk.org.openbanking.datamodel.account.FeeApplicableRange;
+import uk.org.openbanking.datamodel.account.FeeCategory;
+import uk.org.openbanking.datamodel.account.FeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.FeeRateType1;
+import uk.org.openbanking.datamodel.account.FeeType1;
+import uk.org.openbanking.datamodel.account.OtherApplicationFrequency1;
+import uk.org.openbanking.datamodel.account.OtherCalculationFrequency1;
+import uk.org.openbanking.datamodel.account.OtherFeeCategoryType;
+import uk.org.openbanking.datamodel.account.OtherFeeRateType1;
+import uk.org.openbanking.datamodel.account.OtherFeeType1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Other fees/charges details
@@ -40,713 +60,473 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class FeeChargeDetailInner {
 
-  /**
-   * Categorisation of fees and charges into standard categories.
-   */
-  public enum FeeCategoryEnum {
-    OTHER("Other"),
-    
-    SERVICING("Servicing");
+    private FeeCategory feeCategory;
 
-    private String value;
+    private FeeType1 feeType;
 
-    FeeCategoryEnum(String value) {
-      this.value = value;
+    private Boolean negotiableIndicator;
+
+    private String feeAmount;
+
+    private String feeRate;
+
+    private FeeRateType1 feeRateType;
+
+    private ApplicationFrequency2 applicationFrequency;
+
+    private CalculationFrequency2 calculationFrequency;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid FeeChargeCapInner> feeChargeCap;
+
+    private OtherFeeCategoryType otherFeeCategoryType;
+
+    private OtherFeeType1 otherFeeType;
+
+    private OtherFeeRateType1 otherFeeRateType;
+
+    private OtherApplicationFrequency1 otherApplicationFrequency;
+
+    private OtherCalculationFrequency1 otherCalculationFrequency;
+
+    private FeeApplicableRange feeApplicableRange;
+
+    public FeeChargeDetailInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public FeeChargeDetailInner(FeeCategory feeCategory, FeeType1 feeType, ApplicationFrequency2 applicationFrequency) {
+        this.feeCategory = feeCategory;
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public FeeChargeDetailInner feeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+        return this;
+    }
+
+    /**
+     * Get feeCategory
+     *
+     * @return feeCategory
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeCategory")
+    public FeeCategory getFeeCategory() {
+        return feeCategory;
+    }
+
+    public void setFeeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+    }
+
+    public FeeChargeDetailInner feeType(FeeType1 feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public FeeType1 getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(FeeType1 feeType) {
+        this.feeType = feeType;
+    }
+
+    public FeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Fee/charge which is usually negotiable rather than a fixed amount
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public FeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public FeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public FeeChargeDetailInner feeRateType(FeeRateType1 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public FeeRateType1 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(FeeRateType1 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public FeeChargeDetailInner applicationFrequency(ApplicationFrequency2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency2 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public FeeChargeDetailInner calculationFrequency(CalculationFrequency2 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency2 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency2 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public FeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public FeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the fee/charge details.
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the fee/charge details.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public FeeChargeDetailInner feeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public FeeChargeDetailInner addFeeChargeCapItem(FeeChargeCapInner feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid FeeChargeCapInner> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    public FeeChargeDetailInner otherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeCategoryType
+     *
+     * @return otherFeeCategoryType
+     */
+    @Valid
+    @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeCategoryType")
+    public OtherFeeCategoryType getOtherFeeCategoryType() {
+        return otherFeeCategoryType;
+    }
+
+    public void setOtherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+    }
+
+    public FeeChargeDetailInner otherFeeType(OtherFeeType1 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OtherFeeType1 getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OtherFeeType1 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public FeeChargeDetailInner otherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OtherFeeRateType1 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public FeeChargeDetailInner otherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency1 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public FeeChargeDetailInner otherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency1 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    public FeeChargeDetailInner feeApplicableRange(FeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+        return this;
+    }
+
+    /**
+     * Get feeApplicableRange
+     *
+     * @return feeApplicableRange
+     */
+    @Valid
+    @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeApplicableRange")
+    public FeeApplicableRange getFeeApplicableRange() {
+        return feeApplicableRange;
+    }
+
+    public void setFeeApplicableRange(FeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeeChargeDetailInner feeChargeDetailInner = (FeeChargeDetailInner) o;
+        return Objects.equals(this.feeCategory, feeChargeDetailInner.feeCategory) &&
+                Objects.equals(this.feeType, feeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, feeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.feeAmount, feeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, feeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, feeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, feeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, feeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, feeChargeDetailInner.notes) &&
+                Objects.equals(this.feeChargeCap, feeChargeDetailInner.feeChargeCap) &&
+                Objects.equals(this.otherFeeCategoryType, feeChargeDetailInner.otherFeeCategoryType) &&
+                Objects.equals(this.otherFeeType, feeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, feeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, feeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, feeChargeDetailInner.otherCalculationFrequency) &&
+                Objects.equals(this.feeApplicableRange, feeChargeDetailInner.feeApplicableRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeCategory, feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, feeChargeCap, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeApplicableRange);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FeeChargeDetailInner {\n");
+        sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeCategoryEnum fromValue(String value) {
-      for (FeeCategoryEnum b : FeeCategoryEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private FeeCategoryEnum feeCategory;
-
-  /**
-   * Fee/Charge Type
-   */
-  public enum FeeTypeEnum {
-    OTHER("Other"),
-    
-    SERVICECACCOUNTFEE("ServiceCAccountFee"),
-    
-    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
-    
-    SERVICECACCOUNTFEEQUARTERLY("ServiceCAccountFeeQuarterly"),
-    
-    SERVICECFIXEDTARIFF("ServiceCFixedTariff"),
-    
-    SERVICECBUSIDEPACCBREAKAGE("ServiceCBusiDepAccBreakage"),
-    
-    SERVICECMINIMUMMONTHLYFEE("ServiceCMinimumMonthlyFee"),
-    
-    SERVICECOTHER("ServiceCOther");
-
-    private String value;
-
-    FeeTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeTypeEnum feeType;
-
-  private Boolean negotiableIndicator;
-
-  private String feeAmount;
-
-  private String feeRate;
-
-  /**
-   * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   */
-  public enum FeeRateTypeEnum {
-    GROSS("Gross"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    FeeRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeRateTypeEnum fromValue(String value) {
-      for (FeeRateTypeEnum b : FeeRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeRateTypeEnum feeRateType;
-
-  /**
-   * How frequently the fee/charge is applied to the account
-   */
-  public enum ApplicationFrequencyEnum {
-    ONCLOSING("OnClosing"),
-    
-    ONOPENING("OnOpening"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONANNIVERSARY("OnAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHUNDREDPOUNDS("PerHundredPounds"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * How frequently the fee/charge is calculated
-   */
-  public enum CalculationFrequencyEnum {
-    ONCLOSING("OnClosing"),
-    
-    ONOPENING("OnOpening"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONANNIVERSARY("OnAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHUNDREDPOUNDS("PerHundredPounds"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid FeeChargeCapInner> feeChargeCap;
-
-  private OtherFeeCategoryType otherFeeCategoryType;
-
-  private OtherFeeType1 otherFeeType;
-
-  private OtherFeeRateType1 otherFeeRateType;
-
-  private OtherApplicationFrequency1 otherApplicationFrequency;
-
-  private OtherCalculationFrequency1 otherCalculationFrequency;
-
-  private FeeApplicableRange feeApplicableRange;
-
-  public FeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public FeeChargeDetailInner(FeeCategoryEnum feeCategory, FeeTypeEnum feeType, ApplicationFrequencyEnum applicationFrequency) {
-    this.feeCategory = feeCategory;
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public FeeChargeDetailInner feeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-    return this;
-  }
-
-  /**
-   * Categorisation of fees and charges into standard categories.
-   * @return feeCategory
-  */
-  @NotNull 
-  @Schema(name = "FeeCategory", description = "Categorisation of fees and charges into standard categories.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeCategory")
-  public FeeCategoryEnum getFeeCategory() {
-    return feeCategory;
-  }
-
-  public void setFeeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-  }
-
-  public FeeChargeDetailInner feeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Fee/Charge Type
-   * @return feeType
-  */
-  @NotNull 
-  @Schema(name = "FeeType", description = "Fee/Charge Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public FeeTypeEnum getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-  }
-
-  public FeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Fee/charge which is usually negotiable rather than a fixed amount
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public FeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public FeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public FeeChargeDetailInner feeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRateType
-  */
-  
-  @Schema(name = "FeeRateType", description = "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public FeeRateTypeEnum getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public FeeChargeDetailInner applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * How frequently the fee/charge is applied to the account
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "How frequently the fee/charge is applied to the account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public FeeChargeDetailInner calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How frequently the fee/charge is calculated
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How frequently the fee/charge is calculated", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public FeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public FeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the fee/charge details.
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the fee/charge details.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public FeeChargeDetailInner feeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public FeeChargeDetailInner addFeeChargeCapItem(FeeChargeCapInner feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
-    }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
-
-  /**
-   * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid FeeChargeCapInner> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  public FeeChargeDetailInner otherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeCategoryType
-   * @return otherFeeCategoryType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeCategoryType")
-  public OtherFeeCategoryType getOtherFeeCategoryType() {
-    return otherFeeCategoryType;
-  }
-
-  public void setOtherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-  }
-
-  public FeeChargeDetailInner otherFeeType(OtherFeeType1 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OtherFeeType1 getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OtherFeeType1 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public FeeChargeDetailInner otherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OtherFeeRateType1 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public FeeChargeDetailInner otherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency1 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public FeeChargeDetailInner otherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency1 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  public FeeChargeDetailInner feeApplicableRange(FeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-    return this;
-  }
-
-  /**
-   * Get feeApplicableRange
-   * @return feeApplicableRange
-  */
-  @Valid 
-  @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeApplicableRange")
-  public FeeApplicableRange getFeeApplicableRange() {
-    return feeApplicableRange;
-  }
-
-  public void setFeeApplicableRange(FeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    FeeChargeDetailInner feeChargeDetailInner = (FeeChargeDetailInner) o;
-    return Objects.equals(this.feeCategory, feeChargeDetailInner.feeCategory) &&
-        Objects.equals(this.feeType, feeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, feeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.feeAmount, feeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, feeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, feeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, feeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, feeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, feeChargeDetailInner.notes) &&
-        Objects.equals(this.feeChargeCap, feeChargeDetailInner.feeChargeCap) &&
-        Objects.equals(this.otherFeeCategoryType, feeChargeDetailInner.otherFeeCategoryType) &&
-        Objects.equals(this.otherFeeType, feeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, feeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, feeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, feeChargeDetailInner.otherCalculationFrequency) &&
-        Objects.equals(this.feeApplicableRange, feeChargeDetailInner.feeApplicableRange);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeCategory, feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, feeChargeCap, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeApplicableRange);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class FeeChargeDetailInner {\n");
-    sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeChargeDetailInner1.java
@@ -15,21 +15,41 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.ApplicationFrequency5;
+import uk.org.openbanking.datamodel.account.CalculationFrequency5;
+import uk.org.openbanking.datamodel.account.FeeApplicableRange;
+import uk.org.openbanking.datamodel.account.FeeCategory;
+import uk.org.openbanking.datamodel.account.FeeChargeCapInner1;
+import uk.org.openbanking.datamodel.account.FeeRateType3;
+import uk.org.openbanking.datamodel.account.FeeType3;
+import uk.org.openbanking.datamodel.account.OtherApplicationFrequency1;
+import uk.org.openbanking.datamodel.account.OtherCalculationFrequency1;
+import uk.org.openbanking.datamodel.account.OtherFeeCategoryType;
+import uk.org.openbanking.datamodel.account.OtherFeeRateType1;
+import uk.org.openbanking.datamodel.account.OtherFeeType1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Other fees/charges details
@@ -40,685 +60,448 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class FeeChargeDetailInner1 {
 
-  /**
-   * Categorisation of fees and charges into standard categories.
-   */
-  public enum FeeCategoryEnum {
-    OTHER("Other"),
-    
-    SERVICING("Servicing");
+    private FeeCategory feeCategory;
 
-    private String value;
+    private FeeType3 feeType;
 
-    FeeCategoryEnum(String value) {
-      this.value = value;
+    private String feeAmount;
+
+    private String feeRate;
+
+    private FeeRateType3 feeRateType;
+
+    private ApplicationFrequency5 applicationFrequency;
+
+    private CalculationFrequency5 calculationFrequency;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OtherFeeCategoryType otherFeeCategoryType;
+
+    private OtherFeeType1 otherFeeType;
+
+    private OtherFeeRateType1 otherFeeRateType;
+
+    private OtherApplicationFrequency1 otherApplicationFrequency;
+
+    private OtherCalculationFrequency1 otherCalculationFrequency;
+
+    @Valid
+    private List<@Valid FeeChargeCapInner1> feeChargeCap;
+
+    private FeeApplicableRange feeApplicableRange;
+
+    public FeeChargeDetailInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public FeeChargeDetailInner1(FeeCategory feeCategory, FeeType3 feeType, ApplicationFrequency5 applicationFrequency) {
+        this.feeCategory = feeCategory;
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public FeeChargeDetailInner1 feeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+        return this;
+    }
+
+    /**
+     * Get feeCategory
+     *
+     * @return feeCategory
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeCategory")
+    public FeeCategory getFeeCategory() {
+        return feeCategory;
+    }
+
+    public void setFeeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+    }
+
+    public FeeChargeDetailInner1 feeType(FeeType3 feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public FeeType3 getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(FeeType3 feeType) {
+        this.feeType = feeType;
+    }
+
+    public FeeChargeDetailInner1 feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public FeeChargeDetailInner1 feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public FeeChargeDetailInner1 feeRateType(FeeRateType3 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public FeeRateType3 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(FeeRateType3 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public FeeChargeDetailInner1 applicationFrequency(ApplicationFrequency5 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency5 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency5 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public FeeChargeDetailInner1 calculationFrequency(CalculationFrequency5 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency5 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency5 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public FeeChargeDetailInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public FeeChargeDetailInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the fee/charge details.
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the fee/charge details.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public FeeChargeDetailInner1 otherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeCategoryType
+     *
+     * @return otherFeeCategoryType
+     */
+    @Valid
+    @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeCategoryType")
+    public OtherFeeCategoryType getOtherFeeCategoryType() {
+        return otherFeeCategoryType;
+    }
+
+    public void setOtherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+    }
+
+    public FeeChargeDetailInner1 otherFeeType(OtherFeeType1 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OtherFeeType1 getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OtherFeeType1 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public FeeChargeDetailInner1 otherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OtherFeeRateType1 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public FeeChargeDetailInner1 otherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency1 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public FeeChargeDetailInner1 otherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency1 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    public FeeChargeDetailInner1 feeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public FeeChargeDetailInner1 addFeeChargeCapItem(FeeChargeCapInner1 feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid FeeChargeCapInner1> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    public FeeChargeDetailInner1 feeApplicableRange(FeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+        return this;
+    }
+
+    /**
+     * Get feeApplicableRange
+     *
+     * @return feeApplicableRange
+     */
+    @Valid
+    @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeApplicableRange")
+    public FeeApplicableRange getFeeApplicableRange() {
+        return feeApplicableRange;
+    }
+
+    public void setFeeApplicableRange(FeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FeeChargeDetailInner1 feeChargeDetailInner1 = (FeeChargeDetailInner1) o;
+        return Objects.equals(this.feeCategory, feeChargeDetailInner1.feeCategory) &&
+                Objects.equals(this.feeType, feeChargeDetailInner1.feeType) &&
+                Objects.equals(this.feeAmount, feeChargeDetailInner1.feeAmount) &&
+                Objects.equals(this.feeRate, feeChargeDetailInner1.feeRate) &&
+                Objects.equals(this.feeRateType, feeChargeDetailInner1.feeRateType) &&
+                Objects.equals(this.applicationFrequency, feeChargeDetailInner1.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, feeChargeDetailInner1.calculationFrequency) &&
+                Objects.equals(this.notes, feeChargeDetailInner1.notes) &&
+                Objects.equals(this.otherFeeCategoryType, feeChargeDetailInner1.otherFeeCategoryType) &&
+                Objects.equals(this.otherFeeType, feeChargeDetailInner1.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, feeChargeDetailInner1.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, feeChargeDetailInner1.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, feeChargeDetailInner1.otherCalculationFrequency) &&
+                Objects.equals(this.feeChargeCap, feeChargeDetailInner1.feeChargeCap) &&
+                Objects.equals(this.feeApplicableRange, feeChargeDetailInner1.feeApplicableRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeCategory, feeType, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeChargeCap, feeApplicableRange);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class FeeChargeDetailInner1 {\n");
+        sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeCategoryEnum fromValue(String value) {
-      for (FeeCategoryEnum b : FeeCategoryEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private FeeCategoryEnum feeCategory;
-
-  /**
-   * Fee/Charge Type
-   */
-  public enum FeeTypeEnum {
-    SERVICECACCOUNTFEE("ServiceCAccountFee"),
-    
-    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
-    
-    SERVICECOTHER("ServiceCOther"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    FeeTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeTypeEnum feeType;
-
-  private String feeAmount;
-
-  private String feeRate;
-
-  /**
-   * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   */
-  public enum FeeRateTypeEnum {
-    LINKEDBASERATE("LinkedBaseRate"),
-    
-    GROSS("Gross"),
-    
-    NET("Net"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    FeeRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeRateTypeEnum fromValue(String value) {
-      for (FeeRateTypeEnum b : FeeRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeRateTypeEnum feeRateType;
-
-  /**
-   * How frequently the fee/charge is applied to the account
-   */
-  public enum ApplicationFrequencyEnum {
-    ACCOUNTCLOSING("AccountClosing"),
-    
-    ACCOUNTOPENING("AccountOpening"),
-    
-    ACADEMICTERM("AcademicTerm"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * How frequently the fee/charge is calculated
-   */
-  public enum CalculationFrequencyEnum {
-    ACCOUNTCLOSING("AccountClosing"),
-    
-    ACCOUNTOPENING("AccountOpening"),
-    
-    ACADEMICTERM("AcademicTerm"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OtherFeeCategoryType otherFeeCategoryType;
-
-  private OtherFeeType1 otherFeeType;
-
-  private OtherFeeRateType1 otherFeeRateType;
-
-  private OtherApplicationFrequency1 otherApplicationFrequency;
-
-  private OtherCalculationFrequency1 otherCalculationFrequency;
-
-  @Valid
-  private List<@Valid FeeChargeCapInner1> feeChargeCap;
-
-  private FeeApplicableRange feeApplicableRange;
-
-  public FeeChargeDetailInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public FeeChargeDetailInner1(FeeCategoryEnum feeCategory, FeeTypeEnum feeType, ApplicationFrequencyEnum applicationFrequency) {
-    this.feeCategory = feeCategory;
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public FeeChargeDetailInner1 feeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-    return this;
-  }
-
-  /**
-   * Categorisation of fees and charges into standard categories.
-   * @return feeCategory
-  */
-  @NotNull 
-  @Schema(name = "FeeCategory", description = "Categorisation of fees and charges into standard categories.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeCategory")
-  public FeeCategoryEnum getFeeCategory() {
-    return feeCategory;
-  }
-
-  public void setFeeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-  }
-
-  public FeeChargeDetailInner1 feeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Fee/Charge Type
-   * @return feeType
-  */
-  @NotNull 
-  @Schema(name = "FeeType", description = "Fee/Charge Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public FeeTypeEnum getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-  }
-
-  public FeeChargeDetailInner1 feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public FeeChargeDetailInner1 feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public FeeChargeDetailInner1 feeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRateType
-  */
-  
-  @Schema(name = "FeeRateType", description = "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public FeeRateTypeEnum getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public FeeChargeDetailInner1 applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * How frequently the fee/charge is applied to the account
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "How frequently the fee/charge is applied to the account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public FeeChargeDetailInner1 calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How frequently the fee/charge is calculated
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How frequently the fee/charge is calculated", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public FeeChargeDetailInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public FeeChargeDetailInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the fee/charge details.
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the fee/charge details.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public FeeChargeDetailInner1 otherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeCategoryType
-   * @return otherFeeCategoryType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeCategoryType")
-  public OtherFeeCategoryType getOtherFeeCategoryType() {
-    return otherFeeCategoryType;
-  }
-
-  public void setOtherFeeCategoryType(OtherFeeCategoryType otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-  }
-
-  public FeeChargeDetailInner1 otherFeeType(OtherFeeType1 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OtherFeeType1 getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OtherFeeType1 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public FeeChargeDetailInner1 otherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OtherFeeRateType1 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OtherFeeRateType1 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public FeeChargeDetailInner1 otherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency1 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency1 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public FeeChargeDetailInner1 otherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency1 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency1 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  public FeeChargeDetailInner1 feeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public FeeChargeDetailInner1 addFeeChargeCapItem(FeeChargeCapInner1 feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
-    }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
-
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid FeeChargeCapInner1> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  public FeeChargeDetailInner1 feeApplicableRange(FeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-    return this;
-  }
-
-  /**
-   * Get feeApplicableRange
-   * @return feeApplicableRange
-  */
-  @Valid 
-  @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeApplicableRange")
-  public FeeApplicableRange getFeeApplicableRange() {
-    return feeApplicableRange;
-  }
-
-  public void setFeeApplicableRange(FeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    FeeChargeDetailInner1 feeChargeDetailInner1 = (FeeChargeDetailInner1) o;
-    return Objects.equals(this.feeCategory, feeChargeDetailInner1.feeCategory) &&
-        Objects.equals(this.feeType, feeChargeDetailInner1.feeType) &&
-        Objects.equals(this.feeAmount, feeChargeDetailInner1.feeAmount) &&
-        Objects.equals(this.feeRate, feeChargeDetailInner1.feeRate) &&
-        Objects.equals(this.feeRateType, feeChargeDetailInner1.feeRateType) &&
-        Objects.equals(this.applicationFrequency, feeChargeDetailInner1.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, feeChargeDetailInner1.calculationFrequency) &&
-        Objects.equals(this.notes, feeChargeDetailInner1.notes) &&
-        Objects.equals(this.otherFeeCategoryType, feeChargeDetailInner1.otherFeeCategoryType) &&
-        Objects.equals(this.otherFeeType, feeChargeDetailInner1.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, feeChargeDetailInner1.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, feeChargeDetailInner1.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, feeChargeDetailInner1.otherCalculationFrequency) &&
-        Objects.equals(this.feeChargeCap, feeChargeDetailInner1.feeChargeCap) &&
-        Objects.equals(this.feeApplicableRange, feeChargeDetailInner1.feeApplicableRange);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeCategory, feeType, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeChargeCap, feeApplicableRange);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class FeeChargeDetailInner1 {\n");
-    sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeFreeLengthPeriod.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The unit of period (days, weeks, months etc.) of the promotional length
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeFreeLengthPeriod {
+
+    DAY("Day"),
+
+    HALF_YEAR("Half Year"),
+
+    MONTH("Month"),
+
+    QUARTER("Quarter"),
+
+    WEEK("Week"),
+
+    YEAR("Year");
+
+    private String value;
+
+    FeeFreeLengthPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeFreeLengthPeriod fromValue(String value) {
+        for (FeeFreeLengthPeriod b : FeeFreeLengthPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeRateType {
+
+    GROSS("Gross"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeRateType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeRateType fromValue(String value) {
+        for (FeeRateType b : FeeRateType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType1.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeRateType1 {
+
+    GROSS("Gross"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeRateType1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeRateType1 fromValue(String value) {
+        for (FeeRateType1 b : FeeRateType1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType2.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeRateType2 {
+
+    LINKEDBASERATE("LinkedBaseRate"),
+
+    GROSS("Gross"),
+
+    NET("Net"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeRateType2(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeRateType2 fromValue(String value) {
+        for (FeeRateType2 b : FeeRateType2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeRateType3.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeRateType3 {
+
+    LINKEDBASERATE("LinkedBaseRate"),
+
+    GROSS("Gross"),
+
+    NET("Net"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeRateType3(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeRateType3 fromValue(String value) {
+        for (FeeRateType3 b : FeeRateType3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Overdraft fee type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType {
+
+    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
+
+    ANNUALREVIEW("AnnualReview"),
+
+    EMERGENCYBORROWING("EmergencyBorrowing"),
+
+    BORROWINGITEM("BorrowingItem"),
+
+    OVERDRAFTRENEWAL("OverdraftRenewal"),
+
+    OVERDRAFTSETUP("OverdraftSetup"),
+
+    SURCHARGE("Surcharge"),
+
+    TEMPOVERDRAFT("TempOverdraft"),
+
+    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
+
+    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
+
+    OTHER("Other"),
+
+    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+
+    private String value;
+
+    FeeType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType fromValue(String value) {
+        for (FeeType b : FeeType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType1.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/Charge Type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType1 {
+
+    OTHER("Other"),
+
+    SERVICECACCOUNTFEE("ServiceCAccountFee"),
+
+    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
+
+    SERVICECACCOUNTFEEQUARTERLY("ServiceCAccountFeeQuarterly"),
+
+    SERVICECFIXEDTARIFF("ServiceCFixedTariff"),
+
+    SERVICECBUSIDEPACCBREAKAGE("ServiceCBusiDepAccBreakage"),
+
+    SERVICECMINIMUMMONTHLYFEE("ServiceCMinimumMonthlyFee"),
+
+    SERVICECOTHER("ServiceCOther");
+
+    private String value;
+
+    FeeType1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType1 fromValue(String value) {
+        for (FeeType1 b : FeeType1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Overdraft fee type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType2 {
+
+    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
+
+    EMERGENCYBORROWING("EmergencyBorrowing"),
+
+    BORROWINGITEM("BorrowingItem"),
+
+    OVERDRAFTRENEWAL("OverdraftRenewal"),
+
+    ANNUALREVIEW("AnnualReview"),
+
+    OVERDRAFTSETUP("OverdraftSetup"),
+
+    SURCHARGE("Surcharge"),
+
+    TEMPOVERDRAFT("TempOverdraft"),
+
+    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
+
+    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
+
+    OTHER("Other"),
+
+    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+
+    private String value;
+
+    FeeType2(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType2 fromValue(String value) {
+        for (FeeType2 b : FeeType2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2Inner.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/charge type which is being capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType2Inner {
+
+    OTHER("Other"),
+
+    SERVICECACCOUNTFEE("ServiceCAccountFee"),
+
+    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
+
+    SERVICECACCOUNTFEEQUARTERLY("ServiceCAccountFeeQuarterly"),
+
+    SERVICECFIXEDTARIFF("ServiceCFixedTariff"),
+
+    SERVICECBUSIDEPACCBREAKAGE("ServiceCBusiDepAccBreakage"),
+
+    SERVICECMINIMUMMONTHLYFEE("ServiceCMinimumMonthlyFee"),
+
+    SERVICECOTHER("ServiceCOther");
+
+    private String value;
+
+    FeeType2Inner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType2Inner fromValue(String value) {
+        for (FeeType2Inner b : FeeType2Inner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2Inner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType2Inner1.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Overdraft fee type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType2Inner1 {
+
+    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
+
+    EMERGENCYBORROWING("EmergencyBorrowing"),
+
+    BORROWINGITEM("BorrowingItem"),
+
+    OVERDRAFTRENEWAL("OverdraftRenewal"),
+
+    ANNUALREVIEW("AnnualReview"),
+
+    OVERDRAFTSETUP("OverdraftSetup"),
+
+    SURCHARGE("Surcharge"),
+
+    TEMPOVERDRAFT("TempOverdraft"),
+
+    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
+
+    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
+
+    OTHER("Other"),
+
+    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+
+    private String value;
+
+    FeeType2Inner1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType2Inner1 fromValue(String value) {
+        for (FeeType2Inner1 b : FeeType2Inner1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType3.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/Charge Type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType3 {
+
+    SERVICECACCOUNTFEE("ServiceCAccountFee"),
+
+    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
+
+    SERVICECOTHER("ServiceCOther"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeType3(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType3 fromValue(String value) {
+        for (FeeType3 b : FeeType3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType4Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeType4Inner.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/charge type which is being capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeType4Inner {
+
+    SERVICECACCOUNTFEE("ServiceCAccountFee"),
+
+    SERVICECACCOUNTFEEMONTHLY("ServiceCAccountFeeMonthly"),
+
+    SERVICECOTHER("ServiceCOther"),
+
+    OTHER("Other");
+
+    private String value;
+
+    FeeType4Inner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeType4Inner fromValue(String value) {
+        for (FeeType4Inner b : FeeType4Inner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeTypeInner.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Overdraft fee type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FeeTypeInner {
+
+    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
+
+    ANNUALREVIEW("AnnualReview"),
+
+    EMERGENCYBORROWING("EmergencyBorrowing"),
+
+    BORROWINGITEM("BorrowingItem"),
+
+    OVERDRAFTRENEWAL("OverdraftRenewal"),
+
+    OVERDRAFTSETUP("OverdraftSetup"),
+
+    SURCHARGE("Surcharge"),
+
+    TEMPOVERDRAFT("TempOverdraft"),
+
+    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
+
+    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
+
+    OTHER("Other"),
+
+    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+
+    private String value;
+
+    FeeTypeInner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FeeTypeInner fromValue(String value) {
+        for (FeeTypeInner b : FeeTypeInner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FixedVariableInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FixedVariableInterestRateType.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Type of interest rate, Fixed or Variable
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum FixedVariableInterestRateType {
+
+    FIXED("Fixed"),
+
+    VARIABLE("Variable");
+
+    private String value;
+
+    FixedVariableInterestRateType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static FixedVariableInterestRateType fromValue(String value) {
+        for (FixedVariableInterestRateType b : FixedVariableInterestRateType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/MinMaxType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/MinMaxType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Min Max type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum MinMaxType {
+
+    MINIMUM("Minimum"),
+
+    MAXIMUM("Maximum");
+
+    private String value;
+
+    MinMaxType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static MinMaxType fromValue(String value) {
+        for (MinMaxType b : MinMaxType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/MinMaxType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/MinMaxType1.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum MinMaxType1 {
+
+    MINIMUM("Minimum"),
+
+    MAXIMUM("Maximum");
+
+    private String value;
+
+    MinMaxType1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static MinMaxType1 fromValue(String value) {
+        for (MinMaxType1 b : MinMaxType1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Model.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Model.java
@@ -29,63 +29,64 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class Model {
 
-  private Long id;
+    private Long id;
 
-  public Model id(Long id) {
-    this.id = id;
-    return this;
-  }
-
-  /**
-   * Get id
-   * @return id
-  */
-  
-  @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("id")
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public Model id(Long id) {
+        this.id = id;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get id
+     *
+     * @return id
+     */
+
+    @Schema(name = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("id")
+    public Long getId() {
+        return id;
     }
-    Model model = (Model) o;
-    return Objects.equals(this.id, model.id);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(id);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class Model {\n");
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setId(Long id) {
+        this.id = id;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Model model = (Model) o;
+        return Objects.equals(this.id, model.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Model {\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
@@ -39,374 +39,388 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBAccount6 {
 
-  private String accountId;
+    private String accountId;
 
-  private OBAccountStatus1Code status;
+    private OBAccountStatus1Code status;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime statusUpdateDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime statusUpdateDateTime;
 
-  private String currency;
+    private String currency;
 
-  private OBExternalAccountType1Code accountType;
+    private OBExternalAccountType1Code accountType;
 
-  private OBExternalAccountSubType1Code accountSubType;
+    private OBExternalAccountSubType1Code accountSubType;
 
-  private String description;
+    private String description;
 
-  private String nickname;
+    private String nickname;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime openingDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime openingDate;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime maturityDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime maturityDate;
 
-  private String switchStatus;
+    private String switchStatus;
 
-  @Valid
-  private List<@Valid OBAccount6AccountInner> account;
+    @Valid
+    private List<@Valid OBAccount6AccountInner> account;
 
-  private OBBranchAndFinancialInstitutionIdentification50 servicer;
+    private OBBranchAndFinancialInstitutionIdentification50 servicer;
 
-  public OBAccount6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBAccount6(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBAccount6 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBAccount6 status(OBAccountStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Status")
-  public OBAccountStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBAccountStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBAccount6 statusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return statusUpdateDateTime
-  */
-  @Valid 
-  @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatusUpdateDateTime")
-  public DateTime getStatusUpdateDateTime() {
-    return statusUpdateDateTime;
-  }
-
-  public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-  }
-
-  public OBAccount6 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
-   * @return currency
-  */
-  @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public OBAccount6 accountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-    return this;
-  }
-
-  /**
-   * Get accountType
-   * @return accountType
-  */
-  @Valid 
-  @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountType")
-  public OBExternalAccountType1Code getAccountType() {
-    return accountType;
-  }
-
-  public void setAccountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-  }
-
-  public OBAccount6 accountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-    return this;
-  }
-
-  /**
-   * Get accountSubType
-   * @return accountSubType
-  */
-  @Valid 
-  @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountSubType")
-  public OBExternalAccountSubType1Code getAccountSubType() {
-    return accountSubType;
-  }
-
-  public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-  }
-
-  public OBAccount6 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Specifies the description of the account type.
-   * @return description
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBAccount6 nickname(String nickname) {
-    this.nickname = nickname;
-    return this;
-  }
-
-  /**
-   * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
-   * @return nickname
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Nickname")
-  public String getNickname() {
-    return nickname;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
-
-  public OBAccount6 openingDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-    return this;
-  }
-
-  /**
-   * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return openingDate
-  */
-  @Valid 
-  @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OpeningDate")
-  public DateTime getOpeningDate() {
-    return openingDate;
-  }
-
-  public void setOpeningDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-  }
-
-  public OBAccount6 maturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-    return this;
-  }
-
-  /**
-   * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return maturityDate
-  */
-  @Valid 
-  @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaturityDate")
-  public DateTime getMaturityDate() {
-    return maturityDate;
-  }
-
-  public void setMaturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-  }
-
-  public OBAccount6 switchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-    return this;
-  }
-
-  /**
-   * Specifies the switch status for the account, in a coded form.
-   * @return switchStatus
-  */
-  
-  @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SwitchStatus")
-  public String getSwitchStatus() {
-    return switchStatus;
-  }
-
-  public void setSwitchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-  }
-
-  public OBAccount6 account(List<@Valid OBAccount6AccountInner> account) {
-    this.account = account;
-    return this;
-  }
-
-  public OBAccount6 addAccountItem(OBAccount6AccountInner accountItem) {
-    if (this.account == null) {
-      this.account = new ArrayList<>();
+    public OBAccount6() {
+        super();
     }
-    this.account.add(accountItem);
-    return this;
-  }
 
-  /**
-   * Get account
-   * @return account
-  */
-  @Valid 
-  @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Account")
-  public List<@Valid OBAccount6AccountInner> getAccount() {
-    return account;
-  }
-
-  public void setAccount(List<@Valid OBAccount6AccountInner> account) {
-    this.account = account;
-  }
-
-  public OBAccount6 servicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
-    this.servicer = servicer;
-    return this;
-  }
-
-  /**
-   * Get servicer
-   * @return servicer
-  */
-  @Valid 
-  @Schema(name = "Servicer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Servicer")
-  public OBBranchAndFinancialInstitutionIdentification50 getServicer() {
-    return servicer;
-  }
-
-  public void setServicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
-    this.servicer = servicer;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBAccount6(String accountId) {
+        this.accountId = accountId;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBAccount6 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBAccount6 obAccount6 = (OBAccount6) o;
-    return Objects.equals(this.accountId, obAccount6.accountId) &&
-        Objects.equals(this.status, obAccount6.status) &&
-        Objects.equals(this.statusUpdateDateTime, obAccount6.statusUpdateDateTime) &&
-        Objects.equals(this.currency, obAccount6.currency) &&
-        Objects.equals(this.accountType, obAccount6.accountType) &&
-        Objects.equals(this.accountSubType, obAccount6.accountSubType) &&
-        Objects.equals(this.description, obAccount6.description) &&
-        Objects.equals(this.nickname, obAccount6.nickname) &&
-        Objects.equals(this.openingDate, obAccount6.openingDate) &&
-        Objects.equals(this.maturityDate, obAccount6.maturityDate) &&
-        Objects.equals(this.switchStatus, obAccount6.switchStatus) &&
-        Objects.equals(this.account, obAccount6.account) &&
-        Objects.equals(this.servicer, obAccount6.servicer);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus, account, servicer);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBAccount6 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
-    sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
-    sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
-    sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
-    sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
-    sb.append("    account: ").append(toIndentedString(account)).append("\n");
-    sb.append("    servicer: ").append(toIndentedString(servicer)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBAccount6 status(OBAccountStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Status")
+    public OBAccountStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBAccountStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBAccount6 statusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return statusUpdateDateTime
+     */
+    @Valid
+    @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusUpdateDateTime")
+    public DateTime getStatusUpdateDateTime() {
+        return statusUpdateDateTime;
+    }
+
+    public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+    }
+
+    public OBAccount6 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
+     *
+     * @return currency
+     */
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public OBAccount6 accountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+        return this;
+    }
+
+    /**
+     * Get accountType
+     *
+     * @return accountType
+     */
+    @Valid
+    @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountType")
+    public OBExternalAccountType1Code getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+    }
+
+    public OBAccount6 accountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+        return this;
+    }
+
+    /**
+     * Get accountSubType
+     *
+     * @return accountSubType
+     */
+    @Valid
+    @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountSubType")
+    public OBExternalAccountSubType1Code getAccountSubType() {
+        return accountSubType;
+    }
+
+    public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+    }
+
+    public OBAccount6 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Specifies the description of the account type.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBAccount6 nickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    /**
+     * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
+     *
+     * @return nickname
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Nickname")
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public OBAccount6 openingDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+        return this;
+    }
+
+    /**
+     * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return openingDate
+     */
+    @Valid
+    @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OpeningDate")
+    public DateTime getOpeningDate() {
+        return openingDate;
+    }
+
+    public void setOpeningDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+    }
+
+    public OBAccount6 maturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+        return this;
+    }
+
+    /**
+     * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return maturityDate
+     */
+    @Valid
+    @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaturityDate")
+    public DateTime getMaturityDate() {
+        return maturityDate;
+    }
+
+    public void setMaturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+    }
+
+    public OBAccount6 switchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+        return this;
+    }
+
+    /**
+     * Specifies the switch status for the account, in a coded form.
+     *
+     * @return switchStatus
+     */
+
+    @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SwitchStatus")
+    public String getSwitchStatus() {
+        return switchStatus;
+    }
+
+    public void setSwitchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+    }
+
+    public OBAccount6 account(List<@Valid OBAccount6AccountInner> account) {
+        this.account = account;
+        return this;
+    }
+
+    public OBAccount6 addAccountItem(OBAccount6AccountInner accountItem) {
+        if (this.account == null) {
+            this.account = new ArrayList<>();
+        }
+        this.account.add(accountItem);
+        return this;
+    }
+
+    /**
+     * Get account
+     *
+     * @return account
+     */
+    @Valid
+    @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Account")
+    public List<@Valid OBAccount6AccountInner> getAccount() {
+        return account;
+    }
+
+    public void setAccount(List<@Valid OBAccount6AccountInner> account) {
+        this.account = account;
+    }
+
+    public OBAccount6 servicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
+        this.servicer = servicer;
+        return this;
+    }
+
+    /**
+     * Get servicer
+     *
+     * @return servicer
+     */
+    @Valid
+    @Schema(name = "Servicer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Servicer")
+    public OBBranchAndFinancialInstitutionIdentification50 getServicer() {
+        return servicer;
+    }
+
+    public void setServicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
+        this.servicer = servicer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBAccount6 obAccount6 = (OBAccount6) o;
+        return Objects.equals(this.accountId, obAccount6.accountId) &&
+                Objects.equals(this.status, obAccount6.status) &&
+                Objects.equals(this.statusUpdateDateTime, obAccount6.statusUpdateDateTime) &&
+                Objects.equals(this.currency, obAccount6.currency) &&
+                Objects.equals(this.accountType, obAccount6.accountType) &&
+                Objects.equals(this.accountSubType, obAccount6.accountSubType) &&
+                Objects.equals(this.description, obAccount6.description) &&
+                Objects.equals(this.nickname, obAccount6.nickname) &&
+                Objects.equals(this.openingDate, obAccount6.openingDate) &&
+                Objects.equals(this.maturityDate, obAccount6.maturityDate) &&
+                Objects.equals(this.switchStatus, obAccount6.switchStatus) &&
+                Objects.equals(this.account, obAccount6.account) &&
+                Objects.equals(this.servicer, obAccount6.servicer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus, account, servicer);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBAccount6 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
+        sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
+        sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
+        sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
+        sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
+        sb.append("    account: ").append(toIndentedString(account)).append("\n");
+        sb.append("    servicer: ").append(toIndentedString(servicer)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6AccountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6AccountInner.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 /**
  * Provides the details to identify an account.
@@ -34,147 +42,152 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBAccount6AccountInner {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private String secondaryIdentification;
+    private String secondaryIdentification;
 
-  public OBAccount6AccountInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBAccount6AccountInner(String schemeName, String identification) {
-    this.schemeName = schemeName;
-    this.identification = identification;
-  }
-
-  public OBAccount6AccountInner schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  @NotNull 
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBAccount6AccountInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Identification assigned by an institution to identify an account. This identification is known by the account owner.
-   * @return identification
-  */
-  @NotNull @Size(min = 1, max = 256) 
-  @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBAccount6AccountInner name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBAccount6AccountInner secondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-    return this;
-  }
-
-  /**
-   * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-   * @return secondaryIdentification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryIdentification")
-  public String getSecondaryIdentification() {
-    return secondaryIdentification;
-  }
-
-  public void setSecondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBAccount6AccountInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBAccount6AccountInner(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
     }
-    OBAccount6AccountInner obAccount6AccountInner = (OBAccount6AccountInner) o;
-    return Objects.equals(this.schemeName, obAccount6AccountInner.schemeName) &&
-        Objects.equals(this.identification, obAccount6AccountInner.identification) &&
-        Objects.equals(this.name, obAccount6AccountInner.name) &&
-        Objects.equals(this.secondaryIdentification, obAccount6AccountInner.secondaryIdentification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, secondaryIdentification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBAccount6AccountInner {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBAccount6AccountInner schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBAccount6AccountInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBAccount6AccountInner name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBAccount6AccountInner secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBAccount6AccountInner obAccount6AccountInner = (OBAccount6AccountInner) o;
+        return Objects.equals(this.schemeName, obAccount6AccountInner.schemeName) &&
+                Objects.equals(this.identification, obAccount6AccountInner.identification) &&
+                Objects.equals(this.name, obAccount6AccountInner.name) &&
+                Objects.equals(this.secondaryIdentification, obAccount6AccountInner.secondaryIdentification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBAccount6AccountInner {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
@@ -37,320 +37,335 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBAccount6Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private OBAccountStatus1Code status;
+    private OBAccountStatus1Code status;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime statusUpdateDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime statusUpdateDateTime;
 
-  private String currency;
+    private String currency;
 
-  private OBExternalAccountType1Code accountType;
+    private OBExternalAccountType1Code accountType;
 
-  private OBExternalAccountSubType1Code accountSubType;
+    private OBExternalAccountSubType1Code accountSubType;
 
-  private String description;
+    private String description;
 
-  private String nickname;
+    private String nickname;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime openingDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime openingDate;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime maturityDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime maturityDate;
 
-  private String switchStatus;
+    private String switchStatus;
 
-  public OBAccount6Basic() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBAccount6Basic(String accountId, String currency, OBExternalAccountType1Code accountType, OBExternalAccountSubType1Code accountSubType) {
-    this.accountId = accountId;
-    this.currency = currency;
-    this.accountType = accountType;
-    this.accountSubType = accountSubType;
-  }
-
-  public OBAccount6Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBAccount6Basic status(OBAccountStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Status")
-  public OBAccountStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBAccountStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBAccount6Basic statusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return statusUpdateDateTime
-  */
-  @Valid 
-  @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatusUpdateDateTime")
-  public DateTime getStatusUpdateDateTime() {
-    return statusUpdateDateTime;
-  }
-
-  public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-  }
-
-  public OBAccount6Basic currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public OBAccount6Basic accountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-    return this;
-  }
-
-  /**
-   * Get accountType
-   * @return accountType
-  */
-  @NotNull @Valid 
-  @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountType")
-  public OBExternalAccountType1Code getAccountType() {
-    return accountType;
-  }
-
-  public void setAccountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-  }
-
-  public OBAccount6Basic accountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-    return this;
-  }
-
-  /**
-   * Get accountSubType
-   * @return accountSubType
-  */
-  @NotNull @Valid 
-  @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountSubType")
-  public OBExternalAccountSubType1Code getAccountSubType() {
-    return accountSubType;
-  }
-
-  public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-  }
-
-  public OBAccount6Basic description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Specifies the description of the account type.
-   * @return description
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBAccount6Basic nickname(String nickname) {
-    this.nickname = nickname;
-    return this;
-  }
-
-  /**
-   * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
-   * @return nickname
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Nickname")
-  public String getNickname() {
-    return nickname;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
-
-  public OBAccount6Basic openingDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-    return this;
-  }
-
-  /**
-   * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return openingDate
-  */
-  @Valid 
-  @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OpeningDate")
-  public DateTime getOpeningDate() {
-    return openingDate;
-  }
-
-  public void setOpeningDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-  }
-
-  public OBAccount6Basic maturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-    return this;
-  }
-
-  /**
-   * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return maturityDate
-  */
-  @Valid 
-  @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaturityDate")
-  public DateTime getMaturityDate() {
-    return maturityDate;
-  }
-
-  public void setMaturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-  }
-
-  public OBAccount6Basic switchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-    return this;
-  }
-
-  /**
-   * Specifies the switch status for the account, in a coded form.
-   * @return switchStatus
-  */
-  
-  @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SwitchStatus")
-  public String getSwitchStatus() {
-    return switchStatus;
-  }
-
-  public void setSwitchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBAccount6Basic() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBAccount6Basic(String accountId, String currency, OBExternalAccountType1Code accountType, OBExternalAccountSubType1Code accountSubType) {
+        this.accountId = accountId;
+        this.currency = currency;
+        this.accountType = accountType;
+        this.accountSubType = accountSubType;
     }
-    OBAccount6Basic obAccount6Basic = (OBAccount6Basic) o;
-    return Objects.equals(this.accountId, obAccount6Basic.accountId) &&
-        Objects.equals(this.status, obAccount6Basic.status) &&
-        Objects.equals(this.statusUpdateDateTime, obAccount6Basic.statusUpdateDateTime) &&
-        Objects.equals(this.currency, obAccount6Basic.currency) &&
-        Objects.equals(this.accountType, obAccount6Basic.accountType) &&
-        Objects.equals(this.accountSubType, obAccount6Basic.accountSubType) &&
-        Objects.equals(this.description, obAccount6Basic.description) &&
-        Objects.equals(this.nickname, obAccount6Basic.nickname) &&
-        Objects.equals(this.openingDate, obAccount6Basic.openingDate) &&
-        Objects.equals(this.maturityDate, obAccount6Basic.maturityDate) &&
-        Objects.equals(this.switchStatus, obAccount6Basic.switchStatus);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBAccount6Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
-    sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
-    sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
-    sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
-    sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBAccount6Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBAccount6Basic status(OBAccountStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Status")
+    public OBAccountStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBAccountStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBAccount6Basic statusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return statusUpdateDateTime
+     */
+    @Valid
+    @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusUpdateDateTime")
+    public DateTime getStatusUpdateDateTime() {
+        return statusUpdateDateTime;
+    }
+
+    public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+    }
+
+    public OBAccount6Basic currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public OBAccount6Basic accountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+        return this;
+    }
+
+    /**
+     * Get accountType
+     *
+     * @return accountType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountType")
+    public OBExternalAccountType1Code getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+    }
+
+    public OBAccount6Basic accountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+        return this;
+    }
+
+    /**
+     * Get accountSubType
+     *
+     * @return accountSubType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountSubType")
+    public OBExternalAccountSubType1Code getAccountSubType() {
+        return accountSubType;
+    }
+
+    public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+    }
+
+    public OBAccount6Basic description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Specifies the description of the account type.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBAccount6Basic nickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    /**
+     * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
+     *
+     * @return nickname
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Nickname")
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public OBAccount6Basic openingDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+        return this;
+    }
+
+    /**
+     * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return openingDate
+     */
+    @Valid
+    @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OpeningDate")
+    public DateTime getOpeningDate() {
+        return openingDate;
+    }
+
+    public void setOpeningDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+    }
+
+    public OBAccount6Basic maturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+        return this;
+    }
+
+    /**
+     * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return maturityDate
+     */
+    @Valid
+    @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaturityDate")
+    public DateTime getMaturityDate() {
+        return maturityDate;
+    }
+
+    public void setMaturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+    }
+
+    public OBAccount6Basic switchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+        return this;
+    }
+
+    /**
+     * Specifies the switch status for the account, in a coded form.
+     *
+     * @return switchStatus
+     */
+
+    @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SwitchStatus")
+    public String getSwitchStatus() {
+        return switchStatus;
+    }
+
+    public void setSwitchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBAccount6Basic obAccount6Basic = (OBAccount6Basic) o;
+        return Objects.equals(this.accountId, obAccount6Basic.accountId) &&
+                Objects.equals(this.status, obAccount6Basic.status) &&
+                Objects.equals(this.statusUpdateDateTime, obAccount6Basic.statusUpdateDateTime) &&
+                Objects.equals(this.currency, obAccount6Basic.currency) &&
+                Objects.equals(this.accountType, obAccount6Basic.accountType) &&
+                Objects.equals(this.accountSubType, obAccount6Basic.accountSubType) &&
+                Objects.equals(this.description, obAccount6Basic.description) &&
+                Objects.equals(this.nickname, obAccount6Basic.nickname) &&
+                Objects.equals(this.openingDate, obAccount6Basic.openingDate) &&
+                Objects.equals(this.maturityDate, obAccount6Basic.maturityDate) &&
+                Objects.equals(this.switchStatus, obAccount6Basic.switchStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBAccount6Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
+        sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
+        sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
+        sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
+        sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
@@ -39,378 +39,396 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBAccount6Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private OBAccountStatus1Code status;
+    private OBAccountStatus1Code status;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime statusUpdateDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime statusUpdateDateTime;
 
-  private String currency;
+    private String currency;
 
-  private OBExternalAccountType1Code accountType;
+    private OBExternalAccountType1Code accountType;
 
-  private OBExternalAccountSubType1Code accountSubType;
+    private OBExternalAccountSubType1Code accountSubType;
 
-  private String description;
+    private String description;
 
-  private String nickname;
+    private String nickname;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime openingDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime openingDate;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime maturityDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime maturityDate;
 
-  private String switchStatus;
+    private String switchStatus;
 
-  @Valid
-  private List<@Valid OBAccount6AccountInner> account = new ArrayList<>();
+    @Valid
+    private List<@Valid OBAccount6AccountInner> account = new ArrayList<>();
 
-  private OBBranchAndFinancialInstitutionIdentification50 servicer;
+    private OBBranchAndFinancialInstitutionIdentification50 servicer;
 
-  public OBAccount6Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBAccount6Detail(String accountId, String currency, OBExternalAccountType1Code accountType, OBExternalAccountSubType1Code accountSubType, List<@Valid OBAccount6AccountInner> account) {
-    this.accountId = accountId;
-    this.currency = currency;
-    this.accountType = accountType;
-    this.accountSubType = accountSubType;
-    this.account = account;
-  }
-
-  public OBAccount6Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBAccount6Detail status(OBAccountStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Status")
-  public OBAccountStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBAccountStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBAccount6Detail statusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return statusUpdateDateTime
-  */
-  @Valid 
-  @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatusUpdateDateTime")
-  public DateTime getStatusUpdateDateTime() {
-    return statusUpdateDateTime;
-  }
-
-  public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-  }
-
-  public OBAccount6Detail currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  public OBAccount6Detail accountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-    return this;
-  }
-
-  /**
-   * Get accountType
-   * @return accountType
-  */
-  @NotNull @Valid 
-  @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountType")
-  public OBExternalAccountType1Code getAccountType() {
-    return accountType;
-  }
-
-  public void setAccountType(OBExternalAccountType1Code accountType) {
-    this.accountType = accountType;
-  }
-
-  public OBAccount6Detail accountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-    return this;
-  }
-
-  /**
-   * Get accountSubType
-   * @return accountSubType
-  */
-  @NotNull @Valid 
-  @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountSubType")
-  public OBExternalAccountSubType1Code getAccountSubType() {
-    return accountSubType;
-  }
-
-  public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
-    this.accountSubType = accountSubType;
-  }
-
-  public OBAccount6Detail description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Specifies the description of the account type.
-   * @return description
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBAccount6Detail nickname(String nickname) {
-    this.nickname = nickname;
-    return this;
-  }
-
-  /**
-   * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
-   * @return nickname
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Nickname")
-  public String getNickname() {
-    return nickname;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
-
-  public OBAccount6Detail openingDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-    return this;
-  }
-
-  /**
-   * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return openingDate
-  */
-  @Valid 
-  @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OpeningDate")
-  public DateTime getOpeningDate() {
-    return openingDate;
-  }
-
-  public void setOpeningDate(DateTime openingDate) {
-    this.openingDate = openingDate;
-  }
-
-  public OBAccount6Detail maturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-    return this;
-  }
-
-  /**
-   * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return maturityDate
-  */
-  @Valid 
-  @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaturityDate")
-  public DateTime getMaturityDate() {
-    return maturityDate;
-  }
-
-  public void setMaturityDate(DateTime maturityDate) {
-    this.maturityDate = maturityDate;
-  }
-
-  public OBAccount6Detail switchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-    return this;
-  }
-
-  /**
-   * Specifies the switch status for the account, in a coded form.
-   * @return switchStatus
-  */
-  
-  @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SwitchStatus")
-  public String getSwitchStatus() {
-    return switchStatus;
-  }
-
-  public void setSwitchStatus(String switchStatus) {
-    this.switchStatus = switchStatus;
-  }
-
-  public OBAccount6Detail account(List<@Valid OBAccount6AccountInner> account) {
-    this.account = account;
-    return this;
-  }
-
-  public OBAccount6Detail addAccountItem(OBAccount6AccountInner accountItem) {
-    if (this.account == null) {
-      this.account = new ArrayList<>();
+    public OBAccount6Detail() {
+        super();
     }
-    this.account.add(accountItem);
-    return this;
-  }
 
-  /**
-   * Get account
-   * @return account
-  */
-  @NotNull @Valid 
-  @Schema(name = "Account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Account")
-  public List<@Valid OBAccount6AccountInner> getAccount() {
-    return account;
-  }
-
-  public void setAccount(List<@Valid OBAccount6AccountInner> account) {
-    this.account = account;
-  }
-
-  public OBAccount6Detail servicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
-    this.servicer = servicer;
-    return this;
-  }
-
-  /**
-   * Get servicer
-   * @return servicer
-  */
-  @Valid 
-  @Schema(name = "Servicer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Servicer")
-  public OBBranchAndFinancialInstitutionIdentification50 getServicer() {
-    return servicer;
-  }
-
-  public void setServicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
-    this.servicer = servicer;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBAccount6Detail(String accountId, String currency, OBExternalAccountType1Code accountType, OBExternalAccountSubType1Code accountSubType, List<@Valid OBAccount6AccountInner> account) {
+        this.accountId = accountId;
+        this.currency = currency;
+        this.accountType = accountType;
+        this.accountSubType = accountSubType;
+        this.account = account;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBAccount6Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBAccount6Detail obAccount6Detail = (OBAccount6Detail) o;
-    return Objects.equals(this.accountId, obAccount6Detail.accountId) &&
-        Objects.equals(this.status, obAccount6Detail.status) &&
-        Objects.equals(this.statusUpdateDateTime, obAccount6Detail.statusUpdateDateTime) &&
-        Objects.equals(this.currency, obAccount6Detail.currency) &&
-        Objects.equals(this.accountType, obAccount6Detail.accountType) &&
-        Objects.equals(this.accountSubType, obAccount6Detail.accountSubType) &&
-        Objects.equals(this.description, obAccount6Detail.description) &&
-        Objects.equals(this.nickname, obAccount6Detail.nickname) &&
-        Objects.equals(this.openingDate, obAccount6Detail.openingDate) &&
-        Objects.equals(this.maturityDate, obAccount6Detail.maturityDate) &&
-        Objects.equals(this.switchStatus, obAccount6Detail.switchStatus) &&
-        Objects.equals(this.account, obAccount6Detail.account) &&
-        Objects.equals(this.servicer, obAccount6Detail.servicer);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus, account, servicer);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBAccount6Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
-    sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
-    sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
-    sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
-    sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
-    sb.append("    account: ").append(toIndentedString(account)).append("\n");
-    sb.append("    servicer: ").append(toIndentedString(servicer)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBAccount6Detail status(OBAccountStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Status")
+    public OBAccountStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBAccountStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBAccount6Detail statusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return statusUpdateDateTime
+     */
+    @Valid
+    @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusUpdateDateTime")
+    public DateTime getStatusUpdateDateTime() {
+        return statusUpdateDateTime;
+    }
+
+    public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+    }
+
+    public OBAccount6Detail currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "Identification of the currency in which the account is held.  Usage: Currency should only be used in case one and the same account number covers several currencies and the initiating party needs to identify which currency needs to be used for settlement on the account.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public OBAccount6Detail accountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+        return this;
+    }
+
+    /**
+     * Get accountType
+     *
+     * @return accountType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "AccountType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountType")
+    public OBExternalAccountType1Code getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(OBExternalAccountType1Code accountType) {
+        this.accountType = accountType;
+    }
+
+    public OBAccount6Detail accountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+        return this;
+    }
+
+    /**
+     * Get accountSubType
+     *
+     * @return accountSubType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "AccountSubType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountSubType")
+    public OBExternalAccountSubType1Code getAccountSubType() {
+        return accountSubType;
+    }
+
+    public void setAccountSubType(OBExternalAccountSubType1Code accountSubType) {
+        this.accountSubType = accountSubType;
+    }
+
+    public OBAccount6Detail description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Specifies the description of the account type.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Description", description = "Specifies the description of the account type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBAccount6Detail nickname(String nickname) {
+        this.nickname = nickname;
+        return this;
+    }
+
+    /**
+     * The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.
+     *
+     * @return nickname
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Nickname", description = "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Nickname")
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public OBAccount6Detail openingDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+        return this;
+    }
+
+    /**
+     * Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return openingDate
+     */
+    @Valid
+    @Schema(name = "OpeningDate", description = "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OpeningDate")
+    public DateTime getOpeningDate() {
+        return openingDate;
+    }
+
+    public void setOpeningDate(DateTime openingDate) {
+        this.openingDate = openingDate;
+    }
+
+    public OBAccount6Detail maturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+        return this;
+    }
+
+    /**
+     * Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return maturityDate
+     */
+    @Valid
+    @Schema(name = "MaturityDate", description = "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaturityDate")
+    public DateTime getMaturityDate() {
+        return maturityDate;
+    }
+
+    public void setMaturityDate(DateTime maturityDate) {
+        this.maturityDate = maturityDate;
+    }
+
+    public OBAccount6Detail switchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+        return this;
+    }
+
+    /**
+     * Specifies the switch status for the account, in a coded form.
+     *
+     * @return switchStatus
+     */
+
+    @Schema(name = "SwitchStatus", description = "Specifies the switch status for the account, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SwitchStatus")
+    public String getSwitchStatus() {
+        return switchStatus;
+    }
+
+    public void setSwitchStatus(String switchStatus) {
+        this.switchStatus = switchStatus;
+    }
+
+    public OBAccount6Detail account(List<@Valid OBAccount6AccountInner> account) {
+        this.account = account;
+        return this;
+    }
+
+    public OBAccount6Detail addAccountItem(OBAccount6AccountInner accountItem) {
+        if (this.account == null) {
+            this.account = new ArrayList<>();
+        }
+        this.account.add(accountItem);
+        return this;
+    }
+
+    /**
+     * Get account
+     *
+     * @return account
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Account", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Account")
+    public List<@Valid OBAccount6AccountInner> getAccount() {
+        return account;
+    }
+
+    public void setAccount(List<@Valid OBAccount6AccountInner> account) {
+        this.account = account;
+    }
+
+    public OBAccount6Detail servicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
+        this.servicer = servicer;
+        return this;
+    }
+
+    /**
+     * Get servicer
+     *
+     * @return servicer
+     */
+    @Valid
+    @Schema(name = "Servicer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Servicer")
+    public OBBranchAndFinancialInstitutionIdentification50 getServicer() {
+        return servicer;
+    }
+
+    public void setServicer(OBBranchAndFinancialInstitutionIdentification50 servicer) {
+        this.servicer = servicer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBAccount6Detail obAccount6Detail = (OBAccount6Detail) o;
+        return Objects.equals(this.accountId, obAccount6Detail.accountId) &&
+                Objects.equals(this.status, obAccount6Detail.status) &&
+                Objects.equals(this.statusUpdateDateTime, obAccount6Detail.statusUpdateDateTime) &&
+                Objects.equals(this.currency, obAccount6Detail.currency) &&
+                Objects.equals(this.accountType, obAccount6Detail.accountType) &&
+                Objects.equals(this.accountSubType, obAccount6Detail.accountSubType) &&
+                Objects.equals(this.description, obAccount6Detail.description) &&
+                Objects.equals(this.nickname, obAccount6Detail.nickname) &&
+                Objects.equals(this.openingDate, obAccount6Detail.openingDate) &&
+                Objects.equals(this.maturityDate, obAccount6Detail.maturityDate) &&
+                Objects.equals(this.switchStatus, obAccount6Detail.switchStatus) &&
+                Objects.equals(this.account, obAccount6Detail.account) &&
+                Objects.equals(this.servicer, obAccount6Detail.servicer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, status, statusUpdateDateTime, currency, accountType, accountSubType, description, nickname, openingDate, maturityDate, switchStatus, account, servicer);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBAccount6Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
+        sb.append("    accountSubType: ").append(toIndentedString(accountSubType)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    nickname: ").append(toIndentedString(nickname)).append("\n");
+        sb.append("    openingDate: ").append(toIndentedString(openingDate)).append("\n");
+        sb.append("    maturityDate: ").append(toIndentedString(maturityDate)).append("\n");
+        sb.append("    switchStatus: ").append(toIndentedString(switchStatus)).append("\n");
+        sb.append("    account: ").append(toIndentedString(account)).append("\n");
+        sb.append("    servicer: ").append(toIndentedString(servicer)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccountStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccountStatus1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the status of account resource in code form.
@@ -26,41 +40,41 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBAccountStatus1Code {
-  
-  DELETED("Deleted"),
-  
-  DISABLED("Disabled"),
-  
-  ENABLED("Enabled"),
-  
-  PENDING("Pending"),
-  
-  PROFORMA("ProForma");
 
-  private String value;
+    DELETED("Deleted"),
 
-  OBAccountStatus1Code(String value) {
-    this.value = value;
-  }
+    DISABLED("Disabled"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    ENABLED("Enabled"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    PENDING("Pending"),
 
-  @JsonCreator
-  public static OBAccountStatus1Code fromValue(String value) {
-    for (OBAccountStatus1Code b : OBAccountStatus1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    PROFORMA("ProForma");
+
+    private String value;
+
+    OBAccountStatus1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBAccountStatus1Code fromValue(String value) {
+        for (OBAccountStatus1Code b : OBAccountStatus1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * The amount of the most recent direct debit collection.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount0 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount0() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount0(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount0 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount0 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount0() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount0(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount0 obActiveOrHistoricCurrencyAndAmount0 = (OBActiveOrHistoricCurrencyAndAmount0) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount0.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount0.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount0 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount0 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount0 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount0 obActiveOrHistoricCurrencyAndAmount0 = (OBActiveOrHistoricCurrencyAndAmount0) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount0.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount0.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount0 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount1 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount1(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount1 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount1 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount1(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount1 obActiveOrHistoricCurrencyAndAmount1 = (OBActiveOrHistoricCurrencyAndAmount1) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount1.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount1.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount1 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount1 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount1 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount1 obActiveOrHistoricCurrencyAndAmount1 = (OBActiveOrHistoricCurrencyAndAmount1) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount1.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount1.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount1 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Transaction charges to be paid by the charge bearer.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount10 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount10() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount10(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount10 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount10 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount10() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount10(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount10 obActiveOrHistoricCurrencyAndAmount10 = (OBActiveOrHistoricCurrencyAndAmount10) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount10.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount10.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount10 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount10 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount10 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount10 obActiveOrHistoricCurrencyAndAmount10 = (OBActiveOrHistoricCurrencyAndAmount10) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount10.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount10.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount10 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * The amount of the last (most recent) Standing Order instruction.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount11 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount11() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount11(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount11 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount11 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount11() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount11(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount11 obActiveOrHistoricCurrencyAndAmount11 = (OBActiveOrHistoricCurrencyAndAmount11) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount11.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount11.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount11 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount11 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount11 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount11 obActiveOrHistoricCurrencyAndAmount11 = (OBActiveOrHistoricCurrencyAndAmount11) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount11.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount11.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount11 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * The amount of the first Standing Order
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount2 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount2(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount2 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount2 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount2() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount2(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount2 obActiveOrHistoricCurrencyAndAmount2 = (OBActiveOrHistoricCurrencyAndAmount2) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount2.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount2.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount2 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount2 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount2 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount2 obActiveOrHistoricCurrencyAndAmount2 = (OBActiveOrHistoricCurrencyAndAmount2) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount2.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount2.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount2 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * The amount of the next Standing Order.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount3 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount3() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount3(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount3 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount3 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount3() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount3(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount3 obActiveOrHistoricCurrencyAndAmount3 = (OBActiveOrHistoricCurrencyAndAmount3) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount3.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount3.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount3 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount3 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount3 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount3 obActiveOrHistoricCurrencyAndAmount3 = (OBActiveOrHistoricCurrencyAndAmount3) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount3.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount3.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount3 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * The amount of the final Standing Order
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount4 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount4() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount4(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount4 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount4 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount4() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount4(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount4 obActiveOrHistoricCurrencyAndAmount4 = (OBActiveOrHistoricCurrencyAndAmount4) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount4.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount4.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount4 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount4 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount4 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount4 obActiveOrHistoricCurrencyAndAmount4 = (OBActiveOrHistoricCurrencyAndAmount4) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount4.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount4.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount4 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money associated with the statement benefit type.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount5 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount5() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount5(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount5 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount5 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount5() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount5(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount5 obActiveOrHistoricCurrencyAndAmount5 = (OBActiveOrHistoricCurrencyAndAmount5) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount5.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount5.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount5 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount5 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount5 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount5 obActiveOrHistoricCurrencyAndAmount5 = (OBActiveOrHistoricCurrencyAndAmount5) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount5.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount5.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount5 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money associated with the statement fee type.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount6 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount6(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount6 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount6 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount6() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount6(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount6 obActiveOrHistoricCurrencyAndAmount6 = (OBActiveOrHistoricCurrencyAndAmount6) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount6.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount6.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount6 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount6 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount6 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount6 obActiveOrHistoricCurrencyAndAmount6 = (OBActiveOrHistoricCurrencyAndAmount6) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount6.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount6.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount6 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money associated with the statement interest amount type.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount7 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount7() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount7(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount7 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount7 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount7() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount7(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount7 obActiveOrHistoricCurrencyAndAmount7 = (OBActiveOrHistoricCurrencyAndAmount7) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount7.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount7.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount7 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount7 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount7 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount7 obActiveOrHistoricCurrencyAndAmount7 = (OBActiveOrHistoricCurrencyAndAmount7) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount7.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount7.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount7 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money associated with the amount type.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount8 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount8() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount8(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount8 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount8 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount8() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount8(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount8 obActiveOrHistoricCurrencyAndAmount8 = (OBActiveOrHistoricCurrencyAndAmount8) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount8.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount8.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount8 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount8 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount8 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount8 obActiveOrHistoricCurrencyAndAmount8 = (OBActiveOrHistoricCurrencyAndAmount8) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount8.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount8.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount8 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money in the cash transaction entry.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBActiveOrHistoricCurrencyAndAmount9 {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBActiveOrHistoricCurrencyAndAmount9() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBActiveOrHistoricCurrencyAndAmount9(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount9 amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBActiveOrHistoricCurrencyAndAmount9 currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBActiveOrHistoricCurrencyAndAmount9() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount9(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBActiveOrHistoricCurrencyAndAmount9 obActiveOrHistoricCurrencyAndAmount9 = (OBActiveOrHistoricCurrencyAndAmount9) o;
-    return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount9.amount) &&
-        Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount9.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBActiveOrHistoricCurrencyAndAmount9 {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBActiveOrHistoricCurrencyAndAmount9 amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount9 currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount9 obActiveOrHistoricCurrencyAndAmount9 = (OBActiveOrHistoricCurrencyAndAmount9) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount9.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount9.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount9 {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
@@ -32,144 +32,148 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBCAData1 {
 
-  private ProductDetails productDetails;
+    private ProductDetails productDetails;
 
-  private CreditInterest creditInterest;
+    private CreditInterest creditInterest;
 
-  private Overdraft overdraft;
+    private Overdraft overdraft;
 
-  @Valid
-  private List<@Valid OtherFeesChargesInner> otherFeesCharges;
+    @Valid
+    private List<@Valid OtherFeesChargesInner> otherFeesCharges;
 
-  public OBBCAData1 productDetails(ProductDetails productDetails) {
-    this.productDetails = productDetails;
-    return this;
-  }
-
-  /**
-   * Get productDetails
-   * @return productDetails
-  */
-  @Valid 
-  @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProductDetails")
-  public ProductDetails getProductDetails() {
-    return productDetails;
-  }
-
-  public void setProductDetails(ProductDetails productDetails) {
-    this.productDetails = productDetails;
-  }
-
-  public OBBCAData1 creditInterest(CreditInterest creditInterest) {
-    this.creditInterest = creditInterest;
-    return this;
-  }
-
-  /**
-   * Get creditInterest
-   * @return creditInterest
-  */
-  @Valid 
-  @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditInterest")
-  public CreditInterest getCreditInterest() {
-    return creditInterest;
-  }
-
-  public void setCreditInterest(CreditInterest creditInterest) {
-    this.creditInterest = creditInterest;
-  }
-
-  public OBBCAData1 overdraft(Overdraft overdraft) {
-    this.overdraft = overdraft;
-    return this;
-  }
-
-  /**
-   * Get overdraft
-   * @return overdraft
-  */
-  @Valid 
-  @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Overdraft")
-  public Overdraft getOverdraft() {
-    return overdraft;
-  }
-
-  public void setOverdraft(Overdraft overdraft) {
-    this.overdraft = overdraft;
-  }
-
-  public OBBCAData1 otherFeesCharges(List<@Valid OtherFeesChargesInner> otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-    return this;
-  }
-
-  public OBBCAData1 addOtherFeesChargesItem(OtherFeesChargesInner otherFeesChargesItem) {
-    if (this.otherFeesCharges == null) {
-      this.otherFeesCharges = new ArrayList<>();
+    public OBBCAData1 productDetails(ProductDetails productDetails) {
+        this.productDetails = productDetails;
+        return this;
     }
-    this.otherFeesCharges.add(otherFeesChargesItem);
-    return this;
-  }
 
-  /**
-   * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
-   * @return otherFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OtherFeesCharges", description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeesCharges")
-  public List<@Valid OtherFeesChargesInner> getOtherFeesCharges() {
-    return otherFeesCharges;
-  }
-
-  public void setOtherFeesCharges(List<@Valid OtherFeesChargesInner> otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Get productDetails
+     *
+     * @return productDetails
+     */
+    @Valid
+    @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProductDetails")
+    public ProductDetails getProductDetails() {
+        return productDetails;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public void setProductDetails(ProductDetails productDetails) {
+        this.productDetails = productDetails;
     }
-    OBBCAData1 obBCAData1 = (OBBCAData1) o;
-    return Objects.equals(this.productDetails, obBCAData1.productDetails) &&
-        Objects.equals(this.creditInterest, obBCAData1.creditInterest) &&
-        Objects.equals(this.overdraft, obBCAData1.overdraft) &&
-        Objects.equals(this.otherFeesCharges, obBCAData1.otherFeesCharges);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(productDetails, creditInterest, overdraft, otherFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBCAData1 {\n");
-    sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
-    sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
-    sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
-    sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBBCAData1 creditInterest(CreditInterest creditInterest) {
+        this.creditInterest = creditInterest;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get creditInterest
+     *
+     * @return creditInterest
+     */
+    @Valid
+    @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditInterest")
+    public CreditInterest getCreditInterest() {
+        return creditInterest;
+    }
+
+    public void setCreditInterest(CreditInterest creditInterest) {
+        this.creditInterest = creditInterest;
+    }
+
+    public OBBCAData1 overdraft(Overdraft overdraft) {
+        this.overdraft = overdraft;
+        return this;
+    }
+
+    /**
+     * Get overdraft
+     *
+     * @return overdraft
+     */
+    @Valid
+    @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Overdraft")
+    public Overdraft getOverdraft() {
+        return overdraft;
+    }
+
+    public void setOverdraft(Overdraft overdraft) {
+        this.overdraft = overdraft;
+    }
+
+    public OBBCAData1 otherFeesCharges(List<@Valid OtherFeesChargesInner> otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+        return this;
+    }
+
+    public OBBCAData1 addOtherFeesChargesItem(OtherFeesChargesInner otherFeesChargesItem) {
+        if (this.otherFeesCharges == null) {
+            this.otherFeesCharges = new ArrayList<>();
+        }
+        this.otherFeesCharges.add(otherFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
+     *
+     * @return otherFeesCharges
+     */
+    @Valid
+    @Schema(name = "OtherFeesCharges", description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeesCharges")
+    public List<@Valid OtherFeesChargesInner> getOtherFeesCharges() {
+        return otherFeesCharges;
+    }
+
+    public void setOtherFeesCharges(List<@Valid OtherFeesChargesInner> otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBCAData1 obBCAData1 = (OBBCAData1) o;
+        return Objects.equals(this.productDetails, obBCAData1.productDetails) &&
+                Objects.equals(this.creditInterest, obBCAData1.creditInterest) &&
+                Objects.equals(this.overdraft, obBCAData1.overdraft) &&
+                Objects.equals(this.otherFeesCharges, obBCAData1.otherFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productDetails, creditInterest, overdraft, otherFeesCharges);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBCAData1 {\n");
+        sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
+        sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
+        sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
+        sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBalanceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBalanceType1Code.java
@@ -26,57 +26,57 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBBalanceType1Code {
-  
-  CLOSINGAVAILABLE("ClosingAvailable"),
-  
-  CLOSINGBOOKED("ClosingBooked"),
-  
-  CLOSINGCLEARED("ClosingCleared"),
-  
-  EXPECTED("Expected"),
-  
-  FORWARDAVAILABLE("ForwardAvailable"),
-  
-  INFORMATION("Information"),
-  
-  INTERIMAVAILABLE("InterimAvailable"),
-  
-  INTERIMBOOKED("InterimBooked"),
-  
-  INTERIMCLEARED("InterimCleared"),
-  
-  OPENINGAVAILABLE("OpeningAvailable"),
-  
-  OPENINGBOOKED("OpeningBooked"),
-  
-  OPENINGCLEARED("OpeningCleared"),
-  
-  PREVIOUSLYCLOSEDBOOKED("PreviouslyClosedBooked");
 
-  private String value;
+    CLOSINGAVAILABLE("ClosingAvailable"),
 
-  OBBalanceType1Code(String value) {
-    this.value = value;
-  }
+    CLOSINGBOOKED("ClosingBooked"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    CLOSINGCLEARED("ClosingCleared"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    EXPECTED("Expected"),
 
-  @JsonCreator
-  public static OBBalanceType1Code fromValue(String value) {
-    for (OBBalanceType1Code b : OBBalanceType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FORWARDAVAILABLE("ForwardAvailable"),
+
+    INFORMATION("Information"),
+
+    INTERIMAVAILABLE("InterimAvailable"),
+
+    INTERIMBOOKED("InterimBooked"),
+
+    INTERIMCLEARED("InterimCleared"),
+
+    OPENINGAVAILABLE("OpeningAvailable"),
+
+    OPENINGBOOKED("OpeningBooked"),
+
+    OPENINGCLEARED("OpeningCleared"),
+
+    PREVIOUSLYCLOSEDBOOKED("PreviouslyClosedBooked");
+
+    private String value;
+
+    OBBalanceType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBBalanceType1Code fromValue(String value) {
+        for (OBBalanceType1Code b : OBBalanceType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
@@ -15,13 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
 
 /**
  * Set of elements used to fully identify the type of underlying transaction resulting in an entry.
@@ -31,99 +40,101 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBankTransactionCodeStructure1 {
 
-  private String code;
+    private String code;
 
-  private String subCode;
+    private String subCode;
 
-  public OBBankTransactionCodeStructure1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBBankTransactionCodeStructure1(String code, String subCode) {
-    this.code = code;
-    this.subCode = subCode;
-  }
-
-  public OBBankTransactionCodeStructure1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * Specifies the family within a domain.
-   * @return code
-  */
-  @NotNull 
-  @Schema(name = "Code", description = "Specifies the family within a domain.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBBankTransactionCodeStructure1 subCode(String subCode) {
-    this.subCode = subCode;
-    return this;
-  }
-
-  /**
-   * Specifies the sub-product family within a specific family.
-   * @return subCode
-  */
-  @NotNull 
-  @Schema(name = "SubCode", description = "Specifies the sub-product family within a specific family.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SubCode")
-  public String getSubCode() {
-    return subCode;
-  }
-
-  public void setSubCode(String subCode) {
-    this.subCode = subCode;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBankTransactionCodeStructure1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBBankTransactionCodeStructure1(String code, String subCode) {
+        this.code = code;
+        this.subCode = subCode;
     }
-    OBBankTransactionCodeStructure1 obBankTransactionCodeStructure1 = (OBBankTransactionCodeStructure1) o;
-    return Objects.equals(this.code, obBankTransactionCodeStructure1.code) &&
-        Objects.equals(this.subCode, obBankTransactionCodeStructure1.subCode);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, subCode);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBankTransactionCodeStructure1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    subCode: ").append(toIndentedString(subCode)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBBankTransactionCodeStructure1 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Specifies the family within a domain.
+     *
+     * @return code
+     */
+    @NotNull
+    @Schema(name = "Code", description = "Specifies the family within a domain.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBBankTransactionCodeStructure1 subCode(String subCode) {
+        this.subCode = subCode;
+        return this;
+    }
+
+    /**
+     * Specifies the sub-product family within a specific family.
+     *
+     * @return subCode
+     */
+    @NotNull
+    @Schema(name = "SubCode", description = "Specifies the sub-product family within a specific family.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SubCode")
+    public String getSubCode() {
+        return subCode;
+    }
+
+    public void setSubCode(String subCode) {
+        this.subCode = subCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBankTransactionCodeStructure1 obBankTransactionCodeStructure1 = (OBBankTransactionCodeStructure1) o;
+        return Objects.equals(this.code, obBankTransactionCodeStructure1.code) &&
+                Objects.equals(this.subCode, obBankTransactionCodeStructure1.subCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, subCode);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBankTransactionCodeStructure1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    subCode: ").append(toIndentedString(subCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
@@ -32,208 +32,214 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBeneficiary5 {
 
-  private String accountId;
+    private String accountId;
 
-  private String beneficiaryId;
+    private String beneficiaryId;
 
-  private OBBeneficiaryType1Code beneficiaryType;
+    private OBBeneficiaryType1Code beneficiaryType;
 
-  private String reference;
+    private String reference;
 
-  @Valid
-  private OBSupplementaryData1 supplementaryData;
+    private OBSupplementaryData1 supplementaryData;
 
-  private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
 
-  private OBCashAccount50 creditorAccount;
+    private OBCashAccount50 creditorAccount;
 
-  public OBBeneficiary5 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBBeneficiary5 beneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
-   * @return beneficiaryId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryId")
-  public String getBeneficiaryId() {
-    return beneficiaryId;
-  }
-
-  public void setBeneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-  }
-
-  public OBBeneficiary5 beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-    return this;
-  }
-
-  /**
-   * Get beneficiaryType
-   * @return beneficiaryType
-  */
-  @Valid 
-  @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryType")
-  public OBBeneficiaryType1Code getBeneficiaryType() {
-    return beneficiaryType;
-  }
-
-  public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-  }
-
-  public OBBeneficiary5 reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBBeneficiary5 supplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public OBSupplementaryData1 getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  public OBBeneficiary5 creditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification60 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBBeneficiary5 creditorAccount(OBCashAccount50 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount50 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount50 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBeneficiary5 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    OBBeneficiary5 obBeneficiary5 = (OBBeneficiary5) o;
-    return Objects.equals(this.accountId, obBeneficiary5.accountId) &&
-        Objects.equals(this.beneficiaryId, obBeneficiary5.beneficiaryId) &&
-        Objects.equals(this.beneficiaryType, obBeneficiary5.beneficiaryType) &&
-        Objects.equals(this.reference, obBeneficiary5.reference) &&
-        Objects.equals(this.supplementaryData, obBeneficiary5.supplementaryData) &&
-        Objects.equals(this.creditorAgent, obBeneficiary5.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obBeneficiary5.creditorAccount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData, creditorAgent, creditorAccount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBeneficiary5 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
-    sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBBeneficiary5 beneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
+     *
+     * @return beneficiaryId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryId")
+    public String getBeneficiaryId() {
+        return beneficiaryId;
+    }
+
+    public void setBeneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+    }
+
+    public OBBeneficiary5 beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+        return this;
+    }
+
+    /**
+     * Get beneficiaryType
+     *
+     * @return beneficiaryType
+     */
+    @Valid
+    @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryType")
+    public OBBeneficiaryType1Code getBeneficiaryType() {
+        return beneficiaryType;
+    }
+
+    public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+    }
+
+    public OBBeneficiary5 reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBBeneficiary5 supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    public OBBeneficiary5 creditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification60 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBBeneficiary5 creditorAccount(OBCashAccount50 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount50 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount50 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBeneficiary5 obBeneficiary5 = (OBBeneficiary5) o;
+        return Objects.equals(this.accountId, obBeneficiary5.accountId) &&
+                Objects.equals(this.beneficiaryId, obBeneficiary5.beneficiaryId) &&
+                Objects.equals(this.beneficiaryType, obBeneficiary5.beneficiaryType) &&
+                Objects.equals(this.reference, obBeneficiary5.reference) &&
+                Objects.equals(this.supplementaryData, obBeneficiary5.supplementaryData) &&
+                Objects.equals(this.creditorAgent, obBeneficiary5.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obBeneficiary5.creditorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData, creditorAgent, creditorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBeneficiary5 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
+        sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBBeneficiaryType1Code;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBBeneficiary5Basic
@@ -33,168 +43,164 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBeneficiary5Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private String beneficiaryId;
+    private String beneficiaryId;
 
-  private OBBeneficiaryType1Code beneficiaryType;
+    private OBBeneficiaryType1Code beneficiaryType;
 
-  private String reference;
+    private String reference;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBBeneficiary5Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBBeneficiary5Basic beneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
-   * @return beneficiaryId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryId")
-  public String getBeneficiaryId() {
-    return beneficiaryId;
-  }
-
-  public void setBeneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-  }
-
-  public OBBeneficiary5Basic beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-    return this;
-  }
-
-  /**
-   * Get beneficiaryType
-   * @return beneficiaryType
-  */
-  @Valid 
-  @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryType")
-  public OBBeneficiaryType1Code getBeneficiaryType() {
-    return beneficiaryType;
-  }
-
-  public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-  }
-
-  public OBBeneficiary5Basic reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBBeneficiary5Basic supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    public OBBeneficiary5Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    OBBeneficiary5Basic obBeneficiary5Basic = (OBBeneficiary5Basic) o;
-    return Objects.equals(this.accountId, obBeneficiary5Basic.accountId) &&
-        Objects.equals(this.beneficiaryId, obBeneficiary5Basic.beneficiaryId) &&
-        Objects.equals(this.beneficiaryType, obBeneficiary5Basic.beneficiaryType) &&
-        Objects.equals(this.reference, obBeneficiary5Basic.reference) &&
-        Objects.equals(this.supplementaryData, obBeneficiary5Basic.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBeneficiary5Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
-    sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBBeneficiary5Basic beneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
+     *
+     * @return beneficiaryId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryId")
+    public String getBeneficiaryId() {
+        return beneficiaryId;
+    }
+
+    public void setBeneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+    }
+
+    public OBBeneficiary5Basic beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+        return this;
+    }
+
+    /**
+     * Get beneficiaryType
+     *
+     * @return beneficiaryType
+     */
+    @Valid
+    @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryType")
+    public OBBeneficiaryType1Code getBeneficiaryType() {
+        return beneficiaryType;
+    }
+
+    public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+    }
+
+    public OBBeneficiary5Basic reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBBeneficiary5Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBeneficiary5Basic obBeneficiary5Basic = (OBBeneficiary5Basic) o;
+        return Objects.equals(this.accountId, obBeneficiary5Basic.accountId) &&
+                Objects.equals(this.beneficiaryId, obBeneficiary5Basic.beneficiaryId) &&
+                Objects.equals(this.beneficiaryType, obBeneficiary5Basic.beneficiaryType) &&
+                Objects.equals(this.reference, obBeneficiary5Basic.reference) &&
+                Objects.equals(this.supplementaryData, obBeneficiary5Basic.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBeneficiary5Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
+        sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
@@ -15,17 +15,28 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBBeneficiaryType1Code;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification60;
+import uk.org.openbanking.datamodel.account.OBCashAccount50;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBBeneficiary5Detail
@@ -34,227 +45,226 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBeneficiary5Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private String beneficiaryId;
+    private String beneficiaryId;
 
-  private OBBeneficiaryType1Code beneficiaryType;
+    private OBBeneficiaryType1Code beneficiaryType;
 
-  private String reference;
+    private String reference;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
 
-  private OBCashAccount50 creditorAccount;
+    private OBCashAccount50 creditorAccount;
 
-  public OBBeneficiary5Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBBeneficiary5Detail(OBCashAccount50 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBBeneficiary5Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBBeneficiary5Detail beneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
-   * @return beneficiaryId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryId")
-  public String getBeneficiaryId() {
-    return beneficiaryId;
-  }
-
-  public void setBeneficiaryId(String beneficiaryId) {
-    this.beneficiaryId = beneficiaryId;
-  }
-
-  public OBBeneficiary5Detail beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-    return this;
-  }
-
-  /**
-   * Get beneficiaryType
-   * @return beneficiaryType
-  */
-  @Valid 
-  @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficiaryType")
-  public OBBeneficiaryType1Code getBeneficiaryType() {
-    return beneficiaryType;
-  }
-
-  public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
-    this.beneficiaryType = beneficiaryType;
-  }
-
-  public OBBeneficiary5Detail reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBBeneficiary5Detail supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    public OBBeneficiary5Detail() {
+        super();
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  public OBBeneficiary5Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification60 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBBeneficiary5Detail creditorAccount(OBCashAccount50 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount50 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount50 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBBeneficiary5Detail(OBCashAccount50 creditorAccount) {
+        this.creditorAccount = creditorAccount;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBBeneficiary5Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBBeneficiary5Detail obBeneficiary5Detail = (OBBeneficiary5Detail) o;
-    return Objects.equals(this.accountId, obBeneficiary5Detail.accountId) &&
-        Objects.equals(this.beneficiaryId, obBeneficiary5Detail.beneficiaryId) &&
-        Objects.equals(this.beneficiaryType, obBeneficiary5Detail.beneficiaryType) &&
-        Objects.equals(this.reference, obBeneficiary5Detail.reference) &&
-        Objects.equals(this.supplementaryData, obBeneficiary5Detail.supplementaryData) &&
-        Objects.equals(this.creditorAgent, obBeneficiary5Detail.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obBeneficiary5Detail.creditorAccount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData, creditorAgent, creditorAccount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBeneficiary5Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
-    sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBBeneficiary5Detail beneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.
+     *
+     * @return beneficiaryId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "BeneficiaryId", description = "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryId")
+    public String getBeneficiaryId() {
+        return beneficiaryId;
+    }
+
+    public void setBeneficiaryId(String beneficiaryId) {
+        this.beneficiaryId = beneficiaryId;
+    }
+
+    public OBBeneficiary5Detail beneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+        return this;
+    }
+
+    /**
+     * Get beneficiaryType
+     *
+     * @return beneficiaryType
+     */
+    @Valid
+    @Schema(name = "BeneficiaryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryType")
+    public OBBeneficiaryType1Code getBeneficiaryType() {
+        return beneficiaryType;
+    }
+
+    public void setBeneficiaryType(OBBeneficiaryType1Code beneficiaryType) {
+        this.beneficiaryType = beneficiaryType;
+    }
+
+    public OBBeneficiary5Detail reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBBeneficiary5Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    public OBBeneficiary5Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification60 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification60 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBBeneficiary5Detail creditorAccount(OBCashAccount50 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount50 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount50 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBeneficiary5Detail obBeneficiary5Detail = (OBBeneficiary5Detail) o;
+        return Objects.equals(this.accountId, obBeneficiary5Detail.accountId) &&
+                Objects.equals(this.beneficiaryId, obBeneficiary5Detail.beneficiaryId) &&
+                Objects.equals(this.beneficiaryType, obBeneficiary5Detail.beneficiaryType) &&
+                Objects.equals(this.reference, obBeneficiary5Detail.reference) &&
+                Objects.equals(this.supplementaryData, obBeneficiary5Detail.supplementaryData) &&
+                Objects.equals(this.creditorAgent, obBeneficiary5Detail.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obBeneficiary5Detail.creditorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, beneficiaryId, beneficiaryType, reference, supplementaryData, creditorAgent, creditorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBeneficiary5Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    beneficiaryId: ").append(toIndentedString(beneficiaryId)).append("\n");
+        sb.append("    beneficiaryType: ").append(toIndentedString(beneficiaryType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiaryType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiaryType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the Beneficiary Type.
@@ -26,35 +40,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBBeneficiaryType1Code {
-  
-  TRUSTED("Trusted"),
-  
-  ORDINARY("Ordinary");
 
-  private String value;
+    TRUSTED("Trusted"),
 
-  OBBeneficiaryType1Code(String value) {
-    this.value = value;
-  }
+    ORDINARY("Ordinary");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBBeneficiaryType1Code fromValue(String value) {
-    for (OBBeneficiaryType1Code b : OBBeneficiaryType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBBeneficiaryType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBBeneficiaryType1Code fromValue(String value) {
+        for (OBBeneficiaryType1Code b : OBBeneficiaryType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 /**
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.
@@ -34,99 +42,102 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBranchAndFinancialInstitutionIdentification50 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  public OBBranchAndFinancialInstitutionIdentification50() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBBranchAndFinancialInstitutionIdentification50(String schemeName, String identification) {
-    this.schemeName = schemeName;
-    this.identification = identification;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification50 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  @NotNull 
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification50 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of the servicing institution.
-   * @return identification
-  */
-  @NotNull @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBranchAndFinancialInstitutionIdentification50() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBBranchAndFinancialInstitutionIdentification50(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
     }
-    OBBranchAndFinancialInstitutionIdentification50 obBranchAndFinancialInstitutionIdentification50 = (OBBranchAndFinancialInstitutionIdentification50) o;
-    return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification50.schemeName) &&
-        Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification50.identification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBranchAndFinancialInstitutionIdentification50 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBBranchAndFinancialInstitutionIdentification50 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification50 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of the servicing institution.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBranchAndFinancialInstitutionIdentification50 obBranchAndFinancialInstitutionIdentification50 = (OBBranchAndFinancialInstitutionIdentification50) o;
+        return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification50.schemeName) &&
+                Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification50.identification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBranchAndFinancialInstitutionIdentification50 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 /**
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
@@ -34,99 +42,102 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBranchAndFinancialInstitutionIdentification51 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  public OBBranchAndFinancialInstitutionIdentification51() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBBranchAndFinancialInstitutionIdentification51(String schemeName, String identification) {
-    this.schemeName = schemeName;
-    this.identification = identification;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification51 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  @NotNull 
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification51 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of the servicing institution.
-   * @return identification
-  */
-  @NotNull @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBranchAndFinancialInstitutionIdentification51() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBBranchAndFinancialInstitutionIdentification51(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
     }
-    OBBranchAndFinancialInstitutionIdentification51 obBranchAndFinancialInstitutionIdentification51 = (OBBranchAndFinancialInstitutionIdentification51) o;
-    return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification51.schemeName) &&
-        Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification51.identification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBranchAndFinancialInstitutionIdentification51 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBBranchAndFinancialInstitutionIdentification51 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification51 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of the servicing institution.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBranchAndFinancialInstitutionIdentification51 obBranchAndFinancialInstitutionIdentification51 = (OBBranchAndFinancialInstitutionIdentification51) o;
+        return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification51.schemeName) &&
+                Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification51.identification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBranchAndFinancialInstitutionIdentification51 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
@@ -15,16 +15,25 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.common.OBPostalAddress6;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
@@ -35,135 +44,139 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBranchAndFinancialInstitutionIdentification60 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private OBPostalAddress6 postalAddress;
+    private OBPostalAddress6 postalAddress;
 
-  public OBBranchAndFinancialInstitutionIdentification60 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification60 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of the servicing institution.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification60 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name by which an agent is known and which is usually used to identify that agent.
-   * @return name
-  */
-  @Size(min = 1, max = 140) 
-  @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification60 postalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-    return this;
-  }
-
-  /**
-   * Get postalAddress
-   * @return postalAddress
-  */
-  @Valid 
-  @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PostalAddress")
-  public OBPostalAddress6 getPostalAddress() {
-    return postalAddress;
-  }
-
-  public void setPostalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBranchAndFinancialInstitutionIdentification60 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
     }
-    OBBranchAndFinancialInstitutionIdentification60 obBranchAndFinancialInstitutionIdentification60 = (OBBranchAndFinancialInstitutionIdentification60) o;
-    return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification60.schemeName) &&
-        Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification60.identification) &&
-        Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification60.name) &&
-        Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification60.postalAddress);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, postalAddress);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBranchAndFinancialInstitutionIdentification60 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBBranchAndFinancialInstitutionIdentification60 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of the servicing institution.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of the servicing institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification60 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name by which an agent is known and which is usually used to identify that agent.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification60 postalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+        return this;
+    }
+
+    /**
+     * Get postalAddress
+     *
+     * @return postalAddress
+     */
+    @Valid
+    @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostalAddress")
+    public OBPostalAddress6 getPostalAddress() {
+        return postalAddress;
+    }
+
+    public void setPostalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBranchAndFinancialInstitutionIdentification60 obBranchAndFinancialInstitutionIdentification60 = (OBBranchAndFinancialInstitutionIdentification60) o;
+        return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification60.schemeName) &&
+                Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification60.identification) &&
+                Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification60.name) &&
+                Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification60.postalAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, postalAddress);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBranchAndFinancialInstitutionIdentification60 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
@@ -15,16 +15,25 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.common.OBPostalAddress6;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Financial institution servicing an account for the creditor.
@@ -35,135 +44,139 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBranchAndFinancialInstitutionIdentification61 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private OBPostalAddress6 postalAddress;
+    private OBPostalAddress6 postalAddress;
 
-  public OBBranchAndFinancialInstitutionIdentification61 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification61 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a financial institution or a branch of a financial institution.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a financial institution or a branch of a financial institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification61 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name by which an agent is known and which is usually used to identify that agent.
-   * @return name
-  */
-  @Size(min = 1, max = 140) 
-  @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification61 postalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-    return this;
-  }
-
-  /**
-   * Get postalAddress
-   * @return postalAddress
-  */
-  @Valid 
-  @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PostalAddress")
-  public OBPostalAddress6 getPostalAddress() {
-    return postalAddress;
-  }
-
-  public void setPostalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBranchAndFinancialInstitutionIdentification61 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
     }
-    OBBranchAndFinancialInstitutionIdentification61 obBranchAndFinancialInstitutionIdentification61 = (OBBranchAndFinancialInstitutionIdentification61) o;
-    return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification61.schemeName) &&
-        Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification61.identification) &&
-        Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification61.name) &&
-        Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification61.postalAddress);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, postalAddress);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBranchAndFinancialInstitutionIdentification61 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBBranchAndFinancialInstitutionIdentification61 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a financial institution or a branch of a financial institution.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a financial institution or a branch of a financial institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification61 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name by which an agent is known and which is usually used to identify that agent.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification61 postalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+        return this;
+    }
+
+    /**
+     * Get postalAddress
+     *
+     * @return postalAddress
+     */
+    @Valid
+    @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostalAddress")
+    public OBPostalAddress6 getPostalAddress() {
+        return postalAddress;
+    }
+
+    public void setPostalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBranchAndFinancialInstitutionIdentification61 obBranchAndFinancialInstitutionIdentification61 = (OBBranchAndFinancialInstitutionIdentification61) o;
+        return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification61.schemeName) &&
+                Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification61.identification) &&
+                Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification61.name) &&
+                Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification61.postalAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, postalAddress);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBranchAndFinancialInstitutionIdentification61 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
@@ -15,16 +15,25 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.common.OBPostalAddress6;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Financial institution servicing an account for the debtor.
@@ -35,135 +44,139 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBBranchAndFinancialInstitutionIdentification62 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private OBPostalAddress6 postalAddress;
+    private OBPostalAddress6 postalAddress;
 
-  public OBBranchAndFinancialInstitutionIdentification62 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification62 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a financial institution or a branch of a financial institution.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a financial institution or a branch of a financial institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification62 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name by which an agent is known and which is usually used to identify that agent.
-   * @return name
-  */
-  @Size(min = 1, max = 140) 
-  @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBBranchAndFinancialInstitutionIdentification62 postalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-    return this;
-  }
-
-  /**
-   * Get postalAddress
-   * @return postalAddress
-  */
-  @Valid 
-  @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PostalAddress")
-  public OBPostalAddress6 getPostalAddress() {
-    return postalAddress;
-  }
-
-  public void setPostalAddress(OBPostalAddress6 postalAddress) {
-    this.postalAddress = postalAddress;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBBranchAndFinancialInstitutionIdentification62 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
     }
-    OBBranchAndFinancialInstitutionIdentification62 obBranchAndFinancialInstitutionIdentification62 = (OBBranchAndFinancialInstitutionIdentification62) o;
-    return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification62.schemeName) &&
-        Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification62.identification) &&
-        Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification62.name) &&
-        Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification62.postalAddress);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, postalAddress);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBBranchAndFinancialInstitutionIdentification62 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBBranchAndFinancialInstitutionIdentification62 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a financial institution or a branch of a financial institution.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a financial institution or a branch of a financial institution.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification62 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name by which an agent is known and which is usually used to identify that agent.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "Name", description = "Name by which an agent is known and which is usually used to identify that agent.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBBranchAndFinancialInstitutionIdentification62 postalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+        return this;
+    }
+
+    /**
+     * Get postalAddress
+     *
+     * @return postalAddress
+     */
+    @Valid
+    @Schema(name = "PostalAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostalAddress")
+    public OBPostalAddress6 getPostalAddress() {
+        return postalAddress;
+    }
+
+    public void setPostalAddress(OBPostalAddress6 postalAddress) {
+        this.postalAddress = postalAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBBranchAndFinancialInstitutionIdentification62 obBranchAndFinancialInstitutionIdentification62 = (OBBranchAndFinancialInstitutionIdentification62) o;
+        return Objects.equals(this.schemeName, obBranchAndFinancialInstitutionIdentification62.schemeName) &&
+                Objects.equals(this.identification, obBranchAndFinancialInstitutionIdentification62.identification) &&
+                Objects.equals(this.name, obBranchAndFinancialInstitutionIdentification62.name) &&
+                Objects.equals(this.postalAddress, obBranchAndFinancialInstitutionIdentification62.postalAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, postalAddress);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBBranchAndFinancialInstitutionIdentification62 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    postalAddress: ").append(toIndentedString(postalAddress)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
@@ -34,147 +34,152 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCashAccount50 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private String secondaryIdentification;
+    private String secondaryIdentification;
 
-  public OBCashAccount50() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBCashAccount50(String schemeName, String identification) {
-    this.schemeName = schemeName;
-    this.identification = identification;
-  }
-
-  public OBCashAccount50 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  @NotNull 
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBCashAccount50 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Identification assigned by an institution to identify an account. This identification is known by the account owner.
-   * @return identification
-  */
-  @NotNull @Size(min = 1, max = 256) 
-  @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBCashAccount50 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBCashAccount50 secondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-    return this;
-  }
-
-  /**
-   * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-   * @return secondaryIdentification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryIdentification")
-  public String getSecondaryIdentification() {
-    return secondaryIdentification;
-  }
-
-  public void setSecondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCashAccount50() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBCashAccount50(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
     }
-    OBCashAccount50 obCashAccount50 = (OBCashAccount50) o;
-    return Objects.equals(this.schemeName, obCashAccount50.schemeName) &&
-        Objects.equals(this.identification, obCashAccount50.identification) &&
-        Objects.equals(this.name, obCashAccount50.name) &&
-        Objects.equals(this.secondaryIdentification, obCashAccount50.secondaryIdentification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, secondaryIdentification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCashAccount50 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBCashAccount50 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBCashAccount50 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBCashAccount50 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBCashAccount50 secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCashAccount50 obCashAccount50 = (OBCashAccount50) o;
+        return Objects.equals(this.schemeName, obCashAccount50.schemeName) &&
+                Objects.equals(this.identification, obCashAccount50.identification) &&
+                Objects.equals(this.name, obCashAccount50.name) &&
+                Objects.equals(this.secondaryIdentification, obCashAccount50.secondaryIdentification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCashAccount50 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
@@ -34,147 +34,152 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCashAccount51 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private String secondaryIdentification;
+    private String secondaryIdentification;
 
-  public OBCashAccount51() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBCashAccount51(String schemeName, String identification) {
-    this.schemeName = schemeName;
-    this.identification = identification;
-  }
-
-  public OBCashAccount51 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  @NotNull 
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBCashAccount51 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Beneficiary account identification.
-   * @return identification
-  */
-  @NotNull @Size(min = 1, max = 256) 
-  @Schema(name = "Identification", description = "Beneficiary account identification.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBCashAccount51 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBCashAccount51 secondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-    return this;
-  }
-
-  /**
-   * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-   * @return secondaryIdentification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryIdentification")
-  public String getSecondaryIdentification() {
-    return secondaryIdentification;
-  }
-
-  public void setSecondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCashAccount51() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBCashAccount51(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
     }
-    OBCashAccount51 obCashAccount51 = (OBCashAccount51) o;
-    return Objects.equals(this.schemeName, obCashAccount51.schemeName) &&
-        Objects.equals(this.identification, obCashAccount51.identification) &&
-        Objects.equals(this.name, obCashAccount51.name) &&
-        Objects.equals(this.secondaryIdentification, obCashAccount51.secondaryIdentification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, secondaryIdentification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCashAccount51 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBCashAccount51 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBCashAccount51 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Beneficiary account identification.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Beneficiary account identification.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBCashAccount51 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBCashAccount51 secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCashAccount51 obCashAccount51 = (OBCashAccount51) o;
+        return Objects.equals(this.schemeName, obCashAccount51.schemeName) &&
+                Objects.equals(this.identification, obCashAccount51.identification) &&
+                Objects.equals(this.name, obCashAccount51.name) &&
+                Objects.equals(this.secondaryIdentification, obCashAccount51.secondaryIdentification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCashAccount51 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
@@ -33,135 +33,139 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCashAccount60 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private String secondaryIdentification;
+    private String secondaryIdentification;
 
-  public OBCashAccount60 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBCashAccount60 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Identification assigned by an institution to identify an account. This identification is known by the account owner.
-   * @return identification
-  */
-  @Size(min = 1, max = 256) 
-  @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBCashAccount60 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBCashAccount60 secondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-    return this;
-  }
-
-  /**
-   * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-   * @return secondaryIdentification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryIdentification")
-  public String getSecondaryIdentification() {
-    return secondaryIdentification;
-  }
-
-  public void setSecondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCashAccount60 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
     }
-    OBCashAccount60 obCashAccount60 = (OBCashAccount60) o;
-    return Objects.equals(this.schemeName, obCashAccount60.schemeName) &&
-        Objects.equals(this.identification, obCashAccount60.identification) &&
-        Objects.equals(this.name, obCashAccount60.name) &&
-        Objects.equals(this.secondaryIdentification, obCashAccount60.secondaryIdentification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, secondaryIdentification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCashAccount60 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBCashAccount60 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBCashAccount60 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBCashAccount60 secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCashAccount60 obCashAccount60 = (OBCashAccount60) o;
+        return Objects.equals(this.schemeName, obCashAccount60.schemeName) &&
+                Objects.equals(this.identification, obCashAccount60.identification) &&
+                Objects.equals(this.name, obCashAccount60.name) &&
+                Objects.equals(this.secondaryIdentification, obCashAccount60.secondaryIdentification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCashAccount60 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
@@ -33,135 +33,139 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCashAccount61 {
 
-  private String schemeName;
+    private String schemeName;
 
-  private String identification;
+    private String identification;
 
-  private String name;
+    private String name;
 
-  private String secondaryIdentification;
+    private String secondaryIdentification;
 
-  public OBCashAccount61 schemeName(String schemeName) {
-    this.schemeName = schemeName;
-    return this;
-  }
-
-  /**
-   * Name of the identification scheme, in a coded form as published in an external list.
-   * @return schemeName
-  */
-  
-  @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SchemeName")
-  public String getSchemeName() {
-    return schemeName;
-  }
-
-  public void setSchemeName(String schemeName) {
-    this.schemeName = schemeName;
-  }
-
-  public OBCashAccount61 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Identification assigned by an institution to identify an account. This identification is known by the account owner.
-   * @return identification
-  */
-  @Size(min = 1, max = 256) 
-  @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBCashAccount61 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBCashAccount61 secondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-    return this;
-  }
-
-  /**
-   * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-   * @return secondaryIdentification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryIdentification")
-  public String getSecondaryIdentification() {
-    return secondaryIdentification;
-  }
-
-  public void setSecondaryIdentification(String secondaryIdentification) {
-    this.secondaryIdentification = secondaryIdentification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCashAccount61 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
     }
-    OBCashAccount61 obCashAccount61 = (OBCashAccount61) o;
-    return Objects.equals(this.schemeName, obCashAccount61.schemeName) &&
-        Objects.equals(this.identification, obCashAccount61.identification) &&
-        Objects.equals(this.name, obCashAccount61.name) &&
-        Objects.equals(this.secondaryIdentification, obCashAccount61.secondaryIdentification);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(schemeName, identification, name, secondaryIdentification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCashAccount61 {\n");
-    sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBCashAccount61 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBCashAccount61 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels. Note, the account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBCashAccount61 secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCashAccount61 obCashAccount61 = (OBCashAccount61) o;
+        return Objects.equals(this.schemeName, obCashAccount61.schemeName) &&
+                Objects.equals(this.identification, obCashAccount61.identification) &&
+                Objects.equals(this.name, obCashAccount61.name) &&
+                Objects.equals(this.secondaryIdentification, obCashAccount61.secondaryIdentification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCashAccount61 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode0.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBCreditDebitCode0 {
-  
-  CREDIT("Credit"),
-  
-  DEBIT("Debit");
 
-  private String value;
+    CREDIT("Credit"),
 
-  OBCreditDebitCode0(String value) {
-    this.value = value;
-  }
+    DEBIT("Debit");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBCreditDebitCode0 fromValue(String value) {
-    for (OBCreditDebitCode0 b : OBCreditDebitCode0.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBCreditDebitCode0(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBCreditDebitCode0 fromValue(String value) {
+        for (OBCreditDebitCode0 b : OBCreditDebitCode0.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode1.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBCreditDebitCode1 {
-  
-  CREDIT("Credit"),
-  
-  DEBIT("Debit");
 
-  private String value;
+    CREDIT("Credit"),
 
-  OBCreditDebitCode1(String value) {
-    this.value = value;
-  }
+    DEBIT("Debit");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBCreditDebitCode1 fromValue(String value) {
-    for (OBCreditDebitCode1 b : OBCreditDebitCode1.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBCreditDebitCode1(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBCreditDebitCode1 fromValue(String value) {
+        for (OBCreditDebitCode1 b : OBCreditDebitCode1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditDebitCode2.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBCreditDebitCode2 {
-  
-  CREDIT("Credit"),
-  
-  DEBIT("Debit");
 
-  private String value;
+    CREDIT("Credit"),
 
-  OBCreditDebitCode2(String value) {
-    this.value = value;
-  }
+    DEBIT("Debit");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBCreditDebitCode2 fromValue(String value) {
-    for (OBCreditDebitCode2 b : OBCreditDebitCode2.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBCreditDebitCode2(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBCreditDebitCode2 fromValue(String value) {
+        for (OBCreditDebitCode2 b : OBCreditDebitCode2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
@@ -17,20 +17,29 @@ package uk.org.openbanking.datamodel.account;
 
 import static uk.org.openbanking.datamodel.utils.EqualityVerificationUtil.BigDecimalUtil.isEqual;
 
-import java.math.BigDecimal;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.math.BigDecimal;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBCurrencyExchange5InstructedAmount;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details on the currency exchange.
@@ -40,221 +49,230 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCurrencyExchange5 {
 
-  private String sourceCurrency;
+    private String sourceCurrency;
 
-  private String targetCurrency;
+    private String targetCurrency;
 
-  private String unitCurrency;
+    private String unitCurrency;
 
-  private BigDecimal exchangeRate;
+    private BigDecimal exchangeRate;
 
-  private String contractIdentification;
+    private String contractIdentification;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime quotationDate;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime quotationDate;
 
-  private OBCurrencyExchange5InstructedAmount instructedAmount;
+    private OBCurrencyExchange5InstructedAmount instructedAmount;
 
-  public OBCurrencyExchange5() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBCurrencyExchange5(String sourceCurrency, BigDecimal exchangeRate) {
-    this.sourceCurrency = sourceCurrency;
-    this.exchangeRate = exchangeRate;
-  }
-
-  public OBCurrencyExchange5 sourceCurrency(String sourceCurrency) {
-    this.sourceCurrency = sourceCurrency;
-    return this;
-  }
-
-  /**
-   * Currency from which an amount is to be converted in a currency conversion.
-   * @return sourceCurrency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "SourceCurrency", description = "Currency from which an amount is to be converted in a currency conversion.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("SourceCurrency")
-  public String getSourceCurrency() {
-    return sourceCurrency;
-  }
-
-  public void setSourceCurrency(String sourceCurrency) {
-    this.sourceCurrency = sourceCurrency;
-  }
-
-  public OBCurrencyExchange5 targetCurrency(String targetCurrency) {
-    this.targetCurrency = targetCurrency;
-    return this;
-  }
-
-  /**
-   * Currency into which an amount is to be converted in a currency conversion.
-   * @return targetCurrency
-  */
-  @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "TargetCurrency", description = "Currency into which an amount is to be converted in a currency conversion.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TargetCurrency")
-  public String getTargetCurrency() {
-    return targetCurrency;
-  }
-
-  public void setTargetCurrency(String targetCurrency) {
-    this.targetCurrency = targetCurrency;
-  }
-
-  public OBCurrencyExchange5 unitCurrency(String unitCurrency) {
-    this.unitCurrency = unitCurrency;
-    return this;
-  }
-
-  /**
-   * Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP.
-   * @return unitCurrency
-  */
-  @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "UnitCurrency", description = "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("UnitCurrency")
-  public String getUnitCurrency() {
-    return unitCurrency;
-  }
-
-  public void setUnitCurrency(String unitCurrency) {
-    this.unitCurrency = unitCurrency;
-  }
-
-  public OBCurrencyExchange5 exchangeRate(BigDecimal exchangeRate) {
-    this.exchangeRate = exchangeRate;
-    return this;
-  }
-
-  /**
-   * Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).
-   * @return exchangeRate
-  */
-  @NotNull @Valid 
-  @Schema(name = "ExchangeRate", description = "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ExchangeRate")
-  public BigDecimal getExchangeRate() {
-    return exchangeRate;
-  }
-
-  public void setExchangeRate(BigDecimal exchangeRate) {
-    this.exchangeRate = exchangeRate;
-  }
-
-  public OBCurrencyExchange5 contractIdentification(String contractIdentification) {
-    this.contractIdentification = contractIdentification;
-    return this;
-  }
-
-  /**
-   * Unique identification to unambiguously identify the foreign exchange contract.
-   * @return contractIdentification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "ContractIdentification", description = "Unique identification to unambiguously identify the foreign exchange contract.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ContractIdentification")
-  public String getContractIdentification() {
-    return contractIdentification;
-  }
-
-  public void setContractIdentification(String contractIdentification) {
-    this.contractIdentification = contractIdentification;
-  }
-
-  public OBCurrencyExchange5 quotationDate(DateTime quotationDate) {
-    this.quotationDate = quotationDate;
-    return this;
-  }
-
-  /**
-   * Date and time at which an exchange rate is quoted.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return quotationDate
-  */
-  @Valid 
-  @Schema(name = "QuotationDate", description = "Date and time at which an exchange rate is quoted.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("QuotationDate")
-  public DateTime getQuotationDate() {
-    return quotationDate;
-  }
-
-  public void setQuotationDate(DateTime quotationDate) {
-    this.quotationDate = quotationDate;
-  }
-
-  public OBCurrencyExchange5 instructedAmount(OBCurrencyExchange5InstructedAmount instructedAmount) {
-    this.instructedAmount = instructedAmount;
-    return this;
-  }
-
-  /**
-   * Get instructedAmount
-   * @return instructedAmount
-  */
-  @Valid 
-  @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("InstructedAmount")
-  public OBCurrencyExchange5InstructedAmount getInstructedAmount() {
-    return instructedAmount;
-  }
-
-  public void setInstructedAmount(OBCurrencyExchange5InstructedAmount instructedAmount) {
-    this.instructedAmount = instructedAmount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCurrencyExchange5() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBCurrencyExchange5(String sourceCurrency, BigDecimal exchangeRate) {
+        this.sourceCurrency = sourceCurrency;
+        this.exchangeRate = exchangeRate;
     }
-    OBCurrencyExchange5 obCurrencyExchange5 = (OBCurrencyExchange5) o;
-    return Objects.equals(this.sourceCurrency, obCurrencyExchange5.sourceCurrency) &&
-        Objects.equals(this.targetCurrency, obCurrencyExchange5.targetCurrency) &&
-        Objects.equals(this.unitCurrency, obCurrencyExchange5.unitCurrency) &&
-        // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
-        isEqual(this.exchangeRate, obCurrencyExchange5.exchangeRate) &&
-        Objects.equals(this.contractIdentification, obCurrencyExchange5.contractIdentification) &&
-        Objects.equals(this.quotationDate, obCurrencyExchange5.quotationDate) &&
-        Objects.equals(this.instructedAmount, obCurrencyExchange5.instructedAmount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(sourceCurrency, targetCurrency, unitCurrency, exchangeRate, contractIdentification, quotationDate, instructedAmount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCurrencyExchange5 {\n");
-    sb.append("    sourceCurrency: ").append(toIndentedString(sourceCurrency)).append("\n");
-    sb.append("    targetCurrency: ").append(toIndentedString(targetCurrency)).append("\n");
-    sb.append("    unitCurrency: ").append(toIndentedString(unitCurrency)).append("\n");
-    sb.append("    exchangeRate: ").append(toIndentedString(exchangeRate)).append("\n");
-    sb.append("    contractIdentification: ").append(toIndentedString(contractIdentification)).append("\n");
-    sb.append("    quotationDate: ").append(toIndentedString(quotationDate)).append("\n");
-    sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBCurrencyExchange5 sourceCurrency(String sourceCurrency) {
+        this.sourceCurrency = sourceCurrency;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Currency from which an amount is to be converted in a currency conversion.
+     *
+     * @return sourceCurrency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "SourceCurrency", description = "Currency from which an amount is to be converted in a currency conversion.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SourceCurrency")
+    public String getSourceCurrency() {
+        return sourceCurrency;
+    }
+
+    public void setSourceCurrency(String sourceCurrency) {
+        this.sourceCurrency = sourceCurrency;
+    }
+
+    public OBCurrencyExchange5 targetCurrency(String targetCurrency) {
+        this.targetCurrency = targetCurrency;
+        return this;
+    }
+
+    /**
+     * Currency into which an amount is to be converted in a currency conversion.
+     *
+     * @return targetCurrency
+     */
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "TargetCurrency", description = "Currency into which an amount is to be converted in a currency conversion.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TargetCurrency")
+    public String getTargetCurrency() {
+        return targetCurrency;
+    }
+
+    public void setTargetCurrency(String targetCurrency) {
+        this.targetCurrency = targetCurrency;
+    }
+
+    public OBCurrencyExchange5 unitCurrency(String unitCurrency) {
+        this.unitCurrency = unitCurrency;
+        return this;
+    }
+
+    /**
+     * Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP.
+     *
+     * @return unitCurrency
+     */
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "UnitCurrency", description = "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("UnitCurrency")
+    public String getUnitCurrency() {
+        return unitCurrency;
+    }
+
+    public void setUnitCurrency(String unitCurrency) {
+        this.unitCurrency = unitCurrency;
+    }
+
+    public OBCurrencyExchange5 exchangeRate(BigDecimal exchangeRate) {
+        this.exchangeRate = exchangeRate;
+        return this;
+    }
+
+    /**
+     * Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).
+     *
+     * @return exchangeRate
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ExchangeRate", description = "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency. Usage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency).", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ExchangeRate")
+    public BigDecimal getExchangeRate() {
+        return exchangeRate;
+    }
+
+    public void setExchangeRate(BigDecimal exchangeRate) {
+        this.exchangeRate = exchangeRate;
+    }
+
+    public OBCurrencyExchange5 contractIdentification(String contractIdentification) {
+        this.contractIdentification = contractIdentification;
+        return this;
+    }
+
+    /**
+     * Unique identification to unambiguously identify the foreign exchange contract.
+     *
+     * @return contractIdentification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "ContractIdentification", description = "Unique identification to unambiguously identify the foreign exchange contract.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ContractIdentification")
+    public String getContractIdentification() {
+        return contractIdentification;
+    }
+
+    public void setContractIdentification(String contractIdentification) {
+        this.contractIdentification = contractIdentification;
+    }
+
+    public OBCurrencyExchange5 quotationDate(DateTime quotationDate) {
+        this.quotationDate = quotationDate;
+        return this;
+    }
+
+    /**
+     * Date and time at which an exchange rate is quoted.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return quotationDate
+     */
+    @Valid
+    @Schema(name = "QuotationDate", description = "Date and time at which an exchange rate is quoted.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("QuotationDate")
+    public DateTime getQuotationDate() {
+        return quotationDate;
+    }
+
+    public void setQuotationDate(DateTime quotationDate) {
+        this.quotationDate = quotationDate;
+    }
+
+    public OBCurrencyExchange5 instructedAmount(OBCurrencyExchange5InstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBCurrencyExchange5InstructedAmount getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBCurrencyExchange5InstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCurrencyExchange5 obCurrencyExchange5 = (OBCurrencyExchange5) o;
+        return Objects.equals(this.sourceCurrency, obCurrencyExchange5.sourceCurrency) &&
+                Objects.equals(this.targetCurrency, obCurrencyExchange5.targetCurrency) &&
+                Objects.equals(this.unitCurrency, obCurrencyExchange5.unitCurrency) &&
+                // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
+                isEqual(this.exchangeRate, obCurrencyExchange5.exchangeRate) &&
+                Objects.equals(this.contractIdentification, obCurrencyExchange5.contractIdentification) &&
+                Objects.equals(this.quotationDate, obCurrencyExchange5.quotationDate) &&
+                Objects.equals(this.instructedAmount, obCurrencyExchange5.instructedAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceCurrency, targetCurrency, unitCurrency, exchangeRate, contractIdentification, quotationDate, instructedAmount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCurrencyExchange5 {\n");
+        sb.append("    sourceCurrency: ").append(toIndentedString(sourceCurrency)).append("\n");
+        sb.append("    targetCurrency: ").append(toIndentedString(targetCurrency)).append("\n");
+        sb.append("    unitCurrency: ").append(toIndentedString(unitCurrency)).append("\n");
+        sb.append("    exchangeRate: ").append(toIndentedString(exchangeRate)).append("\n");
+        sb.append("    contractIdentification: ").append(toIndentedString(contractIdentification)).append("\n");
+        sb.append("    quotationDate: ").append(toIndentedString(quotationDate)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCurrencyExchange5InstructedAmount {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBCurrencyExchange5InstructedAmount() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBCurrencyExchange5InstructedAmount(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBCurrencyExchange5InstructedAmount amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBCurrencyExchange5InstructedAmount currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBCurrencyExchange5InstructedAmount() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBCurrencyExchange5InstructedAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBCurrencyExchange5InstructedAmount obCurrencyExchange5InstructedAmount = (OBCurrencyExchange5InstructedAmount) o;
-    return Objects.equals(this.amount, obCurrencyExchange5InstructedAmount.amount) &&
-        Objects.equals(this.currency, obCurrencyExchange5InstructedAmount.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBCurrencyExchange5InstructedAmount {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBCurrencyExchange5InstructedAmount amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBCurrencyExchange5InstructedAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCurrencyExchange5InstructedAmount obCurrencyExchange5InstructedAmount = (OBCurrencyExchange5InstructedAmount) o;
+        return Objects.equals(this.amount, obCurrencyExchange5InstructedAmount.amount) &&
+                Objects.equals(this.currency, obCurrencyExchange5InstructedAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCurrencyExchange5InstructedAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEntryStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEntryStatus1Code.java
@@ -26,37 +26,37 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBEntryStatus1Code {
-  
-  BOOKED("Booked"),
-  
-  PENDING("Pending"),
-  
-  REJECTED("Rejected");
 
-  private String value;
+    BOOKED("Booked"),
 
-  OBEntryStatus1Code(String value) {
-    this.value = value;
-  }
+    PENDING("Pending"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    REJECTED("Rejected");
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    private String value;
 
-  @JsonCreator
-  public static OBEntryStatus1Code fromValue(String value) {
-    for (OBEntryStatus1Code b : OBEntryStatus1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBEntryStatus1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBEntryStatus1Code fromValue(String value) {
+        for (OBEntryStatus1Code b : OBEntryStatus1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountSubType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountSubType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the sub type of account (product family group).
@@ -26,47 +40,47 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalAccountSubType1Code {
-  
-  CHARGECARD("ChargeCard"),
-  
-  CREDITCARD("CreditCard"),
-  
-  CURRENTACCOUNT("CurrentAccount"),
-  
-  EMONEY("EMoney"),
-  
-  LOAN("Loan"),
-  
-  MORTGAGE("Mortgage"),
-  
-  PREPAIDCARD("PrePaidCard"),
-  
-  SAVINGS("Savings");
 
-  private String value;
+    CHARGECARD("ChargeCard"),
 
-  OBExternalAccountSubType1Code(String value) {
-    this.value = value;
-  }
+    CREDITCARD("CreditCard"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    CURRENTACCOUNT("CurrentAccount"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    EMONEY("EMoney"),
 
-  @JsonCreator
-  public static OBExternalAccountSubType1Code fromValue(String value) {
-    for (OBExternalAccountSubType1Code b : OBExternalAccountSubType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    LOAN("Loan"),
+
+    MORTGAGE("Mortgage"),
+
+    PREPAIDCARD("PrePaidCard"),
+
+    SAVINGS("Savings");
+
+    private String value;
+
+    OBExternalAccountSubType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalAccountSubType1Code fromValue(String value) {
+        for (OBExternalAccountSubType1Code b : OBExternalAccountSubType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the type of account (personal or business).
@@ -26,35 +40,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalAccountType1Code {
-  
-  BUSINESS("Business"),
-  
-  PERSONAL("Personal");
 
-  private String value;
+    BUSINESS("Business"),
 
-  OBExternalAccountType1Code(String value) {
-    this.value = value;
-  }
+    PERSONAL("Personal");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBExternalAccountType1Code fromValue(String value) {
-    for (OBExternalAccountType1Code b : OBExternalAccountType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBExternalAccountType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalAccountType1Code fromValue(String value) {
+        for (OBExternalAccountType1Code b : OBExternalAccountType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalDirectDebitStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalDirectDebitStatus1Code.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalDirectDebitStatus1Code {
-  
-  ACTIVE("Active"),
-  
-  INACTIVE("Inactive");
 
-  private String value;
+    ACTIVE("Active"),
 
-  OBExternalDirectDebitStatus1Code(String value) {
-    this.value = value;
-  }
+    INACTIVE("Inactive");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBExternalDirectDebitStatus1Code fromValue(String value) {
-    for (OBExternalDirectDebitStatus1Code b : OBExternalDirectDebitStatus1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBExternalDirectDebitStatus1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalDirectDebitStatus1Code fromValue(String value) {
+        for (OBExternalDirectDebitStatus1Code b : OBExternalDirectDebitStatus1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPartyType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalPartyType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Party type, in a coded form.
@@ -26,37 +40,37 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalPartyType1Code {
-  
-  DELEGATE("Delegate"),
-  
-  JOINT("Joint"),
-  
-  SOLE("Sole");
 
-  private String value;
+    DELEGATE("Delegate"),
 
-  OBExternalPartyType1Code(String value) {
-    this.value = value;
-  }
+    JOINT("Joint"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    SOLE("Sole");
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    private String value;
 
-  @JsonCreator
-  public static OBExternalPartyType1Code fromValue(String value) {
-    for (OBExternalPartyType1Code b : OBExternalPartyType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBExternalPartyType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalPartyType1Code fromValue(String value) {
+        for (OBExternalPartyType1Code b : OBExternalPartyType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalScheduleType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalScheduleType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the scheduled payment date type requested
@@ -26,35 +40,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalScheduleType1Code {
-  
-  ARRIVAL("Arrival"),
-  
-  EXECUTION("Execution");
 
-  private String value;
+    ARRIVAL("Arrival"),
 
-  OBExternalScheduleType1Code(String value) {
-    this.value = value;
-  }
+    EXECUTION("Execution");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBExternalScheduleType1Code fromValue(String value) {
-    for (OBExternalScheduleType1Code b : OBExternalScheduleType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBExternalScheduleType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalScheduleType1Code fromValue(String value) {
+        for (OBExternalScheduleType1Code b : OBExternalScheduleType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStandingOrderStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStandingOrderStatus1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the status of the standing order in code form.
@@ -26,35 +40,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalStandingOrderStatus1Code {
-  
-  ACTIVE("Active"),
-  
-  INACTIVE("Inactive");
 
-  private String value;
+    ACTIVE("Active"),
 
-  OBExternalStandingOrderStatus1Code(String value) {
-    this.value = value;
-  }
+    INACTIVE("Inactive");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBExternalStandingOrderStatus1Code fromValue(String value) {
-    for (OBExternalStandingOrderStatus1Code b : OBExternalStandingOrderStatus1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBExternalStandingOrderStatus1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalStandingOrderStatus1Code fromValue(String value) {
+        for (OBExternalStandingOrderStatus1Code b : OBExternalStandingOrderStatus1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBExternalStatementType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Statement type, in a coded form.
@@ -26,41 +40,41 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBExternalStatementType1Code {
-  
-  ACCOUNTCLOSURE("AccountClosure"),
-  
-  ACCOUNTOPENING("AccountOpening"),
-  
-  ANNUAL("Annual"),
-  
-  INTERIM("Interim"),
-  
-  REGULARPERIODIC("RegularPeriodic");
 
-  private String value;
+    ACCOUNTCLOSURE("AccountClosure"),
 
-  OBExternalStatementType1Code(String value) {
-    this.value = value;
-  }
+    ACCOUNTOPENING("AccountOpening"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    ANNUAL("Annual"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    INTERIM("Interim"),
 
-  @JsonCreator
-  public static OBExternalStatementType1Code fromValue(String value) {
-    for (OBExternalStatementType1Code b : OBExternalStatementType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    REGULARPERIODIC("RegularPeriodic");
+
+    private String value;
+
+    OBExternalStatementType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalStatementType1Code fromValue(String value) {
+        for (OBExternalStatementType1Code b : OBExternalStatementType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeCategory1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeCategory1Code.java
@@ -26,37 +26,37 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeCategory1Code {
-  
-  FCOT("FCOT"),
-  
-  FCRE("FCRE"),
-  
-  FCSV("FCSV");
 
-  private String value;
+    FCOT("FCOT"),
 
-  OBFeeCategory1Code(String value) {
-    this.value = value;
-  }
+    FCRE("FCRE"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FCSV("FCSV");
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    private String value;
 
-  @JsonCreator
-  public static OBFeeCategory1Code fromValue(String value) {
-    for (OBFeeCategory1Code b : OBFeeCategory1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBFeeCategory1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeCategory1Code fromValue(String value) {
+        for (OBFeeCategory1Code b : OBFeeCategory1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code0.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Frequency at which the overdraft charge is applied to the account
@@ -26,73 +40,73 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeFrequency1Code0 {
-  
-  FEAC("FEAC"),
-  
-  FEAO("FEAO"),
-  
-  FECP("FECP"),
-  
-  FEDA("FEDA"),
-  
-  FEHO("FEHO"),
-  
-  FEI("FEI"),
-  
-  FEMO("FEMO"),
-  
-  FEOA("FEOA"),
-  
-  FEOT("FEOT"),
-  
-  FEPC("FEPC"),
-  
-  FEPH("FEPH"),
-  
-  FEPO("FEPO"),
-  
-  FEPS("FEPS"),
-  
-  FEPT("FEPT"),
-  
-  FEPTA("FEPTA"),
-  
-  FEPTP("FEPTP"),
-  
-  FEQU("FEQU"),
-  
-  FESM("FESM"),
-  
-  FEST("FEST"),
-  
-  FEWE("FEWE"),
-  
-  FEYE("FEYE");
 
-  private String value;
+    FEAC("FEAC"),
 
-  OBFeeFrequency1Code0(String value) {
-    this.value = value;
-  }
+    FEAO("FEAO"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FECP("FECP"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FEDA("FEDA"),
 
-  @JsonCreator
-  public static OBFeeFrequency1Code0 fromValue(String value) {
-    for (OBFeeFrequency1Code0 b : OBFeeFrequency1Code0.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FEHO("FEHO"),
+
+    FEI("FEI"),
+
+    FEMO("FEMO"),
+
+    FEOA("FEOA"),
+
+    FEOT("FEOT"),
+
+    FEPC("FEPC"),
+
+    FEPH("FEPH"),
+
+    FEPO("FEPO"),
+
+    FEPS("FEPS"),
+
+    FEPT("FEPT"),
+
+    FEPTA("FEPTA"),
+
+    FEPTP("FEPTP"),
+
+    FEQU("FEQU"),
+
+    FESM("FESM"),
+
+    FEST("FEST"),
+
+    FEWE("FEWE"),
+
+    FEYE("FEYE");
+
+    private String value;
+
+    OBFeeFrequency1Code0(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeFrequency1Code0 fromValue(String value) {
+        for (OBFeeFrequency1Code0 b : OBFeeFrequency1Code0.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code1.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * How often is the overdraft fee/charge calculated for the account.
@@ -26,73 +40,73 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeFrequency1Code1 {
-  
-  FEAC("FEAC"),
-  
-  FEAO("FEAO"),
-  
-  FECP("FECP"),
-  
-  FEDA("FEDA"),
-  
-  FEHO("FEHO"),
-  
-  FEI("FEI"),
-  
-  FEMO("FEMO"),
-  
-  FEOA("FEOA"),
-  
-  FEOT("FEOT"),
-  
-  FEPC("FEPC"),
-  
-  FEPH("FEPH"),
-  
-  FEPO("FEPO"),
-  
-  FEPS("FEPS"),
-  
-  FEPT("FEPT"),
-  
-  FEPTA("FEPTA"),
-  
-  FEPTP("FEPTP"),
-  
-  FEQU("FEQU"),
-  
-  FESM("FESM"),
-  
-  FEST("FEST"),
-  
-  FEWE("FEWE"),
-  
-  FEYE("FEYE");
 
-  private String value;
+    FEAC("FEAC"),
 
-  OBFeeFrequency1Code1(String value) {
-    this.value = value;
-  }
+    FEAO("FEAO"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FECP("FECP"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FEDA("FEDA"),
 
-  @JsonCreator
-  public static OBFeeFrequency1Code1 fromValue(String value) {
-    for (OBFeeFrequency1Code1 b : OBFeeFrequency1Code1.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FEHO("FEHO"),
+
+    FEI("FEI"),
+
+    FEMO("FEMO"),
+
+    FEOA("FEOA"),
+
+    FEOT("FEOT"),
+
+    FEPC("FEPC"),
+
+    FEPH("FEPH"),
+
+    FEPO("FEPO"),
+
+    FEPS("FEPS"),
+
+    FEPT("FEPT"),
+
+    FEPTA("FEPTA"),
+
+    FEPTP("FEPTP"),
+
+    FEQU("FEQU"),
+
+    FESM("FESM"),
+
+    FEST("FEST"),
+
+    FEWE("FEWE"),
+
+    FEYE("FEYE");
+
+    private String value;
+
+    OBFeeFrequency1Code1(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeFrequency1Code1 fromValue(String value) {
+        for (OBFeeFrequency1Code1 b : OBFeeFrequency1Code1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code2.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * How frequently the fee/charge is applied to the account
@@ -26,73 +40,73 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeFrequency1Code2 {
-  
-  FEAC("FEAC"),
-  
-  FEAO("FEAO"),
-  
-  FECP("FECP"),
-  
-  FEDA("FEDA"),
-  
-  FEHO("FEHO"),
-  
-  FEI("FEI"),
-  
-  FEMO("FEMO"),
-  
-  FEOA("FEOA"),
-  
-  FEOT("FEOT"),
-  
-  FEPC("FEPC"),
-  
-  FEPH("FEPH"),
-  
-  FEPO("FEPO"),
-  
-  FEPS("FEPS"),
-  
-  FEPT("FEPT"),
-  
-  FEPTA("FEPTA"),
-  
-  FEPTP("FEPTP"),
-  
-  FEQU("FEQU"),
-  
-  FESM("FESM"),
-  
-  FEST("FEST"),
-  
-  FEWE("FEWE"),
-  
-  FEYE("FEYE");
 
-  private String value;
+    FEAC("FEAC"),
 
-  OBFeeFrequency1Code2(String value) {
-    this.value = value;
-  }
+    FEAO("FEAO"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FECP("FECP"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FEDA("FEDA"),
 
-  @JsonCreator
-  public static OBFeeFrequency1Code2 fromValue(String value) {
-    for (OBFeeFrequency1Code2 b : OBFeeFrequency1Code2.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FEHO("FEHO"),
+
+    FEI("FEI"),
+
+    FEMO("FEMO"),
+
+    FEOA("FEOA"),
+
+    FEOT("FEOT"),
+
+    FEPC("FEPC"),
+
+    FEPH("FEPH"),
+
+    FEPO("FEPO"),
+
+    FEPS("FEPS"),
+
+    FEPT("FEPT"),
+
+    FEPTA("FEPTA"),
+
+    FEPTP("FEPTP"),
+
+    FEQU("FEQU"),
+
+    FESM("FESM"),
+
+    FEST("FEST"),
+
+    FEWE("FEWE"),
+
+    FEYE("FEYE");
+
+    private String value;
+
+    OBFeeFrequency1Code2(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeFrequency1Code2 fromValue(String value) {
+        for (OBFeeFrequency1Code2 b : OBFeeFrequency1Code2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code3.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * How frequently the fee/charge is calculated
@@ -26,73 +40,73 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeFrequency1Code3 {
-  
-  FEAC("FEAC"),
-  
-  FEAO("FEAO"),
-  
-  FECP("FECP"),
-  
-  FEDA("FEDA"),
-  
-  FEHO("FEHO"),
-  
-  FEI("FEI"),
-  
-  FEMO("FEMO"),
-  
-  FEOA("FEOA"),
-  
-  FEOT("FEOT"),
-  
-  FEPC("FEPC"),
-  
-  FEPH("FEPH"),
-  
-  FEPO("FEPO"),
-  
-  FEPS("FEPS"),
-  
-  FEPT("FEPT"),
-  
-  FEPTA("FEPTA"),
-  
-  FEPTP("FEPTP"),
-  
-  FEQU("FEQU"),
-  
-  FESM("FESM"),
-  
-  FEST("FEST"),
-  
-  FEWE("FEWE"),
-  
-  FEYE("FEYE");
 
-  private String value;
+    FEAC("FEAC"),
 
-  OBFeeFrequency1Code3(String value) {
-    this.value = value;
-  }
+    FEAO("FEAO"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FECP("FECP"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FEDA("FEDA"),
 
-  @JsonCreator
-  public static OBFeeFrequency1Code3 fromValue(String value) {
-    for (OBFeeFrequency1Code3 b : OBFeeFrequency1Code3.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FEHO("FEHO"),
+
+    FEI("FEI"),
+
+    FEMO("FEMO"),
+
+    FEOA("FEOA"),
+
+    FEOT("FEOT"),
+
+    FEPC("FEPC"),
+
+    FEPH("FEPH"),
+
+    FEPO("FEPO"),
+
+    FEPS("FEPS"),
+
+    FEPT("FEPT"),
+
+    FEPTA("FEPTA"),
+
+    FEPTP("FEPTP"),
+
+    FEQU("FEQU"),
+
+    FESM("FESM"),
+
+    FEST("FEST"),
+
+    FEWE("FEWE"),
+
+    FEYE("FEYE");
+
+    private String value;
+
+    OBFeeFrequency1Code3(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeFrequency1Code3 fromValue(String value) {
+        for (OBFeeFrequency1Code3 b : OBFeeFrequency1Code3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeFrequency1Code4.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Period e.g. day, week, month etc. for which the fee/charge is capped
@@ -26,73 +40,73 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeFrequency1Code4 {
-  
-  FEAC("FEAC"),
-  
-  FEAO("FEAO"),
-  
-  FECP("FECP"),
-  
-  FEDA("FEDA"),
-  
-  FEHO("FEHO"),
-  
-  FEI("FEI"),
-  
-  FEMO("FEMO"),
-  
-  FEOA("FEOA"),
-  
-  FEOT("FEOT"),
-  
-  FEPC("FEPC"),
-  
-  FEPH("FEPH"),
-  
-  FEPO("FEPO"),
-  
-  FEPS("FEPS"),
-  
-  FEPT("FEPT"),
-  
-  FEPTA("FEPTA"),
-  
-  FEPTP("FEPTP"),
-  
-  FEQU("FEQU"),
-  
-  FESM("FESM"),
-  
-  FEST("FEST"),
-  
-  FEWE("FEWE"),
-  
-  FEYE("FEYE");
 
-  private String value;
+    FEAC("FEAC"),
 
-  OBFeeFrequency1Code4(String value) {
-    this.value = value;
-  }
+    FEAO("FEAO"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FECP("FECP"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FEDA("FEDA"),
 
-  @JsonCreator
-  public static OBFeeFrequency1Code4 fromValue(String value) {
-    for (OBFeeFrequency1Code4 b : OBFeeFrequency1Code4.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FEHO("FEHO"),
+
+    FEI("FEI"),
+
+    FEMO("FEMO"),
+
+    FEOA("FEOA"),
+
+    FEOT("FEOT"),
+
+    FEPC("FEPC"),
+
+    FEPH("FEPH"),
+
+    FEPO("FEPO"),
+
+    FEPS("FEPS"),
+
+    FEPT("FEPT"),
+
+    FEPTA("FEPTA"),
+
+    FEPTP("FEPTP"),
+
+    FEQU("FEQU"),
+
+    FESM("FESM"),
+
+    FEST("FEST"),
+
+    FEWE("FEWE"),
+
+    FEYE("FEYE");
+
+    private String value;
+
+    OBFeeFrequency1Code4(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeFrequency1Code4 fromValue(String value) {
+        for (OBFeeFrequency1Code4 b : OBFeeFrequency1Code4.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeType1Code.java
@@ -26,49 +26,49 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBFeeType1Code {
-  
-  FEPF("FEPF"),
-  
-  FTOT("FTOT"),
-  
-  FYAF("FYAF"),
-  
-  FYAM("FYAM"),
-  
-  FYAQ("FYAQ"),
-  
-  FYCP("FYCP"),
-  
-  FYDB("FYDB"),
-  
-  FYMI("FYMI"),
-  
-  FYXX("FYXX");
 
-  private String value;
+    FEPF("FEPF"),
 
-  OBFeeType1Code(String value) {
-    this.value = value;
-  }
+    FTOT("FTOT"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FYAF("FYAF"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FYAM("FYAM"),
 
-  @JsonCreator
-  public static OBFeeType1Code fromValue(String value) {
-    for (OBFeeType1Code b : OBFeeType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FYAQ("FYAQ"),
+
+    FYCP("FYCP"),
+
+    FYDB("FYDB"),
+
+    FYMI("FYMI"),
+
+    FYXX("FYXX");
+
+    private String value;
+
+    OBFeeType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFeeType1Code fromValue(String value) {
+        for (OBFeeType1Code b : OBFeeType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestCalculationMethod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestCalculationMethod1Code.java
@@ -26,37 +26,37 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBInterestCalculationMethod1Code {
-  
-  ITCO("ITCO"),
-  
-  ITOT("ITOT"),
-  
-  ITSI("ITSI");
 
-  private String value;
+    ITCO("ITCO"),
 
-  OBInterestCalculationMethod1Code(String value) {
-    this.value = value;
-  }
+    ITOT("ITOT"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    ITSI("ITSI");
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    private String value;
 
-  @JsonCreator
-  public static OBInterestCalculationMethod1Code fromValue(String value) {
-    for (OBInterestCalculationMethod1Code b : OBInterestCalculationMethod1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBInterestCalculationMethod1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBInterestCalculationMethod1Code fromValue(String value) {
+        for (OBInterestCalculationMethod1Code b : OBInterestCalculationMethod1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestFixedVariableType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestFixedVariableType1Code.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBInterestFixedVariableType1Code {
-  
-  INFI("INFI"),
-  
-  INVA("INVA");
 
-  private String value;
+    INFI("INFI"),
 
-  OBInterestFixedVariableType1Code(String value) {
-    this.value = value;
-  }
+    INVA("INVA");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBInterestFixedVariableType1Code fromValue(String value) {
-    for (OBInterestFixedVariableType1Code b : OBInterestFixedVariableType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBInterestFixedVariableType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBInterestFixedVariableType1Code fromValue(String value) {
+        for (OBInterestFixedVariableType1Code b : OBInterestFixedVariableType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code0.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
@@ -26,43 +40,43 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBInterestRateType1Code0 {
-  
-  INBB("INBB"),
-  
-  INFR("INFR"),
-  
-  INGR("INGR"),
-  
-  INLR("INLR"),
-  
-  INNE("INNE"),
-  
-  INOT("INOT");
 
-  private String value;
+    INBB("INBB"),
 
-  OBInterestRateType1Code0(String value) {
-    this.value = value;
-  }
+    INFR("INFR"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    INGR("INGR"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    INLR("INLR"),
 
-  @JsonCreator
-  public static OBInterestRateType1Code0 fromValue(String value) {
-    for (OBInterestRateType1Code0 b : OBInterestRateType1Code0.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    INNE("INNE"),
+
+    INOT("INOT");
+
+    private String value;
+
+    OBInterestRateType1Code0(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBInterestRateType1Code0 fromValue(String value) {
+        for (OBInterestRateType1Code0 b : OBInterestRateType1Code0.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBInterestRateType1Code1.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)
@@ -26,43 +40,43 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBInterestRateType1Code1 {
-  
-  INBB("INBB"),
-  
-  INFR("INFR"),
-  
-  INGR("INGR"),
-  
-  INLR("INLR"),
-  
-  INNE("INNE"),
-  
-  INOT("INOT");
 
-  private String value;
+    INBB("INBB"),
 
-  OBInterestRateType1Code1(String value) {
-    this.value = value;
-  }
+    INFR("INFR"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    INGR("INGR"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    INLR("INLR"),
 
-  @JsonCreator
-  public static OBInterestRateType1Code1 fromValue(String value) {
-    for (OBInterestRateType1Code1 b : OBInterestRateType1Code1.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    INNE("INNE"),
+
+    INOT("INOT");
+
+    private String value;
+
+    OBInterestRateType1Code1(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBInterestRateType1Code1 fromValue(String value) {
+        for (OBInterestRateType1Code1 b : OBInterestRateType1Code1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
@@ -31,87 +31,89 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBMerchantDetails1 {
 
-  private String merchantName;
+    private String merchantName;
 
-  private String merchantCategoryCode;
+    private String merchantCategoryCode;
 
-  public OBMerchantDetails1 merchantName(String merchantName) {
-    this.merchantName = merchantName;
-    return this;
-  }
-
-  /**
-   * Name by which the merchant is known.
-   * @return merchantName
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "MerchantName", description = "Name by which the merchant is known.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MerchantName")
-  public String getMerchantName() {
-    return merchantName;
-  }
-
-  public void setMerchantName(String merchantName) {
-    this.merchantName = merchantName;
-  }
-
-  public OBMerchantDetails1 merchantCategoryCode(String merchantCategoryCode) {
-    this.merchantCategoryCode = merchantCategoryCode;
-    return this;
-  }
-
-  /**
-   * Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.
-   * @return merchantCategoryCode
-  */
-  @Size(min = 3, max = 4) 
-  @Schema(name = "MerchantCategoryCode", description = "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MerchantCategoryCode")
-  public String getMerchantCategoryCode() {
-    return merchantCategoryCode;
-  }
-
-  public void setMerchantCategoryCode(String merchantCategoryCode) {
-    this.merchantCategoryCode = merchantCategoryCode;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBMerchantDetails1 merchantName(String merchantName) {
+        this.merchantName = merchantName;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Name by which the merchant is known.
+     *
+     * @return merchantName
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "MerchantName", description = "Name by which the merchant is known.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantName")
+    public String getMerchantName() {
+        return merchantName;
     }
-    OBMerchantDetails1 obMerchantDetails1 = (OBMerchantDetails1) o;
-    return Objects.equals(this.merchantName, obMerchantDetails1.merchantName) &&
-        Objects.equals(this.merchantCategoryCode, obMerchantDetails1.merchantCategoryCode);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(merchantName, merchantCategoryCode);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBMerchantDetails1 {\n");
-    sb.append("    merchantName: ").append(toIndentedString(merchantName)).append("\n");
-    sb.append("    merchantCategoryCode: ").append(toIndentedString(merchantCategoryCode)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setMerchantName(String merchantName) {
+        this.merchantName = merchantName;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBMerchantDetails1 merchantCategoryCode(String merchantCategoryCode) {
+        this.merchantCategoryCode = merchantCategoryCode;
+        return this;
+    }
+
+    /**
+     * Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.
+     *
+     * @return merchantCategoryCode
+     */
+    @Size(min = 3, max = 4)
+    @Schema(name = "MerchantCategoryCode", description = "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantCategoryCode")
+    public String getMerchantCategoryCode() {
+        return merchantCategoryCode;
+    }
+
+    public void setMerchantCategoryCode(String merchantCategoryCode) {
+        this.merchantCategoryCode = merchantCategoryCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBMerchantDetails1 obMerchantDetails1 = (OBMerchantDetails1) o;
+        return Objects.equals(this.merchantName, obMerchantDetails1.merchantName) &&
+                Objects.equals(this.merchantCategoryCode, obMerchantDetails1.merchantCategoryCode);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(merchantName, merchantCategoryCode);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBMerchantDetails1 {\n");
+        sb.append("    merchantName: ").append(toIndentedString(merchantName)).append("\n");
+        sb.append("    merchantCategoryCode: ").append(toIndentedString(merchantCategoryCode)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMinMaxType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMinMaxType1Code.java
@@ -26,35 +26,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBMinMaxType1Code {
-  
-  FMMN("FMMN"),
-  
-  FMMX("FMMX");
 
-  private String value;
+    FMMN("FMMN"),
 
-  OBMinMaxType1Code(String value) {
-    this.value = value;
-  }
+    FMMX("FMMX");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBMinMaxType1Code fromValue(String value) {
-    for (OBMinMaxType1Code b : OBMinMaxType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBMinMaxType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBMinMaxType1Code fromValue(String value) {
+        for (OBMinMaxType1Code b : OBMinMaxType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
@@ -34,123 +34,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType10 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType10() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType10(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType10 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType10 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType10 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType10() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType10(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType10 obOtherCodeType10 = (OBOtherCodeType10) o;
-    return Objects.equals(this.code, obOtherCodeType10.code) &&
-        Objects.equals(this.name, obOtherCodeType10.name) &&
-        Objects.equals(this.description, obOtherCodeType10.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType10 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType10 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType10 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType10 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType10 obOtherCodeType10 = (OBOtherCodeType10) o;
+        return Objects.equals(this.code, obOtherCodeType10.code) &&
+                Objects.equals(this.name, obOtherCodeType10.name) &&
+                Objects.equals(this.description, obOtherCodeType10.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType10 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType11 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType11() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType11(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType11 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType11 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType11 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType11() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType11(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType11 obOtherCodeType11 = (OBOtherCodeType11) o;
-    return Objects.equals(this.code, obOtherCodeType11.code) &&
-        Objects.equals(this.name, obOtherCodeType11.name) &&
-        Objects.equals(this.description, obOtherCodeType11.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType11 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType11 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType11 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType11 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType11 obOtherCodeType11 = (OBOtherCodeType11) o;
+        return Objects.equals(this.code, obOtherCodeType11.code) &&
+                Objects.equals(this.name, obOtherCodeType11.name) &&
+                Objects.equals(this.description, obOtherCodeType11.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType11 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType12 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType12() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType12(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType12 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType12 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType12 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType12() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType12(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType12 obOtherCodeType12 = (OBOtherCodeType12) o;
-    return Objects.equals(this.code, obOtherCodeType12.code) &&
-        Objects.equals(this.name, obOtherCodeType12.name) &&
-        Objects.equals(this.description, obOtherCodeType12.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType12 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType12 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType12 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType12 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType12 obOtherCodeType12 = (OBOtherCodeType12) o;
+        return Objects.equals(this.code, obOtherCodeType12.code) &&
+                Objects.equals(this.name, obOtherCodeType12.name) &&
+                Objects.equals(this.description, obOtherCodeType12.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType12 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType13 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType13() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType13(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType13 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType13 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType13 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType13() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType13(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType13 obOtherCodeType13 = (OBOtherCodeType13) o;
-    return Objects.equals(this.code, obOtherCodeType13.code) &&
-        Objects.equals(this.name, obOtherCodeType13.name) &&
-        Objects.equals(this.description, obOtherCodeType13.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType13 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType13 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType13 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType13 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType13 obOtherCodeType13 = (OBOtherCodeType13) o;
+        return Objects.equals(this.code, obOtherCodeType13.code) &&
+                Objects.equals(this.name, obOtherCodeType13.name) &&
+                Objects.equals(this.description, obOtherCodeType13.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType13 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType14 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType14() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType14(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType14 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType14 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType14 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType14() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType14(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType14 obOtherCodeType14 = (OBOtherCodeType14) o;
-    return Objects.equals(this.code, obOtherCodeType14.code) &&
-        Objects.equals(this.name, obOtherCodeType14.name) &&
-        Objects.equals(this.description, obOtherCodeType14.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType14 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType14 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType14 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType14 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType14 obOtherCodeType14 = (OBOtherCodeType14) o;
+        return Objects.equals(this.code, obOtherCodeType14.code) &&
+                Objects.equals(this.name, obOtherCodeType14.name) &&
+                Objects.equals(this.description, obOtherCodeType14.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType14 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType15 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType15() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType15(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType15 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType15 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType15 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType15() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType15(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType15 obOtherCodeType15 = (OBOtherCodeType15) o;
-    return Objects.equals(this.code, obOtherCodeType15.code) &&
-        Objects.equals(this.name, obOtherCodeType15.name) &&
-        Objects.equals(this.description, obOtherCodeType15.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType15 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType15 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType15 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType15 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType15 obOtherCodeType15 = (OBOtherCodeType15) o;
+        return Objects.equals(this.code, obOtherCodeType15.code) &&
+                Objects.equals(this.name, obOtherCodeType15.name) &&
+                Objects.equals(this.description, obOtherCodeType15.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType15 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType16 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType16() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType16(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType16 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType16 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType16 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType16() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType16(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType16 obOtherCodeType16 = (OBOtherCodeType16) o;
-    return Objects.equals(this.code, obOtherCodeType16.code) &&
-        Objects.equals(this.name, obOtherCodeType16.name) &&
-        Objects.equals(this.description, obOtherCodeType16.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType16 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType16 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType16 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType16 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType16 obOtherCodeType16 = (OBOtherCodeType16) o;
+        return Objects.equals(this.code, obOtherCodeType16.code) &&
+                Objects.equals(this.name, obOtherCodeType16.name) &&
+                Objects.equals(this.description, obOtherCodeType16.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType16 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType17 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType17() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType17(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType17 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType17 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType17 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType17() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType17(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType17 obOtherCodeType17 = (OBOtherCodeType17) o;
-    return Objects.equals(this.code, obOtherCodeType17.code) &&
-        Objects.equals(this.name, obOtherCodeType17.name) &&
-        Objects.equals(this.description, obOtherCodeType17.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType17 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType17 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType17 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType17 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType17 obOtherCodeType17 = (OBOtherCodeType17) o;
+        return Objects.equals(this.code, obOtherCodeType17.code) &&
+                Objects.equals(this.name, obOtherCodeType17.name) &&
+                Objects.equals(this.description, obOtherCodeType17.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType17 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
@@ -35,123 +35,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherCodeType18 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherCodeType18() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherCodeType18(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherCodeType18 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherCodeType18 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherCodeType18 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherCodeType18() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherCodeType18(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBOtherCodeType18 obOtherCodeType18 = (OBOtherCodeType18) o;
-    return Objects.equals(this.code, obOtherCodeType18.code) &&
-        Objects.equals(this.name, obOtherCodeType18.name) &&
-        Objects.equals(this.description, obOtherCodeType18.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherCodeType18 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherCodeType18 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherCodeType18 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherCodeType18 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherCodeType18 obOtherCodeType18 = (OBOtherCodeType18) o;
+        return Objects.equals(this.code, obOtherCodeType18.code) &&
+                Objects.equals(this.name, obOtherCodeType18.name) &&
+                Objects.equals(this.description, obOtherCodeType18.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherCodeType18 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
@@ -15,17 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBFeeCategory1Code;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Other Fee/charge type which is not available in the standard code set
@@ -36,148 +45,155 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBOtherFeeChargeDetailType {
 
-  private String code;
+    private String code;
 
-  private OBFeeCategory1Code feeCategory;
+    private OBFeeCategory1Code feeCategory;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBOtherFeeChargeDetailType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBOtherFeeChargeDetailType(OBFeeCategory1Code feeCategory, String name, String description) {
-    this.feeCategory = feeCategory;
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBOtherFeeChargeDetailType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBOtherFeeChargeDetailType feeCategory(OBFeeCategory1Code feeCategory) {
-    this.feeCategory = feeCategory;
-    return this;
-  }
-
-  /**
-   * Get feeCategory
-   * @return feeCategory
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeCategory")
-  public OBFeeCategory1Code getFeeCategory() {
-    return feeCategory;
-  }
-
-  public void setFeeCategory(OBFeeCategory1Code feeCategory) {
-    this.feeCategory = feeCategory;
-  }
-
-  public OBOtherFeeChargeDetailType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBOtherFeeChargeDetailType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBOtherFeeChargeDetailType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBOtherFeeChargeDetailType(OBFeeCategory1Code feeCategory, String name, String description) {
+        this.feeCategory = feeCategory;
+        this.name = name;
+        this.description = description;
     }
-    OBOtherFeeChargeDetailType obOtherFeeChargeDetailType = (OBOtherFeeChargeDetailType) o;
-    return Objects.equals(this.code, obOtherFeeChargeDetailType.code) &&
-        Objects.equals(this.feeCategory, obOtherFeeChargeDetailType.feeCategory) &&
-        Objects.equals(this.name, obOtherFeeChargeDetailType.name) &&
-        Objects.equals(this.description, obOtherFeeChargeDetailType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, feeCategory, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBOtherFeeChargeDetailType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBOtherFeeChargeDetailType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBOtherFeeChargeDetailType feeCategory(OBFeeCategory1Code feeCategory) {
+        this.feeCategory = feeCategory;
+        return this;
+    }
+
+    /**
+     * Get feeCategory
+     *
+     * @return feeCategory
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeCategory")
+    public OBFeeCategory1Code getFeeCategory() {
+        return feeCategory;
+    }
+
+    public void setFeeCategory(OBFeeCategory1Code feeCategory) {
+        this.feeCategory = feeCategory;
+    }
+
+    public OBOtherFeeChargeDetailType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBOtherFeeChargeDetailType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBOtherFeeChargeDetailType obOtherFeeChargeDetailType = (OBOtherFeeChargeDetailType) o;
+        return Objects.equals(this.code, obOtherFeeChargeDetailType.code) &&
+                Objects.equals(this.feeCategory, obOtherFeeChargeDetailType.feeCategory) &&
+                Objects.equals(this.name, obOtherFeeChargeDetailType.name) &&
+                Objects.equals(this.description, obOtherFeeChargeDetailType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, feeCategory, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBOtherFeeChargeDetailType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeType1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Overdraft fee type
@@ -26,55 +40,55 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBOverdraftFeeType1Code {
-  
-  FBAO("FBAO"),
-  
-  FBAR("FBAR"),
-  
-  FBEB("FBEB"),
-  
-  FBIT("FBIT"),
-  
-  FBOR("FBOR"),
-  
-  FBOS("FBOS"),
-  
-  FBSC("FBSC"),
-  
-  FBTO("FBTO"),
-  
-  FBUB("FBUB"),
-  
-  FBUT("FBUT"),
-  
-  FTOT("FTOT"),
-  
-  FTUT("FTUT");
 
-  private String value;
+    FBAO("FBAO"),
 
-  OBOverdraftFeeType1Code(String value) {
-    this.value = value;
-  }
+    FBAR("FBAR"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    FBEB("FBEB"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    FBIT("FBIT"),
 
-  @JsonCreator
-  public static OBOverdraftFeeType1Code fromValue(String value) {
-    for (OBOverdraftFeeType1Code b : OBOverdraftFeeType1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    FBOR("FBOR"),
+
+    FBOS("FBOS"),
+
+    FBSC("FBSC"),
+
+    FBTO("FBTO"),
+
+    FBUB("FBUB"),
+
+    FBUT("FBUT"),
+
+    FTOT("FTOT"),
+
+    FTUT("FTUT");
+
+    private String value;
+
+    OBOverdraftFeeType1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBOverdraftFeeType1Code fromValue(String value) {
+        for (OBOverdraftFeeType1Code b : OBOverdraftFeeType1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
@@ -30,135 +30,139 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBPCAData1 {
 
-  private ProductDetails1 productDetails;
+    private ProductDetails1 productDetails;
 
-  private CreditInterest1 creditInterest;
+    private CreditInterest1 creditInterest;
 
-  private Overdraft1 overdraft;
+    private Overdraft1 overdraft;
 
-  private OtherFeesCharges otherFeesCharges;
+    private OtherFeesCharges otherFeesCharges;
 
-  public OBPCAData1 productDetails(ProductDetails1 productDetails) {
-    this.productDetails = productDetails;
-    return this;
-  }
-
-  /**
-   * Get productDetails
-   * @return productDetails
-  */
-  @Valid 
-  @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProductDetails")
-  public ProductDetails1 getProductDetails() {
-    return productDetails;
-  }
-
-  public void setProductDetails(ProductDetails1 productDetails) {
-    this.productDetails = productDetails;
-  }
-
-  public OBPCAData1 creditInterest(CreditInterest1 creditInterest) {
-    this.creditInterest = creditInterest;
-    return this;
-  }
-
-  /**
-   * Get creditInterest
-   * @return creditInterest
-  */
-  @Valid 
-  @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditInterest")
-  public CreditInterest1 getCreditInterest() {
-    return creditInterest;
-  }
-
-  public void setCreditInterest(CreditInterest1 creditInterest) {
-    this.creditInterest = creditInterest;
-  }
-
-  public OBPCAData1 overdraft(Overdraft1 overdraft) {
-    this.overdraft = overdraft;
-    return this;
-  }
-
-  /**
-   * Get overdraft
-   * @return overdraft
-  */
-  @Valid 
-  @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Overdraft")
-  public Overdraft1 getOverdraft() {
-    return overdraft;
-  }
-
-  public void setOverdraft(Overdraft1 overdraft) {
-    this.overdraft = overdraft;
-  }
-
-  public OBPCAData1 otherFeesCharges(OtherFeesCharges otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-    return this;
-  }
-
-  /**
-   * Get otherFeesCharges
-   * @return otherFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OtherFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeesCharges")
-  public OtherFeesCharges getOtherFeesCharges() {
-    return otherFeesCharges;
-  }
-
-  public void setOtherFeesCharges(OtherFeesCharges otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBPCAData1 productDetails(ProductDetails1 productDetails) {
+        this.productDetails = productDetails;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get productDetails
+     *
+     * @return productDetails
+     */
+    @Valid
+    @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProductDetails")
+    public ProductDetails1 getProductDetails() {
+        return productDetails;
     }
-    OBPCAData1 obPCAData1 = (OBPCAData1) o;
-    return Objects.equals(this.productDetails, obPCAData1.productDetails) &&
-        Objects.equals(this.creditInterest, obPCAData1.creditInterest) &&
-        Objects.equals(this.overdraft, obPCAData1.overdraft) &&
-        Objects.equals(this.otherFeesCharges, obPCAData1.otherFeesCharges);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(productDetails, creditInterest, overdraft, otherFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBPCAData1 {\n");
-    sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
-    sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
-    sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
-    sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setProductDetails(ProductDetails1 productDetails) {
+        this.productDetails = productDetails;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBPCAData1 creditInterest(CreditInterest1 creditInterest) {
+        this.creditInterest = creditInterest;
+        return this;
+    }
+
+    /**
+     * Get creditInterest
+     *
+     * @return creditInterest
+     */
+    @Valid
+    @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditInterest")
+    public CreditInterest1 getCreditInterest() {
+        return creditInterest;
+    }
+
+    public void setCreditInterest(CreditInterest1 creditInterest) {
+        this.creditInterest = creditInterest;
+    }
+
+    public OBPCAData1 overdraft(Overdraft1 overdraft) {
+        this.overdraft = overdraft;
+        return this;
+    }
+
+    /**
+     * Get overdraft
+     *
+     * @return overdraft
+     */
+    @Valid
+    @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Overdraft")
+    public Overdraft1 getOverdraft() {
+        return overdraft;
+    }
+
+    public void setOverdraft(Overdraft1 overdraft) {
+        this.overdraft = overdraft;
+    }
+
+    public OBPCAData1 otherFeesCharges(OtherFeesCharges otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+        return this;
+    }
+
+    /**
+     * Get otherFeesCharges
+     *
+     * @return otherFeesCharges
+     */
+    @Valid
+    @Schema(name = "OtherFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeesCharges")
+    public OtherFeesCharges getOtherFeesCharges() {
+        return otherFeesCharges;
+    }
+
+    public void setOtherFeesCharges(OtherFeesCharges otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBPCAData1 obPCAData1 = (OBPCAData1) o;
+        return Objects.equals(this.productDetails, obPCAData1.productDetails) &&
+                Objects.equals(this.creditInterest, obPCAData1.creditInterest) &&
+                Objects.equals(this.overdraft, obPCAData1.overdraft) &&
+                Objects.equals(this.otherFeesCharges, obPCAData1.otherFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productDetails, creditInterest, overdraft, otherFeesCharges);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBPCAData1 {\n");
+        sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
+        sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
+        sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
+        sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
@@ -35,371 +35,385 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBParty2 {
 
-  private String partyId;
+    private String partyId;
 
-  private String partyNumber;
+    private String partyNumber;
 
-  private OBExternalPartyType1Code partyType;
+    private OBExternalPartyType1Code partyType;
 
-  private String name;
+    private String name;
 
-  private String fullLegalName;
+    private String fullLegalName;
 
-  private String legalStructure;
+    private String legalStructure;
 
-  private Boolean beneficialOwnership;
+    private Boolean beneficialOwnership;
 
-  private String accountRole;
+    private String accountRole;
 
-  private String emailAddress;
+    private String emailAddress;
 
-  private String phone;
+    private String phone;
 
-  private String mobile;
+    private String mobile;
 
-  private OBPartyRelationships1 relationships;
+    private OBPartyRelationships1 relationships;
 
-  @Valid
-  private List<@Valid OBParty2AddressInner> address;
+    @Valid
+    private List<@Valid OBParty2AddressInner> address;
 
-  public OBParty2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBParty2(String partyId) {
-    this.partyId = partyId;
-  }
-
-  public OBParty2 partyId(String partyId) {
-    this.partyId = partyId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner.
-   * @return partyId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "PartyId", description = "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("PartyId")
-  public String getPartyId() {
-    return partyId;
-  }
-
-  public void setPartyId(String partyId) {
-    this.partyId = partyId;
-  }
-
-  public OBParty2 partyNumber(String partyNumber) {
-    this.partyNumber = partyNumber;
-    return this;
-  }
-
-  /**
-   * Number assigned by an agent to identify its customer.
-   * @return partyNumber
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "PartyNumber", description = "Number assigned by an agent to identify its customer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PartyNumber")
-  public String getPartyNumber() {
-    return partyNumber;
-  }
-
-  public void setPartyNumber(String partyNumber) {
-    this.partyNumber = partyNumber;
-  }
-
-  public OBParty2 partyType(OBExternalPartyType1Code partyType) {
-    this.partyType = partyType;
-    return this;
-  }
-
-  /**
-   * Get partyType
-   * @return partyType
-  */
-  @Valid 
-  @Schema(name = "PartyType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PartyType")
-  public OBExternalPartyType1Code getPartyType() {
-    return partyType;
-  }
-
-  public void setPartyType(OBExternalPartyType1Code partyType) {
-    this.partyType = partyType;
-  }
-
-  public OBParty2 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name by which a party is known and which is usually used to identify that party.
-   * @return name
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "Name by which a party is known and which is usually used to identify that party.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBParty2 fullLegalName(String fullLegalName) {
-    this.fullLegalName = fullLegalName;
-    return this;
-  }
-
-  /**
-   * Specifies a character string with a maximum length of 350 characters.
-   * @return fullLegalName
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "FullLegalName", description = "Specifies a character string with a maximum length of 350 characters.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FullLegalName")
-  public String getFullLegalName() {
-    return fullLegalName;
-  }
-
-  public void setFullLegalName(String fullLegalName) {
-    this.fullLegalName = fullLegalName;
-  }
-
-  public OBParty2 legalStructure(String legalStructure) {
-    this.legalStructure = legalStructure;
-    return this;
-  }
-
-  /**
-   * Legal standing of the party.
-   * @return legalStructure
-  */
-  
-  @Schema(name = "LegalStructure", description = "Legal standing of the party.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LegalStructure")
-  public String getLegalStructure() {
-    return legalStructure;
-  }
-
-  public void setLegalStructure(String legalStructure) {
-    this.legalStructure = legalStructure;
-  }
-
-  public OBParty2 beneficialOwnership(Boolean beneficialOwnership) {
-    this.beneficialOwnership = beneficialOwnership;
-    return this;
-  }
-
-  /**
-   * Get beneficialOwnership
-   * @return beneficialOwnership
-  */
-  
-  @Schema(name = "BeneficialOwnership", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BeneficialOwnership")
-  public Boolean getBeneficialOwnership() {
-    return beneficialOwnership;
-  }
-
-  public void setBeneficialOwnership(Boolean beneficialOwnership) {
-    this.beneficialOwnership = beneficialOwnership;
-  }
-
-  public OBParty2 accountRole(String accountRole) {
-    this.accountRole = accountRole;
-    return this;
-  }
-
-  /**
-   * A party’s role with respect to the related account.
-   * @return accountRole
-  */
-  
-  @Schema(name = "AccountRole", description = "A party’s role with respect to the related account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AccountRole")
-  public String getAccountRole() {
-    return accountRole;
-  }
-
-  public void setAccountRole(String accountRole) {
-    this.accountRole = accountRole;
-  }
-
-  public OBParty2 emailAddress(String emailAddress) {
-    this.emailAddress = emailAddress;
-    return this;
-  }
-
-  /**
-   * Address for electronic mail (e-mail).
-   * @return emailAddress
-  */
-  @Size(min = 1, max = 256) 
-  @Schema(name = "EmailAddress", description = "Address for electronic mail (e-mail).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("EmailAddress")
-  public String getEmailAddress() {
-    return emailAddress;
-  }
-
-  public void setEmailAddress(String emailAddress) {
-    this.emailAddress = emailAddress;
-  }
-
-  public OBParty2 phone(String phone) {
-    this.phone = phone;
-    return this;
-  }
-
-  /**
-   * Collection of information that identifies a phone number, as defined by telecom services.
-   * @return phone
-  */
-  @Pattern(regexp = "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}") 
-  @Schema(name = "Phone", description = "Collection of information that identifies a phone number, as defined by telecom services.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Phone")
-  public String getPhone() {
-    return phone;
-  }
-
-  public void setPhone(String phone) {
-    this.phone = phone;
-  }
-
-  public OBParty2 mobile(String mobile) {
-    this.mobile = mobile;
-    return this;
-  }
-
-  /**
-   * Collection of information that identifies a mobile phone number, as defined by telecom services.
-   * @return mobile
-  */
-  @Pattern(regexp = "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}") 
-  @Schema(name = "Mobile", description = "Collection of information that identifies a mobile phone number, as defined by telecom services.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Mobile")
-  public String getMobile() {
-    return mobile;
-  }
-
-  public void setMobile(String mobile) {
-    this.mobile = mobile;
-  }
-
-  public OBParty2 relationships(OBPartyRelationships1 relationships) {
-    this.relationships = relationships;
-    return this;
-  }
-
-  /**
-   * Get relationships
-   * @return relationships
-  */
-  @Valid 
-  @Schema(name = "Relationships", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Relationships")
-  public OBPartyRelationships1 getRelationships() {
-    return relationships;
-  }
-
-  public void setRelationships(OBPartyRelationships1 relationships) {
-    this.relationships = relationships;
-  }
-
-  public OBParty2 address(List<@Valid OBParty2AddressInner> address) {
-    this.address = address;
-    return this;
-  }
-
-  public OBParty2 addAddressItem(OBParty2AddressInner addressItem) {
-    if (this.address == null) {
-      this.address = new ArrayList<>();
+    public OBParty2() {
+        super();
     }
-    this.address.add(addressItem);
-    return this;
-  }
 
-  /**
-   * Get address
-   * @return address
-  */
-  @Valid 
-  @Schema(name = "Address", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Address")
-  public List<@Valid OBParty2AddressInner> getAddress() {
-    return address;
-  }
-
-  public void setAddress(List<@Valid OBParty2AddressInner> address) {
-    this.address = address;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBParty2(String partyId) {
+        this.partyId = partyId;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBParty2 partyId(String partyId) {
+        this.partyId = partyId;
+        return this;
     }
-    OBParty2 obParty2 = (OBParty2) o;
-    return Objects.equals(this.partyId, obParty2.partyId) &&
-        Objects.equals(this.partyNumber, obParty2.partyNumber) &&
-        Objects.equals(this.partyType, obParty2.partyType) &&
-        Objects.equals(this.name, obParty2.name) &&
-        Objects.equals(this.fullLegalName, obParty2.fullLegalName) &&
-        Objects.equals(this.legalStructure, obParty2.legalStructure) &&
-        Objects.equals(this.beneficialOwnership, obParty2.beneficialOwnership) &&
-        Objects.equals(this.accountRole, obParty2.accountRole) &&
-        Objects.equals(this.emailAddress, obParty2.emailAddress) &&
-        Objects.equals(this.phone, obParty2.phone) &&
-        Objects.equals(this.mobile, obParty2.mobile) &&
-        Objects.equals(this.relationships, obParty2.relationships) &&
-        Objects.equals(this.address, obParty2.address);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(partyId, partyNumber, partyType, name, fullLegalName, legalStructure, beneficialOwnership, accountRole, emailAddress, phone, mobile, relationships, address);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBParty2 {\n");
-    sb.append("    partyId: ").append(toIndentedString(partyId)).append("\n");
-    sb.append("    partyNumber: ").append(toIndentedString(partyNumber)).append("\n");
-    sb.append("    partyType: ").append(toIndentedString(partyType)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    fullLegalName: ").append(toIndentedString(fullLegalName)).append("\n");
-    sb.append("    legalStructure: ").append(toIndentedString(legalStructure)).append("\n");
-    sb.append("    beneficialOwnership: ").append(toIndentedString(beneficialOwnership)).append("\n");
-    sb.append("    accountRole: ").append(toIndentedString(accountRole)).append("\n");
-    sb.append("    emailAddress: ").append(toIndentedString(emailAddress)).append("\n");
-    sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
-    sb.append("    mobile: ").append(toIndentedString(mobile)).append("\n");
-    sb.append("    relationships: ").append(toIndentedString(relationships)).append("\n");
-    sb.append("    address: ").append(toIndentedString(address)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner.
+     *
+     * @return partyId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "PartyId", description = "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("PartyId")
+    public String getPartyId() {
+        return partyId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setPartyId(String partyId) {
+        this.partyId = partyId;
+    }
+
+    public OBParty2 partyNumber(String partyNumber) {
+        this.partyNumber = partyNumber;
+        return this;
+    }
+
+    /**
+     * Number assigned by an agent to identify its customer.
+     *
+     * @return partyNumber
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "PartyNumber", description = "Number assigned by an agent to identify its customer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PartyNumber")
+    public String getPartyNumber() {
+        return partyNumber;
+    }
+
+    public void setPartyNumber(String partyNumber) {
+        this.partyNumber = partyNumber;
+    }
+
+    public OBParty2 partyType(OBExternalPartyType1Code partyType) {
+        this.partyType = partyType;
+        return this;
+    }
+
+    /**
+     * Get partyType
+     *
+     * @return partyType
+     */
+    @Valid
+    @Schema(name = "PartyType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PartyType")
+    public OBExternalPartyType1Code getPartyType() {
+        return partyType;
+    }
+
+    public void setPartyType(OBExternalPartyType1Code partyType) {
+        this.partyType = partyType;
+    }
+
+    public OBParty2 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name by which a party is known and which is usually used to identify that party.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "Name by which a party is known and which is usually used to identify that party.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBParty2 fullLegalName(String fullLegalName) {
+        this.fullLegalName = fullLegalName;
+        return this;
+    }
+
+    /**
+     * Specifies a character string with a maximum length of 350 characters.
+     *
+     * @return fullLegalName
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "FullLegalName", description = "Specifies a character string with a maximum length of 350 characters.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FullLegalName")
+    public String getFullLegalName() {
+        return fullLegalName;
+    }
+
+    public void setFullLegalName(String fullLegalName) {
+        this.fullLegalName = fullLegalName;
+    }
+
+    public OBParty2 legalStructure(String legalStructure) {
+        this.legalStructure = legalStructure;
+        return this;
+    }
+
+    /**
+     * Legal standing of the party.
+     *
+     * @return legalStructure
+     */
+
+    @Schema(name = "LegalStructure", description = "Legal standing of the party.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LegalStructure")
+    public String getLegalStructure() {
+        return legalStructure;
+    }
+
+    public void setLegalStructure(String legalStructure) {
+        this.legalStructure = legalStructure;
+    }
+
+    public OBParty2 beneficialOwnership(Boolean beneficialOwnership) {
+        this.beneficialOwnership = beneficialOwnership;
+        return this;
+    }
+
+    /**
+     * Get beneficialOwnership
+     *
+     * @return beneficialOwnership
+     */
+
+    @Schema(name = "BeneficialOwnership", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficialOwnership")
+    public Boolean getBeneficialOwnership() {
+        return beneficialOwnership;
+    }
+
+    public void setBeneficialOwnership(Boolean beneficialOwnership) {
+        this.beneficialOwnership = beneficialOwnership;
+    }
+
+    public OBParty2 accountRole(String accountRole) {
+        this.accountRole = accountRole;
+        return this;
+    }
+
+    /**
+     * A party’s role with respect to the related account.
+     *
+     * @return accountRole
+     */
+
+    @Schema(name = "AccountRole", description = "A party’s role with respect to the related account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AccountRole")
+    public String getAccountRole() {
+        return accountRole;
+    }
+
+    public void setAccountRole(String accountRole) {
+        this.accountRole = accountRole;
+    }
+
+    public OBParty2 emailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+        return this;
+    }
+
+    /**
+     * Address for electronic mail (e-mail).
+     *
+     * @return emailAddress
+     */
+    @Size(min = 1, max = 256)
+    @Schema(name = "EmailAddress", description = "Address for electronic mail (e-mail).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EmailAddress")
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public OBParty2 phone(String phone) {
+        this.phone = phone;
+        return this;
+    }
+
+    /**
+     * Collection of information that identifies a phone number, as defined by telecom services.
+     *
+     * @return phone
+     */
+    @Pattern(regexp = "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}")
+    @Schema(name = "Phone", description = "Collection of information that identifies a phone number, as defined by telecom services.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Phone")
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public OBParty2 mobile(String mobile) {
+        this.mobile = mobile;
+        return this;
+    }
+
+    /**
+     * Collection of information that identifies a mobile phone number, as defined by telecom services.
+     *
+     * @return mobile
+     */
+    @Pattern(regexp = "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}")
+    @Schema(name = "Mobile", description = "Collection of information that identifies a mobile phone number, as defined by telecom services.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Mobile")
+    public String getMobile() {
+        return mobile;
+    }
+
+    public void setMobile(String mobile) {
+        this.mobile = mobile;
+    }
+
+    public OBParty2 relationships(OBPartyRelationships1 relationships) {
+        this.relationships = relationships;
+        return this;
+    }
+
+    /**
+     * Get relationships
+     *
+     * @return relationships
+     */
+    @Valid
+    @Schema(name = "Relationships", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Relationships")
+    public OBPartyRelationships1 getRelationships() {
+        return relationships;
+    }
+
+    public void setRelationships(OBPartyRelationships1 relationships) {
+        this.relationships = relationships;
+    }
+
+    public OBParty2 address(List<@Valid OBParty2AddressInner> address) {
+        this.address = address;
+        return this;
+    }
+
+    public OBParty2 addAddressItem(OBParty2AddressInner addressItem) {
+        if (this.address == null) {
+            this.address = new ArrayList<>();
+        }
+        this.address.add(addressItem);
+        return this;
+    }
+
+    /**
+     * Get address
+     *
+     * @return address
+     */
+    @Valid
+    @Schema(name = "Address", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Address")
+    public List<@Valid OBParty2AddressInner> getAddress() {
+        return address;
+    }
+
+    public void setAddress(List<@Valid OBParty2AddressInner> address) {
+        this.address = address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBParty2 obParty2 = (OBParty2) o;
+        return Objects.equals(this.partyId, obParty2.partyId) &&
+                Objects.equals(this.partyNumber, obParty2.partyNumber) &&
+                Objects.equals(this.partyType, obParty2.partyType) &&
+                Objects.equals(this.name, obParty2.name) &&
+                Objects.equals(this.fullLegalName, obParty2.fullLegalName) &&
+                Objects.equals(this.legalStructure, obParty2.legalStructure) &&
+                Objects.equals(this.beneficialOwnership, obParty2.beneficialOwnership) &&
+                Objects.equals(this.accountRole, obParty2.accountRole) &&
+                Objects.equals(this.emailAddress, obParty2.emailAddress) &&
+                Objects.equals(this.phone, obParty2.phone) &&
+                Objects.equals(this.mobile, obParty2.mobile) &&
+                Objects.equals(this.relationships, obParty2.relationships) &&
+                Objects.equals(this.address, obParty2.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partyId, partyNumber, partyType, name, fullLegalName, legalStructure, beneficialOwnership, accountRole, emailAddress, phone, mobile, relationships, address);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBParty2 {\n");
+        sb.append("    partyId: ").append(toIndentedString(partyId)).append("\n");
+        sb.append("    partyNumber: ").append(toIndentedString(partyNumber)).append("\n");
+        sb.append("    partyType: ").append(toIndentedString(partyType)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    fullLegalName: ").append(toIndentedString(fullLegalName)).append("\n");
+        sb.append("    legalStructure: ").append(toIndentedString(legalStructure)).append("\n");
+        sb.append("    beneficialOwnership: ").append(toIndentedString(beneficialOwnership)).append("\n");
+        sb.append("    accountRole: ").append(toIndentedString(accountRole)).append("\n");
+        sb.append("    emailAddress: ").append(toIndentedString(emailAddress)).append("\n");
+        sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
+        sb.append("    mobile: ").append(toIndentedString(mobile)).append("\n");
+        sb.append("    relationships: ").append(toIndentedString(relationships)).append("\n");
+        sb.append("    address: ").append(toIndentedString(address)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2AddressInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2AddressInner.java
@@ -15,20 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import uk.org.openbanking.datamodel.common.OBAddressTypeCode;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Postal address of a party.
@@ -39,251 +49,260 @@ import uk.org.openbanking.datamodel.common.OBAddressTypeCode;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBParty2AddressInner {
 
-  private OBAddressTypeCode addressType;
+    private OBAddressTypeCode addressType;
 
-  @Valid
-  private List<@Size(min = 1, max = 70)String> addressLine;
+    @Valid
+    private List<@Size(min = 1, max = 70) String> addressLine;
 
-  private String streetName;
+    private String streetName;
 
-  private String buildingNumber;
+    private String buildingNumber;
 
-  private String postCode;
+    private String postCode;
 
-  private String townName;
+    private String townName;
 
-  private String countrySubDivision;
+    private String countrySubDivision;
 
-  private String country;
+    private String country;
 
-  public OBParty2AddressInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBParty2AddressInner(String country) {
-    this.country = country;
-  }
-
-  public OBParty2AddressInner addressType(OBAddressTypeCode addressType) {
-    this.addressType = addressType;
-    return this;
-  }
-
-  /**
-   * Get addressType
-   * @return addressType
-  */
-  @Valid 
-  @Schema(name = "AddressType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AddressType")
-  public OBAddressTypeCode getAddressType() {
-    return addressType;
-  }
-
-  public void setAddressType(OBAddressTypeCode addressType) {
-    this.addressType = addressType;
-  }
-
-  public OBParty2AddressInner addressLine(List<@Size(min = 1, max = 70)String> addressLine) {
-    this.addressLine = addressLine;
-    return this;
-  }
-
-  public OBParty2AddressInner addAddressLineItem(String addressLineItem) {
-    if (this.addressLine == null) {
-      this.addressLine = new ArrayList<>();
+    public OBParty2AddressInner() {
+        super();
     }
-    this.addressLine.add(addressLineItem);
-    return this;
-  }
 
-  /**
-   * Get addressLine
-   * @return addressLine
-  */
-  @Size(min = 0, max = 5) 
-  @Schema(name = "AddressLine", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AddressLine")
-  public List<@Size(min = 1, max = 70)String> getAddressLine() {
-    return addressLine;
-  }
-
-  public void setAddressLine(List<@Size(min = 1, max = 70)String> addressLine) {
-    this.addressLine = addressLine;
-  }
-
-  public OBParty2AddressInner streetName(String streetName) {
-    this.streetName = streetName;
-    return this;
-  }
-
-  /**
-   * Name of a street or thoroughfare.
-   * @return streetName
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "StreetName", description = "Name of a street or thoroughfare.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StreetName")
-  public String getStreetName() {
-    return streetName;
-  }
-
-  public void setStreetName(String streetName) {
-    this.streetName = streetName;
-  }
-
-  public OBParty2AddressInner buildingNumber(String buildingNumber) {
-    this.buildingNumber = buildingNumber;
-    return this;
-  }
-
-  /**
-   * Number that identifies the position of a building on a street.
-   * @return buildingNumber
-  */
-  @Size(min = 1, max = 16) 
-  @Schema(name = "BuildingNumber", description = "Number that identifies the position of a building on a street.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BuildingNumber")
-  public String getBuildingNumber() {
-    return buildingNumber;
-  }
-
-  public void setBuildingNumber(String buildingNumber) {
-    this.buildingNumber = buildingNumber;
-  }
-
-  public OBParty2AddressInner postCode(String postCode) {
-    this.postCode = postCode;
-    return this;
-  }
-
-  /**
-   * Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.
-   * @return postCode
-  */
-  @Size(min = 1, max = 16) 
-  @Schema(name = "PostCode", description = "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PostCode")
-  public String getPostCode() {
-    return postCode;
-  }
-
-  public void setPostCode(String postCode) {
-    this.postCode = postCode;
-  }
-
-  public OBParty2AddressInner townName(String townName) {
-    this.townName = townName;
-    return this;
-  }
-
-  /**
-   * Name of a built-up area, with defined boundaries, and a local government.
-   * @return townName
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "TownName", description = "Name of a built-up area, with defined boundaries, and a local government.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TownName")
-  public String getTownName() {
-    return townName;
-  }
-
-  public void setTownName(String townName) {
-    this.townName = townName;
-  }
-
-  public OBParty2AddressInner countrySubDivision(String countrySubDivision) {
-    this.countrySubDivision = countrySubDivision;
-    return this;
-  }
-
-  /**
-   * Identifies a subdivision of a country eg, state, region, county.
-   * @return countrySubDivision
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "CountrySubDivision", description = "Identifies a subdivision of a country eg, state, region, county.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CountrySubDivision")
-  public String getCountrySubDivision() {
-    return countrySubDivision;
-  }
-
-  public void setCountrySubDivision(String countrySubDivision) {
-    this.countrySubDivision = countrySubDivision;
-  }
-
-  public OBParty2AddressInner country(String country) {
-    this.country = country;
-    return this;
-  }
-
-  /**
-   * Nation with its own government, occupying a particular territory.
-   * @return country
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{2,2}$") 
-  @Schema(name = "Country", description = "Nation with its own government, occupying a particular territory.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Country")
-  public String getCountry() {
-    return country;
-  }
-
-  public void setCountry(String country) {
-    this.country = country;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBParty2AddressInner(String country) {
+        this.country = country;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBParty2AddressInner addressType(OBAddressTypeCode addressType) {
+        this.addressType = addressType;
+        return this;
     }
-    OBParty2AddressInner obParty2AddressInner = (OBParty2AddressInner) o;
-    return Objects.equals(this.addressType, obParty2AddressInner.addressType) &&
-        Objects.equals(this.addressLine, obParty2AddressInner.addressLine) &&
-        Objects.equals(this.streetName, obParty2AddressInner.streetName) &&
-        Objects.equals(this.buildingNumber, obParty2AddressInner.buildingNumber) &&
-        Objects.equals(this.postCode, obParty2AddressInner.postCode) &&
-        Objects.equals(this.townName, obParty2AddressInner.townName) &&
-        Objects.equals(this.countrySubDivision, obParty2AddressInner.countrySubDivision) &&
-        Objects.equals(this.country, obParty2AddressInner.country);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(addressType, addressLine, streetName, buildingNumber, postCode, townName, countrySubDivision, country);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBParty2AddressInner {\n");
-    sb.append("    addressType: ").append(toIndentedString(addressType)).append("\n");
-    sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
-    sb.append("    streetName: ").append(toIndentedString(streetName)).append("\n");
-    sb.append("    buildingNumber: ").append(toIndentedString(buildingNumber)).append("\n");
-    sb.append("    postCode: ").append(toIndentedString(postCode)).append("\n");
-    sb.append("    townName: ").append(toIndentedString(townName)).append("\n");
-    sb.append("    countrySubDivision: ").append(toIndentedString(countrySubDivision)).append("\n");
-    sb.append("    country: ").append(toIndentedString(country)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get addressType
+     *
+     * @return addressType
+     */
+    @Valid
+    @Schema(name = "AddressType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressType")
+    public OBAddressTypeCode getAddressType() {
+        return addressType;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAddressType(OBAddressTypeCode addressType) {
+        this.addressType = addressType;
+    }
+
+    public OBParty2AddressInner addressLine(List<@Size(min = 1, max = 70) String> addressLine) {
+        this.addressLine = addressLine;
+        return this;
+    }
+
+    public OBParty2AddressInner addAddressLineItem(String addressLineItem) {
+        if (this.addressLine == null) {
+            this.addressLine = new ArrayList<>();
+        }
+        this.addressLine.add(addressLineItem);
+        return this;
+    }
+
+    /**
+     * Get addressLine
+     *
+     * @return addressLine
+     */
+    @Size(min = 0, max = 5)
+    @Schema(name = "AddressLine", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressLine")
+    public List<@Size(min = 1, max = 70) String> getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine(List<@Size(min = 1, max = 70) String> addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public OBParty2AddressInner streetName(String streetName) {
+        this.streetName = streetName;
+        return this;
+    }
+
+    /**
+     * Name of a street or thoroughfare.
+     *
+     * @return streetName
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "StreetName", description = "Name of a street or thoroughfare.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StreetName")
+    public String getStreetName() {
+        return streetName;
+    }
+
+    public void setStreetName(String streetName) {
+        this.streetName = streetName;
+    }
+
+    public OBParty2AddressInner buildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+        return this;
+    }
+
+    /**
+     * Number that identifies the position of a building on a street.
+     *
+     * @return buildingNumber
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "BuildingNumber", description = "Number that identifies the position of a building on a street.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BuildingNumber")
+    public String getBuildingNumber() {
+        return buildingNumber;
+    }
+
+    public void setBuildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+    }
+
+    public OBParty2AddressInner postCode(String postCode) {
+        this.postCode = postCode;
+        return this;
+    }
+
+    /**
+     * Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.
+     *
+     * @return postCode
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "PostCode", description = "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostCode")
+    public String getPostCode() {
+        return postCode;
+    }
+
+    public void setPostCode(String postCode) {
+        this.postCode = postCode;
+    }
+
+    public OBParty2AddressInner townName(String townName) {
+        this.townName = townName;
+        return this;
+    }
+
+    /**
+     * Name of a built-up area, with defined boundaries, and a local government.
+     *
+     * @return townName
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "TownName", description = "Name of a built-up area, with defined boundaries, and a local government.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TownName")
+    public String getTownName() {
+        return townName;
+    }
+
+    public void setTownName(String townName) {
+        this.townName = townName;
+    }
+
+    public OBParty2AddressInner countrySubDivision(String countrySubDivision) {
+        this.countrySubDivision = countrySubDivision;
+        return this;
+    }
+
+    /**
+     * Identifies a subdivision of a country eg, state, region, county.
+     *
+     * @return countrySubDivision
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "CountrySubDivision", description = "Identifies a subdivision of a country eg, state, region, county.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CountrySubDivision")
+    public String getCountrySubDivision() {
+        return countrySubDivision;
+    }
+
+    public void setCountrySubDivision(String countrySubDivision) {
+        this.countrySubDivision = countrySubDivision;
+    }
+
+    public OBParty2AddressInner country(String country) {
+        this.country = country;
+        return this;
+    }
+
+    /**
+     * Nation with its own government, occupying a particular territory.
+     *
+     * @return country
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{2,2}$")
+    @Schema(name = "Country", description = "Nation with its own government, occupying a particular territory.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Country")
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBParty2AddressInner obParty2AddressInner = (OBParty2AddressInner) o;
+        return Objects.equals(this.addressType, obParty2AddressInner.addressType) &&
+                Objects.equals(this.addressLine, obParty2AddressInner.addressLine) &&
+                Objects.equals(this.streetName, obParty2AddressInner.streetName) &&
+                Objects.equals(this.buildingNumber, obParty2AddressInner.buildingNumber) &&
+                Objects.equals(this.postCode, obParty2AddressInner.postCode) &&
+                Objects.equals(this.townName, obParty2AddressInner.townName) &&
+                Objects.equals(this.countrySubDivision, obParty2AddressInner.countrySubDivision) &&
+                Objects.equals(this.country, obParty2AddressInner.country);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressType, addressLine, streetName, buildingNumber, postCode, townName, countrySubDivision, country);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBParty2AddressInner {\n");
+        sb.append("    addressType: ").append(toIndentedString(addressType)).append("\n");
+        sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
+        sb.append("    streetName: ").append(toIndentedString(streetName)).append("\n");
+        sb.append("    buildingNumber: ").append(toIndentedString(buildingNumber)).append("\n");
+        sb.append("    postCode: ").append(toIndentedString(postCode)).append("\n");
+        sb.append("    townName: ").append(toIndentedString(townName)).append("\n");
+        sb.append("    countrySubDivision: ").append(toIndentedString(countrySubDivision)).append("\n");
+        sb.append("    country: ").append(toIndentedString(country)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
@@ -15,13 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBPartyRelationships1Account;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * The Party&#39;s relationships with other resources.
@@ -31,63 +42,64 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBPartyRelationships1 {
 
-  private OBPartyRelationships1Account account;
+    private OBPartyRelationships1Account account;
 
-  public OBPartyRelationships1 account(OBPartyRelationships1Account account) {
-    this.account = account;
-    return this;
-  }
-
-  /**
-   * Get account
-   * @return account
-  */
-  @Valid 
-  @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Account")
-  public OBPartyRelationships1Account getAccount() {
-    return account;
-  }
-
-  public void setAccount(OBPartyRelationships1Account account) {
-    this.account = account;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBPartyRelationships1 account(OBPartyRelationships1Account account) {
+        this.account = account;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get account
+     *
+     * @return account
+     */
+    @Valid
+    @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Account")
+    public OBPartyRelationships1Account getAccount() {
+        return account;
     }
-    OBPartyRelationships1 obPartyRelationships1 = (OBPartyRelationships1) o;
-    return Objects.equals(this.account, obPartyRelationships1.account);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(account);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBPartyRelationships1 {\n");
-    sb.append("    account: ").append(toIndentedString(account)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setAccount(OBPartyRelationships1Account account) {
+        this.account = account;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBPartyRelationships1 obPartyRelationships1 = (OBPartyRelationships1) o;
+        return Objects.equals(this.account, obPartyRelationships1.account);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(account);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBPartyRelationships1 {\n");
+        sb.append("    account: ").append(toIndentedString(account)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
@@ -19,13 +19,20 @@ import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.net.URI;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Relationship to the Account resource.
@@ -36,99 +43,103 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBPartyRelationships1Account {
 
-  private URI related;
+    private URI related;
 
-  private String id;
+    private String id;
 
-  public OBPartyRelationships1Account() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBPartyRelationships1Account(URI related, String id) {
-    this.related = related;
-    this.id = id;
-  }
-
-  public OBPartyRelationships1Account related(URI related) {
-    this.related = related;
-    return this;
-  }
-
-  /**
-   * Absolute URI to the related resource.
-   * @return related
-  */
-  @NotNull @Valid 
-  @Schema(name = "Related", description = "Absolute URI to the related resource.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Related")
-  public URI getRelated() {
-    return related;
-  }
-
-  public void setRelated(URI related) {
-    this.related = related;
-  }
-
-  public OBPartyRelationships1Account id(String id) {
-    this.id = id;
-    return this;
-  }
-
-  /**
-   * Unique identification as assigned by the ASPSP to uniquely identify the related resource.
-   * @return id
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "Id", description = "Unique identification as assigned by the ASPSP to uniquely identify the related resource.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Id")
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBPartyRelationships1Account() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBPartyRelationships1Account(URI related, String id) {
+        this.related = related;
+        this.id = id;
     }
-    OBPartyRelationships1Account obPartyRelationships1Account = (OBPartyRelationships1Account) o;
-    return Objects.equals(this.related, obPartyRelationships1Account.related) &&
-        Objects.equals(this.id, obPartyRelationships1Account.id);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(related, id);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBPartyRelationships1Account {\n");
-    sb.append("    related: ").append(toIndentedString(related)).append("\n");
-    sb.append("    id: ").append(toIndentedString(id)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBPartyRelationships1Account related(URI related) {
+        this.related = related;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Absolute URI to the related resource.
+     *
+     * @return related
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Related", description = "Absolute URI to the related resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Related")
+    public URI getRelated() {
+        return related;
+    }
+
+    public void setRelated(URI related) {
+        this.related = related;
+    }
+
+    public OBPartyRelationships1Account id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the related resource.
+     *
+     * @return id
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "Id", description = "Unique identification as assigned by the ASPSP to uniquely identify the related resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Id")
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBPartyRelationships1Account obPartyRelationships1Account = (OBPartyRelationships1Account) o;
+        return Objects.equals(this.related, obPartyRelationships1Account.related) &&
+                Objects.equals(this.id, obPartyRelationships1Account.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(related, id);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBPartyRelationships1Account {\n");
+        sb.append("    related: ").append(toIndentedString(related)).append("\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPeriod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPeriod1Code.java
@@ -26,45 +26,45 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBPeriod1Code {
-  
-  PACT("PACT"),
-  
-  PDAY("PDAY"),
-  
-  PHYR("PHYR"),
-  
-  PMTH("PMTH"),
-  
-  PQTR("PQTR"),
-  
-  PWEK("PWEK"),
-  
-  PYER("PYER");
 
-  private String value;
+    PACT("PACT"),
 
-  OBPeriod1Code(String value) {
-    this.value = value;
-  }
+    PDAY("PDAY"),
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    PHYR("PHYR"),
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
+    PMTH("PMTH"),
 
-  @JsonCreator
-  public static OBPeriod1Code fromValue(String value) {
-    for (OBPeriod1Code b : OBPeriod1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBPeriod1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBPeriod1Code fromValue(String value) {
+        for (OBPeriod1Code b : OBPeriod1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadAccount6 {
 
-  private OBReadAccount6Data data;
+    private OBReadAccount6Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadAccount6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadAccount6(OBReadAccount6Data data) {
-    this.data = data;
-  }
-
-  public OBReadAccount6 data(OBReadAccount6Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadAccount6Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadAccount6Data data) {
-    this.data = data;
-  }
-
-  public OBReadAccount6 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadAccount6 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadAccount6() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadAccount6(OBReadAccount6Data data) {
+        this.data = data;
     }
-    OBReadAccount6 obReadAccount6 = (OBReadAccount6) o;
-    return Objects.equals(this.data, obReadAccount6.data) &&
-        Objects.equals(this.links, obReadAccount6.links) &&
-        Objects.equals(this.meta, obReadAccount6.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadAccount6 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadAccount6 data(OBReadAccount6Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadAccount6Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadAccount6Data data) {
+        this.data = data;
+    }
+
+    public OBReadAccount6 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadAccount6 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadAccount6 obReadAccount6 = (OBReadAccount6) o;
+        return Objects.equals(this.data, obReadAccount6.data) &&
+                Objects.equals(this.links, obReadAccount6.links) &&
+                Objects.equals(this.meta, obReadAccount6.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadAccount6 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
@@ -34,72 +34,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadAccount6Data {
 
-  @Valid
-  private List<@Valid OBAccount6> account;
+    @Valid
+    private List<@Valid OBAccount6> account;
 
-  public OBReadAccount6Data account(List<@Valid OBAccount6> account) {
-    this.account = account;
-    return this;
-  }
-
-  public OBReadAccount6Data addAccountItem(OBAccount6 accountItem) {
-    if (this.account == null) {
-      this.account = new ArrayList<>();
+    public OBReadAccount6Data account(List<@Valid OBAccount6> account) {
+        this.account = account;
+        return this;
     }
-    this.account.add(accountItem);
-    return this;
-  }
 
-  /**
-   * Get account
-   * @return account
-  */
-  @Valid 
-  @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Account")
-  public List<@Valid OBAccount6> getAccount() {
-    return account;
-  }
-
-  public void setAccount(List<@Valid OBAccount6> account) {
-    this.account = account;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadAccount6Data addAccountItem(OBAccount6 accountItem) {
+        if (this.account == null) {
+            this.account = new ArrayList<>();
+        }
+        this.account.add(accountItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get account
+     *
+     * @return account
+     */
+    @Valid
+    @Schema(name = "Account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Account")
+    public List<@Valid OBAccount6> getAccount() {
+        return account;
     }
-    OBReadAccount6Data obReadAccount6Data = (OBReadAccount6Data) o;
-    return Objects.equals(this.account, obReadAccount6Data.account);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(account);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadAccount6Data {\n");
-    sb.append("    account: ").append(toIndentedString(account)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setAccount(List<@Valid OBAccount6> account) {
+        this.account = account;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadAccount6Data obReadAccount6Data = (OBReadAccount6Data) o;
+        return Objects.equals(this.account, obReadAccount6Data.account);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(account);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadAccount6Data {\n");
+        sb.append("    account: ").append(toIndentedString(account)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1 {
 
-  private OBReadBalance1Data data;
+    private OBReadBalance1Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadBalance1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1(OBReadBalance1Data data) {
-    this.data = data;
-  }
-
-  public OBReadBalance1 data(OBReadBalance1Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadBalance1Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadBalance1Data data) {
-    this.data = data;
-  }
-
-  public OBReadBalance1 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadBalance1 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadBalance1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1(OBReadBalance1Data data) {
+        this.data = data;
     }
-    OBReadBalance1 obReadBalance1 = (OBReadBalance1) o;
-    return Objects.equals(this.data, obReadBalance1.data) &&
-        Objects.equals(this.links, obReadBalance1.links) &&
-        Objects.equals(this.meta, obReadBalance1.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadBalance1 data(OBReadBalance1Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadBalance1Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadBalance1Data data) {
+        this.data = data;
+    }
+
+    public OBReadBalance1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadBalance1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1 obReadBalance1 = (OBReadBalance1) o;
+        return Objects.equals(this.data, obReadBalance1.data) &&
+                Objects.equals(this.links, obReadBalance1.links) &&
+                Objects.equals(this.meta, obReadBalance1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
@@ -36,83 +36,86 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1Data {
 
-  @Valid
-  private List<@Valid OBReadBalance1DataBalanceInner> balance = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadBalance1DataBalanceInner> balance = new ArrayList<>();
 
-  public OBReadBalance1Data() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1Data(List<@Valid OBReadBalance1DataBalanceInner> balance) {
-    this.balance = balance;
-  }
-
-  public OBReadBalance1Data balance(List<@Valid OBReadBalance1DataBalanceInner> balance) {
-    this.balance = balance;
-    return this;
-  }
-
-  public OBReadBalance1Data addBalanceItem(OBReadBalance1DataBalanceInner balanceItem) {
-    if (this.balance == null) {
-      this.balance = new ArrayList<>();
+    public OBReadBalance1Data() {
+        super();
     }
-    this.balance.add(balanceItem);
-    return this;
-  }
 
-  /**
-   * Get balance
-   * @return balance
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "Balance", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Balance")
-  public List<@Valid OBReadBalance1DataBalanceInner> getBalance() {
-    return balance;
-  }
-
-  public void setBalance(List<@Valid OBReadBalance1DataBalanceInner> balance) {
-    this.balance = balance;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1Data(List<@Valid OBReadBalance1DataBalanceInner> balance) {
+        this.balance = balance;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadBalance1Data balance(List<@Valid OBReadBalance1DataBalanceInner> balance) {
+        this.balance = balance;
+        return this;
     }
-    OBReadBalance1Data obReadBalance1Data = (OBReadBalance1Data) o;
-    return Objects.equals(this.balance, obReadBalance1Data.balance);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(balance);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1Data {\n");
-    sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadBalance1Data addBalanceItem(OBReadBalance1DataBalanceInner balanceItem) {
+        if (this.balance == null) {
+            this.balance = new ArrayList<>();
+        }
+        this.balance.add(balanceItem);
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get balance
+     *
+     * @return balance
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "Balance", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Balance")
+    public List<@Valid OBReadBalance1DataBalanceInner> getBalance() {
+        return balance;
+    }
+
+    public void setBalance(List<@Valid OBReadBalance1DataBalanceInner> balance) {
+        this.balance = balance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1Data obReadBalance1Data = (OBReadBalance1Data) o;
+        return Objects.equals(this.balance, obReadBalance1Data.balance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(balance);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1Data {\n");
+        sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInner.java
@@ -15,21 +15,36 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode2;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerAmount;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerCreditLineInner;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to define the balance details.
@@ -40,208 +55,219 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1DataBalanceInner {
 
-  private String accountId;
+    private String accountId;
 
-  private OBCreditDebitCode2 creditDebitIndicator;
+    private OBCreditDebitCode2 creditDebitIndicator;
 
-  private OBBalanceType1Code type;
+    private OBBalanceType1Code type;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime dateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime dateTime;
 
-  private OBReadBalance1DataBalanceInnerAmount amount;
+    private OBReadBalance1DataBalanceInnerAmount amount;
 
-  @Valid
-  private List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine;
+    @Valid
+    private List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine;
 
-  public OBReadBalance1DataBalanceInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1DataBalanceInner(String accountId, OBCreditDebitCode2 creditDebitIndicator, OBBalanceType1Code type, DateTime dateTime, OBReadBalance1DataBalanceInnerAmount amount) {
-    this.accountId = accountId;
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.type = type;
-    this.dateTime = dateTime;
-    this.amount = amount;
-  }
-
-  public OBReadBalance1DataBalanceInner accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBReadBalance1DataBalanceInner creditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode2 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBReadBalance1DataBalanceInner type(OBBalanceType1Code type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Get type
-   * @return type
-  */
-  @NotNull @Valid 
-  @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public OBBalanceType1Code getType() {
-    return type;
-  }
-
-  public void setType(OBBalanceType1Code type) {
-    this.type = type;
-  }
-
-  public OBReadBalance1DataBalanceInner dateTime(DateTime dateTime) {
-    this.dateTime = dateTime;
-    return this;
-  }
-
-  /**
-   * Indicates the date (and time) of the balance.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return dateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "DateTime", description = "Indicates the date (and time) of the balance.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("DateTime")
-  public DateTime getDateTime() {
-    return dateTime;
-  }
-
-  public void setDateTime(DateTime dateTime) {
-    this.dateTime = dateTime;
-  }
-
-  public OBReadBalance1DataBalanceInner amount(OBReadBalance1DataBalanceInnerAmount amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBReadBalance1DataBalanceInnerAmount getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBReadBalance1DataBalanceInnerAmount amount) {
-    this.amount = amount;
-  }
-
-  public OBReadBalance1DataBalanceInner creditLine(List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine) {
-    this.creditLine = creditLine;
-    return this;
-  }
-
-  public OBReadBalance1DataBalanceInner addCreditLineItem(OBReadBalance1DataBalanceInnerCreditLineInner creditLineItem) {
-    if (this.creditLine == null) {
-      this.creditLine = new ArrayList<>();
+    public OBReadBalance1DataBalanceInner() {
+        super();
     }
-    this.creditLine.add(creditLineItem);
-    return this;
-  }
 
-  /**
-   * Get creditLine
-   * @return creditLine
-  */
-  @Valid 
-  @Schema(name = "CreditLine", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditLine")
-  public List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> getCreditLine() {
-    return creditLine;
-  }
-
-  public void setCreditLine(List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine) {
-    this.creditLine = creditLine;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1DataBalanceInner(String accountId, OBCreditDebitCode2 creditDebitIndicator, OBBalanceType1Code type, DateTime dateTime, OBReadBalance1DataBalanceInnerAmount amount) {
+        this.accountId = accountId;
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.type = type;
+        this.dateTime = dateTime;
+        this.amount = amount;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadBalance1DataBalanceInner accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBReadBalance1DataBalanceInner obReadBalance1DataBalanceInner = (OBReadBalance1DataBalanceInner) o;
-    return Objects.equals(this.accountId, obReadBalance1DataBalanceInner.accountId) &&
-        Objects.equals(this.creditDebitIndicator, obReadBalance1DataBalanceInner.creditDebitIndicator) &&
-        Objects.equals(this.type, obReadBalance1DataBalanceInner.type) &&
-        Objects.equals(this.dateTime, obReadBalance1DataBalanceInner.dateTime) &&
-        Objects.equals(this.amount, obReadBalance1DataBalanceInner.amount) &&
-        Objects.equals(this.creditLine, obReadBalance1DataBalanceInner.creditLine);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, creditDebitIndicator, type, dateTime, amount, creditLine);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1DataBalanceInner {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    creditLine: ").append(toIndentedString(creditLine)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBReadBalance1DataBalanceInner creditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode2 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBReadBalance1DataBalanceInner type(OBBalanceType1Code type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public OBBalanceType1Code getType() {
+        return type;
+    }
+
+    public void setType(OBBalanceType1Code type) {
+        this.type = type;
+    }
+
+    public OBReadBalance1DataBalanceInner dateTime(DateTime dateTime) {
+        this.dateTime = dateTime;
+        return this;
+    }
+
+    /**
+     * Indicates the date (and time) of the balance.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return dateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "DateTime", description = "Indicates the date (and time) of the balance.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("DateTime")
+    public DateTime getDateTime() {
+        return dateTime;
+    }
+
+    public void setDateTime(DateTime dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    public OBReadBalance1DataBalanceInner amount(OBReadBalance1DataBalanceInnerAmount amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBReadBalance1DataBalanceInnerAmount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBReadBalance1DataBalanceInnerAmount amount) {
+        this.amount = amount;
+    }
+
+    public OBReadBalance1DataBalanceInner creditLine(List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine) {
+        this.creditLine = creditLine;
+        return this;
+    }
+
+    public OBReadBalance1DataBalanceInner addCreditLineItem(OBReadBalance1DataBalanceInnerCreditLineInner creditLineItem) {
+        if (this.creditLine == null) {
+            this.creditLine = new ArrayList<>();
+        }
+        this.creditLine.add(creditLineItem);
+        return this;
+    }
+
+    /**
+     * Get creditLine
+     *
+     * @return creditLine
+     */
+    @Valid
+    @Schema(name = "CreditLine", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditLine")
+    public List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> getCreditLine() {
+        return creditLine;
+    }
+
+    public void setCreditLine(List<@Valid OBReadBalance1DataBalanceInnerCreditLineInner> creditLine) {
+        this.creditLine = creditLine;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1DataBalanceInner obReadBalance1DataBalanceInner = (OBReadBalance1DataBalanceInner) o;
+        return Objects.equals(this.accountId, obReadBalance1DataBalanceInner.accountId) &&
+                Objects.equals(this.creditDebitIndicator, obReadBalance1DataBalanceInner.creditDebitIndicator) &&
+                Objects.equals(this.type, obReadBalance1DataBalanceInner.type) &&
+                Objects.equals(this.dateTime, obReadBalance1DataBalanceInner.dateTime) &&
+                Objects.equals(this.amount, obReadBalance1DataBalanceInner.amount) &&
+                Objects.equals(this.creditLine, obReadBalance1DataBalanceInner.creditLine);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, creditDebitIndicator, type, dateTime, amount, creditLine);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1DataBalanceInner {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    creditLine: ").append(toIndentedString(creditLine)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerAmount.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money of the cash balance.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1DataBalanceInnerAmount {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBReadBalance1DataBalanceInnerAmount() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1DataBalanceInnerAmount(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBReadBalance1DataBalanceInnerAmount amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBReadBalance1DataBalanceInnerAmount currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadBalance1DataBalanceInnerAmount() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1DataBalanceInnerAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBReadBalance1DataBalanceInnerAmount obReadBalance1DataBalanceInnerAmount = (OBReadBalance1DataBalanceInnerAmount) o;
-    return Objects.equals(this.amount, obReadBalance1DataBalanceInnerAmount.amount) &&
-        Objects.equals(this.currency, obReadBalance1DataBalanceInnerAmount.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1DataBalanceInnerAmount {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadBalance1DataBalanceInnerAmount amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBReadBalance1DataBalanceInnerAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1DataBalanceInnerAmount obReadBalance1DataBalanceInnerAmount = (OBReadBalance1DataBalanceInnerAmount) o;
+        return Objects.equals(this.amount, obReadBalance1DataBalanceInnerAmount.amount) &&
+                Objects.equals(this.currency, obReadBalance1DataBalanceInnerAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1DataBalanceInnerAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
@@ -15,17 +15,27 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerCreditLineInnerAmount;
+import uk.org.openbanking.datamodel.account.OBReadBalance1DataBalanceInnerCreditLineInnerType;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details on the credit line.
@@ -36,163 +46,125 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1DataBalanceInnerCreditLineInner {
 
-  private Boolean included;
+    private Boolean included;
 
-  /**
-   * Limit type, in a coded form.
-   */
-  public enum TypeEnum {
-    AVAILABLE("Available"),
-    
-    CREDIT("Credit"),
-    
-    EMERGENCY("Emergency"),
-    
-    PRE_AGREED("Pre-Agreed"),
-    
-    TEMPORARY("Temporary");
+    private OBReadBalance1DataBalanceInnerCreditLineInnerType type;
 
-    private String value;
+    private OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount;
 
-    TypeEnum(String value) {
-      this.value = value;
+    public OBReadBalance1DataBalanceInnerCreditLineInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1DataBalanceInnerCreditLineInner(Boolean included) {
+        this.included = included;
+    }
+
+    public OBReadBalance1DataBalanceInnerCreditLineInner included(Boolean included) {
+        this.included = included;
+        return this;
+    }
+
+    /**
+     * Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account.
+     *
+     * @return included
+     */
+    @NotNull
+    @Schema(name = "Included", description = "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Included")
+    public Boolean getIncluded() {
+        return included;
+    }
+
+    public void setIncluded(Boolean included) {
+        this.included = included;
+    }
+
+    public OBReadBalance1DataBalanceInnerCreditLineInner type(OBReadBalance1DataBalanceInnerCreditLineInnerType type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Type")
+    public OBReadBalance1DataBalanceInnerCreditLineInnerType getType() {
+        return type;
+    }
+
+    public void setType(OBReadBalance1DataBalanceInnerCreditLineInnerType type) {
+        this.type = type;
+    }
+
+    public OBReadBalance1DataBalanceInnerCreditLineInner amount(OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Amount")
+    public OBReadBalance1DataBalanceInnerCreditLineInnerAmount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1DataBalanceInnerCreditLineInner obReadBalance1DataBalanceInnerCreditLineInner = (OBReadBalance1DataBalanceInnerCreditLineInner) o;
+        return Objects.equals(this.included, obReadBalance1DataBalanceInnerCreditLineInner.included) &&
+                Objects.equals(this.type, obReadBalance1DataBalanceInnerCreditLineInner.type) &&
+                Objects.equals(this.amount, obReadBalance1DataBalanceInnerCreditLineInner.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(included, type, amount);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1DataBalanceInnerCreditLineInner {\n");
+        sb.append("    included: ").append(toIndentedString(included)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TypeEnum fromValue(String value) {
-      for (TypeEnum b : TypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TypeEnum type;
-
-  private OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount;
-
-  public OBReadBalance1DataBalanceInnerCreditLineInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1DataBalanceInnerCreditLineInner(Boolean included) {
-    this.included = included;
-  }
-
-  public OBReadBalance1DataBalanceInnerCreditLineInner included(Boolean included) {
-    this.included = included;
-    return this;
-  }
-
-  /**
-   * Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account.
-   * @return included
-  */
-  @NotNull 
-  @Schema(name = "Included", description = "Indicates whether or not the credit line is included in the balance of the account. Usage: If not present, credit line is not included in the balance amount of the account.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Included")
-  public Boolean getIncluded() {
-    return included;
-  }
-
-  public void setIncluded(Boolean included) {
-    this.included = included;
-  }
-
-  public OBReadBalance1DataBalanceInnerCreditLineInner type(TypeEnum type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Limit type, in a coded form.
-   * @return type
-  */
-  
-  @Schema(name = "Type", description = "Limit type, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Type")
-  public TypeEnum getType() {
-    return type;
-  }
-
-  public void setType(TypeEnum type) {
-    this.type = type;
-  }
-
-  public OBReadBalance1DataBalanceInnerCreditLineInner amount(OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Amount")
-  public OBReadBalance1DataBalanceInnerCreditLineInnerAmount getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadBalance1DataBalanceInnerCreditLineInner obReadBalance1DataBalanceInnerCreditLineInner = (OBReadBalance1DataBalanceInnerCreditLineInner) o;
-    return Objects.equals(this.included, obReadBalance1DataBalanceInnerCreditLineInner.included) &&
-        Objects.equals(this.type, obReadBalance1DataBalanceInnerCreditLineInner.type) &&
-        Objects.equals(this.amount, obReadBalance1DataBalanceInnerCreditLineInner.amount);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(included, type, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1DataBalanceInnerCreditLineInner {\n");
-    sb.append("    included: ").append(toIndentedString(included)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money of the credit line.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBalance1DataBalanceInnerCreditLineInnerAmount {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBReadBalance1DataBalanceInnerCreditLineInnerAmount() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBalance1DataBalanceInnerCreditLineInnerAmount(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBReadBalance1DataBalanceInnerCreditLineInnerAmount currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadBalance1DataBalanceInnerCreditLineInnerAmount() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBalance1DataBalanceInnerCreditLineInnerAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBReadBalance1DataBalanceInnerCreditLineInnerAmount obReadBalance1DataBalanceInnerCreditLineInnerAmount = (OBReadBalance1DataBalanceInnerCreditLineInnerAmount) o;
-    return Objects.equals(this.amount, obReadBalance1DataBalanceInnerCreditLineInnerAmount.amount) &&
-        Objects.equals(this.currency, obReadBalance1DataBalanceInnerCreditLineInnerAmount.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBalance1DataBalanceInnerCreditLineInnerAmount {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadBalance1DataBalanceInnerCreditLineInnerAmount amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBReadBalance1DataBalanceInnerCreditLineInnerAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBalance1DataBalanceInnerCreditLineInnerAmount obReadBalance1DataBalanceInnerCreditLineInnerAmount = (OBReadBalance1DataBalanceInnerCreditLineInnerAmount) o;
+        return Objects.equals(this.amount, obReadBalance1DataBalanceInnerCreditLineInnerAmount.amount) &&
+                Objects.equals(this.currency, obReadBalance1DataBalanceInnerCreditLineInnerAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBalance1DataBalanceInnerCreditLineInnerAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Limit type, in a coded form.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadBalance1DataBalanceInnerCreditLineInnerType {
+
+    AVAILABLE("Available"),
+
+    CREDIT("Credit"),
+
+    EMERGENCY("Emergency"),
+
+    PRE_AGREED("Pre-Agreed"),
+
+    TEMPORARY("Temporary");
+
+    private String value;
+
+    OBReadBalance1DataBalanceInnerCreditLineInnerType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadBalance1DataBalanceInnerCreditLineInnerType fromValue(String value) {
+        for (OBReadBalance1DataBalanceInnerCreditLineInnerType b : OBReadBalance1DataBalanceInnerCreditLineInnerType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBeneficiary5 {
 
-  private OBReadBeneficiary5Data data;
+    private OBReadBeneficiary5Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadBeneficiary5() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadBeneficiary5(OBReadBeneficiary5Data data) {
-    this.data = data;
-  }
-
-  public OBReadBeneficiary5 data(OBReadBeneficiary5Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadBeneficiary5Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadBeneficiary5Data data) {
-    this.data = data;
-  }
-
-  public OBReadBeneficiary5 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadBeneficiary5 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadBeneficiary5() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadBeneficiary5(OBReadBeneficiary5Data data) {
+        this.data = data;
     }
-    OBReadBeneficiary5 obReadBeneficiary5 = (OBReadBeneficiary5) o;
-    return Objects.equals(this.data, obReadBeneficiary5.data) &&
-        Objects.equals(this.links, obReadBeneficiary5.links) &&
-        Objects.equals(this.meta, obReadBeneficiary5.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBeneficiary5 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadBeneficiary5 data(OBReadBeneficiary5Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadBeneficiary5Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadBeneficiary5Data data) {
+        this.data = data;
+    }
+
+    public OBReadBeneficiary5 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadBeneficiary5 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBeneficiary5 obReadBeneficiary5 = (OBReadBeneficiary5) o;
+        return Objects.equals(this.data, obReadBeneficiary5.data) &&
+                Objects.equals(this.links, obReadBeneficiary5.links) &&
+                Objects.equals(this.meta, obReadBeneficiary5.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBeneficiary5 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
@@ -15,16 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBBeneficiary5;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadBeneficiary5Data
@@ -34,72 +47,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadBeneficiary5Data {
 
-  @Valid
-  private List<@Valid OBBeneficiary5> beneficiary;
+    @Valid
+    private List<@Valid OBBeneficiary5> beneficiary;
 
-  public OBReadBeneficiary5Data beneficiary(List<@Valid OBBeneficiary5> beneficiary) {
-    this.beneficiary = beneficiary;
-    return this;
-  }
-
-  public OBReadBeneficiary5Data addBeneficiaryItem(OBBeneficiary5 beneficiaryItem) {
-    if (this.beneficiary == null) {
-      this.beneficiary = new ArrayList<>();
+    public OBReadBeneficiary5Data beneficiary(List<@Valid OBBeneficiary5> beneficiary) {
+        this.beneficiary = beneficiary;
+        return this;
     }
-    this.beneficiary.add(beneficiaryItem);
-    return this;
-  }
 
-  /**
-   * Get beneficiary
-   * @return beneficiary
-  */
-  @Valid 
-  @Schema(name = "Beneficiary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Beneficiary")
-  public List<@Valid OBBeneficiary5> getBeneficiary() {
-    return beneficiary;
-  }
-
-  public void setBeneficiary(List<@Valid OBBeneficiary5> beneficiary) {
-    this.beneficiary = beneficiary;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadBeneficiary5Data addBeneficiaryItem(OBBeneficiary5 beneficiaryItem) {
+        if (this.beneficiary == null) {
+            this.beneficiary = new ArrayList<>();
+        }
+        this.beneficiary.add(beneficiaryItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get beneficiary
+     *
+     * @return beneficiary
+     */
+    @Valid
+    @Schema(name = "Beneficiary", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Beneficiary")
+    public List<@Valid OBBeneficiary5> getBeneficiary() {
+        return beneficiary;
     }
-    OBReadBeneficiary5Data obReadBeneficiary5Data = (OBReadBeneficiary5Data) o;
-    return Objects.equals(this.beneficiary, obReadBeneficiary5Data.beneficiary);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(beneficiary);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadBeneficiary5Data {\n");
-    sb.append("    beneficiary: ").append(toIndentedString(beneficiary)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setBeneficiary(List<@Valid OBBeneficiary5> beneficiary) {
+        this.beneficiary = beneficiary;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadBeneficiary5Data obReadBeneficiary5Data = (OBReadBeneficiary5Data) o;
+        return Objects.equals(this.beneficiary, obReadBeneficiary5Data.beneficiary);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(beneficiary);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadBeneficiary5Data {\n");
+        sb.append("    beneficiary: ").append(toIndentedString(beneficiary)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
@@ -31,99 +31,103 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadConsent1 {
 
-  private OBReadConsent1Data data;
+    private OBReadConsent1Data data;
 
-  private OBRisk2 risk;
+    private OBRisk2 risk;
 
-  public OBReadConsent1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadConsent1(OBReadConsent1Data data, OBRisk2 risk) {
-    this.data = data;
-    this.risk = risk;
-  }
-
-  public OBReadConsent1 data(OBReadConsent1Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadConsent1Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadConsent1Data data) {
-    this.data = data;
-  }
-
-  public OBReadConsent1 risk(OBRisk2 risk) {
-    this.risk = risk;
-    return this;
-  }
-
-  /**
-   * The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.
-   * @return risk
-  */
-  @NotNull 
-  @Schema(name = "Risk", description = "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Risk")
-  public OBRisk2 getRisk() {
-    return risk;
-  }
-
-  public void setRisk(OBRisk2 risk) {
-    this.risk = risk;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadConsent1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadConsent1(OBReadConsent1Data data, OBRisk2 risk) {
+        this.data = data;
+        this.risk = risk;
     }
-    OBReadConsent1 obReadConsent1 = (OBReadConsent1) o;
-    return Objects.equals(this.data, obReadConsent1.data) &&
-        Objects.equals(this.risk, obReadConsent1.risk);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, risk);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadConsent1 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    risk: ").append(toIndentedString(risk)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadConsent1 data(OBReadConsent1Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadConsent1Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadConsent1Data data) {
+        this.data = data;
+    }
+
+    public OBReadConsent1 risk(OBRisk2 risk) {
+        this.risk = risk;
+        return this;
+    }
+
+    /**
+     * Get risk
+     *
+     * @return risk
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Risk", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Risk")
+    public OBRisk2 getRisk() {
+        return risk;
+    }
+
+    public void setRisk(OBRisk2 risk) {
+        this.risk = risk;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadConsent1 obReadConsent1 = (OBReadConsent1) o;
+        return Objects.equals(this.data, obReadConsent1.data) &&
+                Objects.equals(this.risk, obReadConsent1.risk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, risk);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadConsent1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    risk: ").append(toIndentedString(risk)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
@@ -30,6 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
 
 /**
  * OBReadConsent1Data
@@ -39,158 +40,164 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadConsent1Data {
 
-  @Valid
-  private List<OBExternalPermissions1Code> permissions = new ArrayList<>();
+    @Valid
+    private List<@Valid OBExternalPermissions1Code> permissions = new ArrayList<>();
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime expirationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime expirationDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime transactionFromDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime transactionFromDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime transactionToDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime transactionToDateTime;
 
-  public OBReadConsent1Data() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadConsent1Data(List<OBExternalPermissions1Code> permissions) {
-    this.permissions = permissions;
-  }
-
-  public OBReadConsent1Data permissions(List<OBExternalPermissions1Code> permissions) {
-    this.permissions = permissions;
-    return this;
-  }
-
-  public OBReadConsent1Data addPermissionsItem(OBExternalPermissions1Code permissionsItem) {
-    if (this.permissions == null) {
-      this.permissions = new ArrayList<>();
+    public OBReadConsent1Data() {
+        super();
     }
-    this.permissions.add(permissionsItem);
-    return this;
-  }
 
-  /**
-   * Get permissions
-   * @return permissions
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "Permissions", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Permissions")
-  public List<OBExternalPermissions1Code> getPermissions() {
-    return permissions;
-  }
-
-  public void setPermissions(List<OBExternalPermissions1Code> permissions) {
-    this.permissions = permissions;
-  }
-
-  public OBReadConsent1Data expirationDateTime(DateTime expirationDateTime) {
-    this.expirationDateTime = expirationDateTime;
-    return this;
-  }
-
-  /**
-   * Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return expirationDateTime
-  */
-  @Valid 
-  @Schema(name = "ExpirationDateTime", description = "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ExpirationDateTime")
-  public DateTime getExpirationDateTime() {
-    return expirationDateTime;
-  }
-
-  public void setExpirationDateTime(DateTime expirationDateTime) {
-    this.expirationDateTime = expirationDateTime;
-  }
-
-  public OBReadConsent1Data transactionFromDateTime(DateTime transactionFromDateTime) {
-    this.transactionFromDateTime = transactionFromDateTime;
-    return this;
-  }
-
-  /**
-   * Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return transactionFromDateTime
-  */
-  @Valid 
-  @Schema(name = "TransactionFromDateTime", description = "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionFromDateTime")
-  public DateTime getTransactionFromDateTime() {
-    return transactionFromDateTime;
-  }
-
-  public void setTransactionFromDateTime(DateTime transactionFromDateTime) {
-    this.transactionFromDateTime = transactionFromDateTime;
-  }
-
-  public OBReadConsent1Data transactionToDateTime(DateTime transactionToDateTime) {
-    this.transactionToDateTime = transactionToDateTime;
-    return this;
-  }
-
-  /**
-   * Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return transactionToDateTime
-  */
-  @Valid 
-  @Schema(name = "TransactionToDateTime", description = "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionToDateTime")
-  public DateTime getTransactionToDateTime() {
-    return transactionToDateTime;
-  }
-
-  public void setTransactionToDateTime(DateTime transactionToDateTime) {
-    this.transactionToDateTime = transactionToDateTime;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadConsent1Data(List<@Valid OBExternalPermissions1Code> permissions) {
+        this.permissions = permissions;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadConsent1Data permissions(List<@Valid OBExternalPermissions1Code> permissions) {
+        this.permissions = permissions;
+        return this;
     }
-    OBReadConsent1Data obReadConsent1Data = (OBReadConsent1Data) o;
-    return Objects.equals(this.permissions, obReadConsent1Data.permissions) &&
-        Objects.equals(this.expirationDateTime, obReadConsent1Data.expirationDateTime) &&
-        Objects.equals(this.transactionFromDateTime, obReadConsent1Data.transactionFromDateTime) &&
-        Objects.equals(this.transactionToDateTime, obReadConsent1Data.transactionToDateTime);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(permissions, expirationDateTime, transactionFromDateTime, transactionToDateTime);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadConsent1Data {\n");
-    sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
-    sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
-    sb.append("    transactionFromDateTime: ").append(toIndentedString(transactionFromDateTime)).append("\n");
-    sb.append("    transactionToDateTime: ").append(toIndentedString(transactionToDateTime)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadConsent1Data addPermissionsItem(OBExternalPermissions1Code permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get permissions
+     *
+     * @return permissions
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "Permissions", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Permissions")
+    public List<@Valid OBExternalPermissions1Code> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(List<@Valid OBExternalPermissions1Code> permissions) {
+        this.permissions = permissions;
+    }
+
+    public OBReadConsent1Data expirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+        return this;
+    }
+
+    /**
+     * Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return expirationDateTime
+     */
+    @Valid
+    @Schema(name = "ExpirationDateTime", description = "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ExpirationDateTime")
+    public DateTime getExpirationDateTime() {
+        return expirationDateTime;
+    }
+
+    public void setExpirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public OBReadConsent1Data transactionFromDateTime(DateTime transactionFromDateTime) {
+        this.transactionFromDateTime = transactionFromDateTime;
+        return this;
+    }
+
+    /**
+     * Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return transactionFromDateTime
+     */
+    @Valid
+    @Schema(name = "TransactionFromDateTime", description = "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionFromDateTime")
+    public DateTime getTransactionFromDateTime() {
+        return transactionFromDateTime;
+    }
+
+    public void setTransactionFromDateTime(DateTime transactionFromDateTime) {
+        this.transactionFromDateTime = transactionFromDateTime;
+    }
+
+    public OBReadConsent1Data transactionToDateTime(DateTime transactionToDateTime) {
+        this.transactionToDateTime = transactionToDateTime;
+        return this;
+    }
+
+    /**
+     * Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return transactionToDateTime
+     */
+    @Valid
+    @Schema(name = "TransactionToDateTime", description = "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionToDateTime")
+    public DateTime getTransactionToDateTime() {
+        return transactionToDateTime;
+    }
+
+    public void setTransactionToDateTime(DateTime transactionToDateTime) {
+        this.transactionToDateTime = transactionToDateTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadConsent1Data obReadConsent1Data = (OBReadConsent1Data) o;
+        return Objects.equals(this.permissions, obReadConsent1Data.permissions) &&
+                Objects.equals(this.expirationDateTime, obReadConsent1Data.expirationDateTime) &&
+                Objects.equals(this.transactionFromDateTime, obReadConsent1Data.transactionFromDateTime) &&
+                Objects.equals(this.transactionToDateTime, obReadConsent1Data.transactionToDateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(permissions, expirationDateTime, transactionFromDateTime, transactionToDateTime);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadConsent1Data {\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
+        sb.append("    transactionFromDateTime: ").append(toIndentedString(transactionFromDateTime)).append("\n");
+        sb.append("    transactionToDateTime: ").append(toIndentedString(transactionToDateTime)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
@@ -15,16 +15,27 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.account.OBReadConsentResponse1Data;
+import uk.org.openbanking.datamodel.account.OBRisk2;
 import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadConsentResponse1
@@ -33,147 +44,153 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadConsentResponse1 {
 
-  private OBReadConsentResponse1Data data;
+    private OBReadConsentResponse1Data data;
 
-  private OBRisk2 risk;
+    private OBRisk2 risk;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadConsentResponse1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadConsentResponse1(OBReadConsentResponse1Data data, OBRisk2 risk) {
-    this.data = data;
-    this.risk = risk;
-  }
-
-  public OBReadConsentResponse1 data(OBReadConsentResponse1Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadConsentResponse1Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadConsentResponse1Data data) {
-    this.data = data;
-  }
-
-  public OBReadConsentResponse1 risk(OBRisk2 risk) {
-    this.risk = risk;
-    return this;
-  }
-
-  /**
-   * The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.
-   * @return risk
-  */
-  @NotNull 
-  @Schema(name = "Risk", description = "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Risk")
-  public OBRisk2 getRisk() {
-    return risk;
-  }
-
-  public void setRisk(OBRisk2 risk) {
-    this.risk = risk;
-  }
-
-  public OBReadConsentResponse1 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadConsentResponse1 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadConsentResponse1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadConsentResponse1(OBReadConsentResponse1Data data, OBRisk2 risk) {
+        this.data = data;
+        this.risk = risk;
     }
-    OBReadConsentResponse1 obReadConsentResponse1 = (OBReadConsentResponse1) o;
-    return Objects.equals(this.data, obReadConsentResponse1.data) &&
-        Objects.equals(this.risk, obReadConsentResponse1.risk) &&
-        Objects.equals(this.links, obReadConsentResponse1.links) &&
-        Objects.equals(this.meta, obReadConsentResponse1.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, risk, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadConsentResponse1 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    risk: ").append(toIndentedString(risk)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadConsentResponse1 data(OBReadConsentResponse1Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadConsentResponse1Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadConsentResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBReadConsentResponse1 risk(OBRisk2 risk) {
+        this.risk = risk;
+        return this;
+    }
+
+    /**
+     * Get risk
+     *
+     * @return risk
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Risk", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Risk")
+    public OBRisk2 getRisk() {
+        return risk;
+    }
+
+    public void setRisk(OBRisk2 risk) {
+        this.risk = risk;
+    }
+
+    public OBReadConsentResponse1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadConsentResponse1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadConsentResponse1 obReadConsentResponse1 = (OBReadConsentResponse1) o;
+        return Objects.equals(this.data, obReadConsentResponse1.data) &&
+                Objects.equals(this.risk, obReadConsentResponse1.risk) &&
+                Objects.equals(this.links, obReadConsentResponse1.links) &&
+                Objects.equals(this.meta, obReadConsentResponse1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, risk, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadConsentResponse1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    risk: ").append(toIndentedString(risk)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
@@ -15,22 +15,34 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.common.OBExternalPermissions1Code;
 import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadConsentResponse1Data
@@ -40,260 +52,274 @@ import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadConsentResponse1Data {
 
-  private String consentId;
+    private String consentId;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime creationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
 
-  private OBExternalRequestStatus1Code status;
+    private OBExternalRequestStatus1Code status;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime statusUpdateDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime statusUpdateDateTime;
 
-  @Valid
-  private List<OBExternalPermissions1Code> permissions = new ArrayList<>();
+    @Valid
+    private List<@Valid OBExternalPermissions1Code> permissions = new ArrayList<>();
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime expirationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime expirationDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime transactionFromDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime transactionFromDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime transactionToDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime transactionToDateTime;
 
-  public OBReadConsentResponse1Data() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadConsentResponse1Data(String consentId, DateTime creationDateTime, OBExternalRequestStatus1Code status, DateTime statusUpdateDateTime, List<OBExternalPermissions1Code> permissions) {
-    this.consentId = consentId;
-    this.creationDateTime = creationDateTime;
-    this.status = status;
-    this.statusUpdateDateTime = statusUpdateDateTime;
-    this.permissions = permissions;
-  }
-
-  public OBReadConsentResponse1Data consentId(String consentId) {
-    this.consentId = consentId;
-    return this;
-  }
-
-  /**
-   * Unique identification as assigned to identify the account access consent resource.
-   * @return consentId
-  */
-  @NotNull @Size(min = 1, max = 128) 
-  @Schema(name = "ConsentId", description = "Unique identification as assigned to identify the account access consent resource.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ConsentId")
-  public String getConsentId() {
-    return consentId;
-  }
-
-  public void setConsentId(String consentId) {
-    this.consentId = consentId;
-  }
-
-  public OBReadConsentResponse1Data creationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return creationDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreationDateTime")
-  public DateTime getCreationDateTime() {
-    return creationDateTime;
-  }
-
-  public void setCreationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBReadConsentResponse1Data status(OBExternalRequestStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Specifies the status of consent resource in code form.
-   * @return status
-  */
-  @NotNull 
-  @Schema(name = "Status", description = "Specifies the status of consent resource in code form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Status")
-  public OBExternalRequestStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBExternalRequestStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBReadConsentResponse1Data statusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return statusUpdateDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("StatusUpdateDateTime")
-  public DateTime getStatusUpdateDateTime() {
-    return statusUpdateDateTime;
-  }
-
-  public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
-    this.statusUpdateDateTime = statusUpdateDateTime;
-  }
-
-  public OBReadConsentResponse1Data permissions(List<OBExternalPermissions1Code> permissions) {
-    this.permissions = permissions;
-    return this;
-  }
-
-  public OBReadConsentResponse1Data addPermissionsItem(OBExternalPermissions1Code permissionsItem) {
-    if (this.permissions == null) {
-      this.permissions = new ArrayList<>();
+    public OBReadConsentResponse1Data() {
+        super();
     }
-    this.permissions.add(permissionsItem);
-    return this;
-  }
 
-  /**
-   * Get permissions
-   * @return permissions
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "Permissions", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Permissions")
-  public List<OBExternalPermissions1Code> getPermissions() {
-    return permissions;
-  }
-
-  public void setPermissions(List<OBExternalPermissions1Code> permissions) {
-    this.permissions = permissions;
-  }
-
-  public OBReadConsentResponse1Data expirationDateTime(DateTime expirationDateTime) {
-    this.expirationDateTime = expirationDateTime;
-    return this;
-  }
-
-  /**
-   * Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return expirationDateTime
-  */
-  @Valid 
-  @Schema(name = "ExpirationDateTime", description = "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ExpirationDateTime")
-  public DateTime getExpirationDateTime() {
-    return expirationDateTime;
-  }
-
-  public void setExpirationDateTime(DateTime expirationDateTime) {
-    this.expirationDateTime = expirationDateTime;
-  }
-
-  public OBReadConsentResponse1Data transactionFromDateTime(DateTime transactionFromDateTime) {
-    this.transactionFromDateTime = transactionFromDateTime;
-    return this;
-  }
-
-  /**
-   * Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return transactionFromDateTime
-  */
-  @Valid 
-  @Schema(name = "TransactionFromDateTime", description = "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionFromDateTime")
-  public DateTime getTransactionFromDateTime() {
-    return transactionFromDateTime;
-  }
-
-  public void setTransactionFromDateTime(DateTime transactionFromDateTime) {
-    this.transactionFromDateTime = transactionFromDateTime;
-  }
-
-  public OBReadConsentResponse1Data transactionToDateTime(DateTime transactionToDateTime) {
-    this.transactionToDateTime = transactionToDateTime;
-    return this;
-  }
-
-  /**
-   * Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return transactionToDateTime
-  */
-  @Valid 
-  @Schema(name = "TransactionToDateTime", description = "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionToDateTime")
-  public DateTime getTransactionToDateTime() {
-    return transactionToDateTime;
-  }
-
-  public void setTransactionToDateTime(DateTime transactionToDateTime) {
-    this.transactionToDateTime = transactionToDateTime;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadConsentResponse1Data(String consentId, DateTime creationDateTime, OBExternalRequestStatus1Code status, DateTime statusUpdateDateTime, List<@Valid OBExternalPermissions1Code> permissions) {
+        this.consentId = consentId;
+        this.creationDateTime = creationDateTime;
+        this.status = status;
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        this.permissions = permissions;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadConsentResponse1Data consentId(String consentId) {
+        this.consentId = consentId;
+        return this;
     }
-    OBReadConsentResponse1Data obReadConsentResponse1Data = (OBReadConsentResponse1Data) o;
-    return Objects.equals(this.consentId, obReadConsentResponse1Data.consentId) &&
-        Objects.equals(this.creationDateTime, obReadConsentResponse1Data.creationDateTime) &&
-        Objects.equals(this.status, obReadConsentResponse1Data.status) &&
-        Objects.equals(this.statusUpdateDateTime, obReadConsentResponse1Data.statusUpdateDateTime) &&
-        Objects.equals(this.permissions, obReadConsentResponse1Data.permissions) &&
-        Objects.equals(this.expirationDateTime, obReadConsentResponse1Data.expirationDateTime) &&
-        Objects.equals(this.transactionFromDateTime, obReadConsentResponse1Data.transactionFromDateTime) &&
-        Objects.equals(this.transactionToDateTime, obReadConsentResponse1Data.transactionToDateTime);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(consentId, creationDateTime, status, statusUpdateDateTime, permissions, expirationDateTime, transactionFromDateTime, transactionToDateTime);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadConsentResponse1Data {\n");
-    sb.append("    consentId: ").append(toIndentedString(consentId)).append("\n");
-    sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
-    sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
-    sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
-    sb.append("    transactionFromDateTime: ").append(toIndentedString(transactionFromDateTime)).append("\n");
-    sb.append("    transactionToDateTime: ").append(toIndentedString(transactionToDateTime)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Unique identification as assigned to identify the account access consent resource.
+     *
+     * @return consentId
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "ConsentId", description = "Unique identification as assigned to identify the account access consent resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ConsentId")
+    public String getConsentId() {
+        return consentId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public OBReadConsentResponse1Data creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBReadConsentResponse1Data status(OBExternalRequestStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Status")
+    public OBExternalRequestStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBExternalRequestStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBReadConsentResponse1Data statusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return statusUpdateDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("StatusUpdateDateTime")
+    public DateTime getStatusUpdateDateTime() {
+        return statusUpdateDateTime;
+    }
+
+    public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+    }
+
+    public OBReadConsentResponse1Data permissions(List<@Valid OBExternalPermissions1Code> permissions) {
+        this.permissions = permissions;
+        return this;
+    }
+
+    public OBReadConsentResponse1Data addPermissionsItem(OBExternalPermissions1Code permissionsItem) {
+        if (this.permissions == null) {
+            this.permissions = new ArrayList<>();
+        }
+        this.permissions.add(permissionsItem);
+        return this;
+    }
+
+    /**
+     * Get permissions
+     *
+     * @return permissions
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "Permissions", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Permissions")
+    public List<@Valid OBExternalPermissions1Code> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(List<@Valid OBExternalPermissions1Code> permissions) {
+        this.permissions = permissions;
+    }
+
+    public OBReadConsentResponse1Data expirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+        return this;
+    }
+
+    /**
+     * Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return expirationDateTime
+     */
+    @Valid
+    @Schema(name = "ExpirationDateTime", description = "Specified date and time the permissions will expire. If this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ExpirationDateTime")
+    public DateTime getExpirationDateTime() {
+        return expirationDateTime;
+    }
+
+    public void setExpirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public OBReadConsentResponse1Data transactionFromDateTime(DateTime transactionFromDateTime) {
+        this.transactionFromDateTime = transactionFromDateTime;
+        return this;
+    }
+
+    /**
+     * Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return transactionFromDateTime
+     */
+    @Valid
+    @Schema(name = "TransactionFromDateTime", description = "Specified start date and time for the transaction query period. If this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionFromDateTime")
+    public DateTime getTransactionFromDateTime() {
+        return transactionFromDateTime;
+    }
+
+    public void setTransactionFromDateTime(DateTime transactionFromDateTime) {
+        this.transactionFromDateTime = transactionFromDateTime;
+    }
+
+    public OBReadConsentResponse1Data transactionToDateTime(DateTime transactionToDateTime) {
+        this.transactionToDateTime = transactionToDateTime;
+        return this;
+    }
+
+    /**
+     * Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return transactionToDateTime
+     */
+    @Valid
+    @Schema(name = "TransactionToDateTime", description = "Specified end date and time for the transaction query period. If this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionToDateTime")
+    public DateTime getTransactionToDateTime() {
+        return transactionToDateTime;
+    }
+
+    public void setTransactionToDateTime(DateTime transactionToDateTime) {
+        this.transactionToDateTime = transactionToDateTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadConsentResponse1Data obReadConsentResponse1Data = (OBReadConsentResponse1Data) o;
+        return Objects.equals(this.consentId, obReadConsentResponse1Data.consentId) &&
+                Objects.equals(this.creationDateTime, obReadConsentResponse1Data.creationDateTime) &&
+                Objects.equals(this.status, obReadConsentResponse1Data.status) &&
+                Objects.equals(this.statusUpdateDateTime, obReadConsentResponse1Data.statusUpdateDateTime) &&
+                Objects.equals(this.permissions, obReadConsentResponse1Data.permissions) &&
+                Objects.equals(this.expirationDateTime, obReadConsentResponse1Data.expirationDateTime) &&
+                Objects.equals(this.transactionFromDateTime, obReadConsentResponse1Data.transactionFromDateTime) &&
+                Objects.equals(this.transactionToDateTime, obReadConsentResponse1Data.transactionToDateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(consentId, creationDateTime, status, statusUpdateDateTime, permissions, expirationDateTime, transactionFromDateTime, transactionToDateTime);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadConsentResponse1Data {\n");
+        sb.append("    consentId: ").append(toIndentedString(consentId)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
+        sb.append("    permissions: ").append(toIndentedString(permissions)).append("\n");
+        sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
+        sb.append("    transactionFromDateTime: ").append(toIndentedString(transactionFromDateTime)).append("\n");
+        sb.append("    transactionToDateTime: ").append(toIndentedString(transactionToDateTime)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
@@ -15,15 +15,28 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBStatement2;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadDataStatement2
@@ -32,72 +45,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadDataStatement2 {
 
-  @Valid
-  private List<@Valid OBStatement2> statement;
+    @Valid
+    private List<@Valid OBStatement2> statement;
 
-  public OBReadDataStatement2 statement(List<@Valid OBStatement2> statement) {
-    this.statement = statement;
-    return this;
-  }
-
-  public OBReadDataStatement2 addStatementItem(OBStatement2 statementItem) {
-    if (this.statement == null) {
-      this.statement = new ArrayList<>();
+    public OBReadDataStatement2 statement(List<@Valid OBStatement2> statement) {
+        this.statement = statement;
+        return this;
     }
-    this.statement.add(statementItem);
-    return this;
-  }
 
-  /**
-   * Get statement
-   * @return statement
-  */
-  @Valid 
-  @Schema(name = "Statement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Statement")
-  public List<@Valid OBStatement2> getStatement() {
-    return statement;
-  }
-
-  public void setStatement(List<@Valid OBStatement2> statement) {
-    this.statement = statement;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadDataStatement2 addStatementItem(OBStatement2 statementItem) {
+        if (this.statement == null) {
+            this.statement = new ArrayList<>();
+        }
+        this.statement.add(statementItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get statement
+     *
+     * @return statement
+     */
+    @Valid
+    @Schema(name = "Statement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Statement")
+    public List<@Valid OBStatement2> getStatement() {
+        return statement;
     }
-    OBReadDataStatement2 obReadDataStatement2 = (OBReadDataStatement2) o;
-    return Objects.equals(this.statement, obReadDataStatement2.statement);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(statement);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadDataStatement2 {\n");
-    sb.append("    statement: ").append(toIndentedString(statement)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setStatement(List<@Valid OBStatement2> statement) {
+        this.statement = statement;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadDataStatement2 obReadDataStatement2 = (OBReadDataStatement2) o;
+        return Objects.equals(this.statement, obReadDataStatement2.statement);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statement);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadDataStatement2 {\n");
+        sb.append("    statement: ").append(toIndentedString(statement)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
@@ -15,15 +15,28 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBTransaction6;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadDataTransaction6
@@ -32,72 +45,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadDataTransaction6 {
 
-  @Valid
-  private List<@Valid OBTransaction6> transaction;
+    @Valid
+    private List<@Valid OBTransaction6> transaction;
 
-  public OBReadDataTransaction6 transaction(List<@Valid OBTransaction6> transaction) {
-    this.transaction = transaction;
-    return this;
-  }
-
-  public OBReadDataTransaction6 addTransactionItem(OBTransaction6 transactionItem) {
-    if (this.transaction == null) {
-      this.transaction = new ArrayList<>();
+    public OBReadDataTransaction6 transaction(List<@Valid OBTransaction6> transaction) {
+        this.transaction = transaction;
+        return this;
     }
-    this.transaction.add(transactionItem);
-    return this;
-  }
 
-  /**
-   * Get transaction
-   * @return transaction
-  */
-  @Valid 
-  @Schema(name = "Transaction", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Transaction")
-  public List<@Valid OBTransaction6> getTransaction() {
-    return transaction;
-  }
-
-  public void setTransaction(List<@Valid OBTransaction6> transaction) {
-    this.transaction = transaction;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadDataTransaction6 addTransactionItem(OBTransaction6 transactionItem) {
+        if (this.transaction == null) {
+            this.transaction = new ArrayList<>();
+        }
+        this.transaction.add(transactionItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get transaction
+     *
+     * @return transaction
+     */
+    @Valid
+    @Schema(name = "Transaction", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Transaction")
+    public List<@Valid OBTransaction6> getTransaction() {
+        return transaction;
     }
-    OBReadDataTransaction6 obReadDataTransaction6 = (OBReadDataTransaction6) o;
-    return Objects.equals(this.transaction, obReadDataTransaction6.transaction);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(transaction);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadDataTransaction6 {\n");
-    sb.append("    transaction: ").append(toIndentedString(transaction)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setTransaction(List<@Valid OBTransaction6> transaction) {
+        this.transaction = transaction;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadDataTransaction6 obReadDataTransaction6 = (OBReadDataTransaction6) o;
+        return Objects.equals(this.transaction, obReadDataTransaction6.transaction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transaction);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadDataTransaction6 {\n");
+        sb.append("    transaction: ").append(toIndentedString(transaction)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.account.OBReadDirectDebit2Data;
 import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadDirectDebit2
@@ -33,122 +43,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadDirectDebit2 {
 
-  private OBReadDirectDebit2Data data;
+    private OBReadDirectDebit2Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadDirectDebit2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadDirectDebit2(OBReadDirectDebit2Data data) {
-    this.data = data;
-  }
-
-  public OBReadDirectDebit2 data(OBReadDirectDebit2Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadDirectDebit2Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadDirectDebit2Data data) {
-    this.data = data;
-  }
-
-  public OBReadDirectDebit2 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadDirectDebit2 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadDirectDebit2() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadDirectDebit2(OBReadDirectDebit2Data data) {
+        this.data = data;
     }
-    OBReadDirectDebit2 obReadDirectDebit2 = (OBReadDirectDebit2) o;
-    return Objects.equals(this.data, obReadDirectDebit2.data) &&
-        Objects.equals(this.links, obReadDirectDebit2.links) &&
-        Objects.equals(this.meta, obReadDirectDebit2.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadDirectDebit2 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadDirectDebit2 data(OBReadDirectDebit2Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadDirectDebit2Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadDirectDebit2Data data) {
+        this.data = data;
+    }
+
+    public OBReadDirectDebit2 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadDirectDebit2 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadDirectDebit2 obReadDirectDebit2 = (OBReadDirectDebit2) o;
+        return Objects.equals(this.data, obReadDirectDebit2.data) &&
+                Objects.equals(this.links, obReadDirectDebit2.links) &&
+                Objects.equals(this.meta, obReadDirectDebit2.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadDirectDebit2 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
@@ -15,16 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadDirectDebit2DataDirectDebitInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadDirectDebit2Data
@@ -34,72 +47,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadDirectDebit2Data {
 
-  @Valid
-  private List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit;
+    @Valid
+    private List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit;
 
-  public OBReadDirectDebit2Data directDebit(List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit) {
-    this.directDebit = directDebit;
-    return this;
-  }
-
-  public OBReadDirectDebit2Data addDirectDebitItem(OBReadDirectDebit2DataDirectDebitInner directDebitItem) {
-    if (this.directDebit == null) {
-      this.directDebit = new ArrayList<>();
+    public OBReadDirectDebit2Data directDebit(List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit) {
+        this.directDebit = directDebit;
+        return this;
     }
-    this.directDebit.add(directDebitItem);
-    return this;
-  }
 
-  /**
-   * Get directDebit
-   * @return directDebit
-  */
-  @Valid 
-  @Schema(name = "DirectDebit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DirectDebit")
-  public List<@Valid OBReadDirectDebit2DataDirectDebitInner> getDirectDebit() {
-    return directDebit;
-  }
-
-  public void setDirectDebit(List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit) {
-    this.directDebit = directDebit;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadDirectDebit2Data addDirectDebitItem(OBReadDirectDebit2DataDirectDebitInner directDebitItem) {
+        if (this.directDebit == null) {
+            this.directDebit = new ArrayList<>();
+        }
+        this.directDebit.add(directDebitItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get directDebit
+     *
+     * @return directDebit
+     */
+    @Valid
+    @Schema(name = "DirectDebit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DirectDebit")
+    public List<@Valid OBReadDirectDebit2DataDirectDebitInner> getDirectDebit() {
+        return directDebit;
     }
-    OBReadDirectDebit2Data obReadDirectDebit2Data = (OBReadDirectDebit2Data) o;
-    return Objects.equals(this.directDebit, obReadDirectDebit2Data.directDebit);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(directDebit);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadDirectDebit2Data {\n");
-    sb.append("    directDebit: ").append(toIndentedString(directDebit)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setDirectDebit(List<@Valid OBReadDirectDebit2DataDirectDebitInner> directDebit) {
+        this.directDebit = directDebit;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadDirectDebit2Data obReadDirectDebit2Data = (OBReadDirectDebit2Data) o;
+        return Objects.equals(this.directDebit, obReadDirectDebit2Data.directDebit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(directDebit);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadDirectDebit2Data {\n");
+        sb.append("    directDebit: ").append(toIndentedString(directDebit)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebitInner.java
@@ -15,19 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount0;
+import uk.org.openbanking.datamodel.account.OBExternalDirectDebitStatus1Code;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Account to or from which a cash entry is made.
@@ -38,245 +49,256 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadDirectDebit2DataDirectDebitInner {
 
-  private String accountId;
+    private String accountId;
 
-  private String directDebitId;
+    private String directDebitId;
 
-  private String mandateIdentification;
+    private String mandateIdentification;
 
-  private OBExternalDirectDebitStatus1Code directDebitStatusCode;
+    private OBExternalDirectDebitStatus1Code directDebitStatusCode;
 
-  private String name;
+    private String name;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime previousPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime previousPaymentDateTime;
 
-  private String frequency;
+    private String frequency;
 
-  private OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount;
+    private OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount;
 
-  public OBReadDirectDebit2DataDirectDebitInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadDirectDebit2DataDirectDebitInner(String accountId, String mandateIdentification, String name) {
-    this.accountId = accountId;
-    this.mandateIdentification = mandateIdentification;
-    this.name = name;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner directDebitId(String directDebitId) {
-    this.directDebitId = directDebitId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner.
-   * @return directDebitId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "DirectDebitId", description = "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DirectDebitId")
-  public String getDirectDebitId() {
-    return directDebitId;
-  }
-
-  public void setDirectDebitId(String directDebitId) {
-    this.directDebitId = directDebitId;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner mandateIdentification(String mandateIdentification) {
-    this.mandateIdentification = mandateIdentification;
-    return this;
-  }
-
-  /**
-   * Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference.
-   * @return mandateIdentification
-  */
-  @NotNull @Size(min = 1, max = 35) 
-  @Schema(name = "MandateIdentification", description = "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MandateIdentification")
-  public String getMandateIdentification() {
-    return mandateIdentification;
-  }
-
-  public void setMandateIdentification(String mandateIdentification) {
-    this.mandateIdentification = mandateIdentification;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner directDebitStatusCode(OBExternalDirectDebitStatus1Code directDebitStatusCode) {
-    this.directDebitStatusCode = directDebitStatusCode;
-    return this;
-  }
-
-  /**
-   * Get directDebitStatusCode
-   * @return directDebitStatusCode
-  */
-  @Valid 
-  @Schema(name = "DirectDebitStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DirectDebitStatusCode")
-  public OBExternalDirectDebitStatus1Code getDirectDebitStatusCode() {
-    return directDebitStatusCode;
-  }
-
-  public void setDirectDebitStatusCode(OBExternalDirectDebitStatus1Code directDebitStatusCode) {
-    this.directDebitStatusCode = directDebitStatusCode;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name of Service User.
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Name of Service User.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner previousPaymentDateTime(DateTime previousPaymentDateTime) {
-    this.previousPaymentDateTime = previousPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * Date of most recent direct debit collection.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return previousPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "PreviousPaymentDateTime", description = "Date of most recent direct debit collection.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PreviousPaymentDateTime")
-  public DateTime getPreviousPaymentDateTime() {
-    return previousPaymentDateTime;
-  }
-
-  public void setPreviousPaymentDateTime(DateTime previousPaymentDateTime) {
-    this.previousPaymentDateTime = previousPaymentDateTime;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * Regularity with which direct debit instructions are to be created and processed.
-   * @return frequency
-  */
-  
-  @Schema(name = "Frequency", description = "Regularity with which direct debit instructions are to be created and processed.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBReadDirectDebit2DataDirectDebitInner previousPaymentAmount(OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount) {
-    this.previousPaymentAmount = previousPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get previousPaymentAmount
-   * @return previousPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "PreviousPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PreviousPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount0 getPreviousPaymentAmount() {
-    return previousPaymentAmount;
-  }
-
-  public void setPreviousPaymentAmount(OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount) {
-    this.previousPaymentAmount = previousPaymentAmount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadDirectDebit2DataDirectDebitInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadDirectDebit2DataDirectDebitInner(String accountId, String mandateIdentification, String name) {
+        this.accountId = accountId;
+        this.mandateIdentification = mandateIdentification;
+        this.name = name;
     }
-    OBReadDirectDebit2DataDirectDebitInner obReadDirectDebit2DataDirectDebitInner = (OBReadDirectDebit2DataDirectDebitInner) o;
-    return Objects.equals(this.accountId, obReadDirectDebit2DataDirectDebitInner.accountId) &&
-        Objects.equals(this.directDebitId, obReadDirectDebit2DataDirectDebitInner.directDebitId) &&
-        Objects.equals(this.mandateIdentification, obReadDirectDebit2DataDirectDebitInner.mandateIdentification) &&
-        Objects.equals(this.directDebitStatusCode, obReadDirectDebit2DataDirectDebitInner.directDebitStatusCode) &&
-        Objects.equals(this.name, obReadDirectDebit2DataDirectDebitInner.name) &&
-        Objects.equals(this.previousPaymentDateTime, obReadDirectDebit2DataDirectDebitInner.previousPaymentDateTime) &&
-        Objects.equals(this.frequency, obReadDirectDebit2DataDirectDebitInner.frequency) &&
-        Objects.equals(this.previousPaymentAmount, obReadDirectDebit2DataDirectDebitInner.previousPaymentAmount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, directDebitId, mandateIdentification, directDebitStatusCode, name, previousPaymentDateTime, frequency, previousPaymentAmount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadDirectDebit2DataDirectDebitInner {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    directDebitId: ").append(toIndentedString(directDebitId)).append("\n");
-    sb.append("    mandateIdentification: ").append(toIndentedString(mandateIdentification)).append("\n");
-    sb.append("    directDebitStatusCode: ").append(toIndentedString(directDebitStatusCode)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    previousPaymentDateTime: ").append(toIndentedString(previousPaymentDateTime)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    previousPaymentAmount: ").append(toIndentedString(previousPaymentAmount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadDirectDebit2DataDirectDebitInner accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner directDebitId(String directDebitId) {
+        this.directDebitId = directDebitId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner.
+     *
+     * @return directDebitId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "DirectDebitId", description = "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DirectDebitId")
+    public String getDirectDebitId() {
+        return directDebitId;
+    }
+
+    public void setDirectDebitId(String directDebitId) {
+        this.directDebitId = directDebitId;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner mandateIdentification(String mandateIdentification) {
+        this.mandateIdentification = mandateIdentification;
+        return this;
+    }
+
+    /**
+     * Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference.
+     *
+     * @return mandateIdentification
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "MandateIdentification", description = "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MandateIdentification")
+    public String getMandateIdentification() {
+        return mandateIdentification;
+    }
+
+    public void setMandateIdentification(String mandateIdentification) {
+        this.mandateIdentification = mandateIdentification;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner directDebitStatusCode(OBExternalDirectDebitStatus1Code directDebitStatusCode) {
+        this.directDebitStatusCode = directDebitStatusCode;
+        return this;
+    }
+
+    /**
+     * Get directDebitStatusCode
+     *
+     * @return directDebitStatusCode
+     */
+    @Valid
+    @Schema(name = "DirectDebitStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DirectDebitStatusCode")
+    public OBExternalDirectDebitStatus1Code getDirectDebitStatusCode() {
+        return directDebitStatusCode;
+    }
+
+    public void setDirectDebitStatusCode(OBExternalDirectDebitStatus1Code directDebitStatusCode) {
+        this.directDebitStatusCode = directDebitStatusCode;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name of Service User.
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Name of Service User.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner previousPaymentDateTime(DateTime previousPaymentDateTime) {
+        this.previousPaymentDateTime = previousPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * Date of most recent direct debit collection.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return previousPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "PreviousPaymentDateTime", description = "Date of most recent direct debit collection.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PreviousPaymentDateTime")
+    public DateTime getPreviousPaymentDateTime() {
+        return previousPaymentDateTime;
+    }
+
+    public void setPreviousPaymentDateTime(DateTime previousPaymentDateTime) {
+        this.previousPaymentDateTime = previousPaymentDateTime;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * Regularity with which direct debit instructions are to be created and processed.
+     *
+     * @return frequency
+     */
+
+    @Schema(name = "Frequency", description = "Regularity with which direct debit instructions are to be created and processed.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBReadDirectDebit2DataDirectDebitInner previousPaymentAmount(OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount) {
+        this.previousPaymentAmount = previousPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get previousPaymentAmount
+     *
+     * @return previousPaymentAmount
+     */
+    @Valid
+    @Schema(name = "PreviousPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PreviousPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount0 getPreviousPaymentAmount() {
+        return previousPaymentAmount;
+    }
+
+    public void setPreviousPaymentAmount(OBActiveOrHistoricCurrencyAndAmount0 previousPaymentAmount) {
+        this.previousPaymentAmount = previousPaymentAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadDirectDebit2DataDirectDebitInner obReadDirectDebit2DataDirectDebitInner = (OBReadDirectDebit2DataDirectDebitInner) o;
+        return Objects.equals(this.accountId, obReadDirectDebit2DataDirectDebitInner.accountId) &&
+                Objects.equals(this.directDebitId, obReadDirectDebit2DataDirectDebitInner.directDebitId) &&
+                Objects.equals(this.mandateIdentification, obReadDirectDebit2DataDirectDebitInner.mandateIdentification) &&
+                Objects.equals(this.directDebitStatusCode, obReadDirectDebit2DataDirectDebitInner.directDebitStatusCode) &&
+                Objects.equals(this.name, obReadDirectDebit2DataDirectDebitInner.name) &&
+                Objects.equals(this.previousPaymentDateTime, obReadDirectDebit2DataDirectDebitInner.previousPaymentDateTime) &&
+                Objects.equals(this.frequency, obReadDirectDebit2DataDirectDebitInner.frequency) &&
+                Objects.equals(this.previousPaymentAmount, obReadDirectDebit2DataDirectDebitInner.previousPaymentAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, directDebitId, mandateIdentification, directDebitStatusCode, name, previousPaymentDateTime, frequency, previousPaymentAmount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadDirectDebit2DataDirectDebitInner {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    directDebitId: ").append(toIndentedString(directDebitId)).append("\n");
+        sb.append("    mandateIdentification: ").append(toIndentedString(mandateIdentification)).append("\n");
+        sb.append("    directDebitStatusCode: ").append(toIndentedString(directDebitStatusCode)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    previousPaymentDateTime: ").append(toIndentedString(previousPaymentDateTime)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    previousPaymentAmount: ").append(toIndentedString(previousPaymentAmount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadOffer1 {
 
-  private OBReadOffer1Data data;
+    private OBReadOffer1Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadOffer1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadOffer1(OBReadOffer1Data data) {
-    this.data = data;
-  }
-
-  public OBReadOffer1 data(OBReadOffer1Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadOffer1Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadOffer1Data data) {
-    this.data = data;
-  }
-
-  public OBReadOffer1 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadOffer1 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadOffer1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadOffer1(OBReadOffer1Data data) {
+        this.data = data;
     }
-    OBReadOffer1 obReadOffer1 = (OBReadOffer1) o;
-    return Objects.equals(this.data, obReadOffer1.data) &&
-        Objects.equals(this.links, obReadOffer1.links) &&
-        Objects.equals(this.meta, obReadOffer1.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadOffer1 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadOffer1 data(OBReadOffer1Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadOffer1Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadOffer1Data data) {
+        this.data = data;
+    }
+
+    public OBReadOffer1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadOffer1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadOffer1 obReadOffer1 = (OBReadOffer1) o;
+        return Objects.equals(this.data, obReadOffer1.data) &&
+                Objects.equals(this.links, obReadOffer1.links) &&
+                Objects.equals(this.meta, obReadOffer1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadOffer1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
@@ -34,72 +34,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadOffer1Data {
 
-  @Valid
-  private List<@Valid OBReadOffer1DataOfferInner> offer;
+    @Valid
+    private List<@Valid OBReadOffer1DataOfferInner> offer;
 
-  public OBReadOffer1Data offer(List<@Valid OBReadOffer1DataOfferInner> offer) {
-    this.offer = offer;
-    return this;
-  }
-
-  public OBReadOffer1Data addOfferItem(OBReadOffer1DataOfferInner offerItem) {
-    if (this.offer == null) {
-      this.offer = new ArrayList<>();
+    public OBReadOffer1Data offer(List<@Valid OBReadOffer1DataOfferInner> offer) {
+        this.offer = offer;
+        return this;
     }
-    this.offer.add(offerItem);
-    return this;
-  }
 
-  /**
-   * Get offer
-   * @return offer
-  */
-  @Valid 
-  @Schema(name = "Offer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Offer")
-  public List<@Valid OBReadOffer1DataOfferInner> getOffer() {
-    return offer;
-  }
-
-  public void setOffer(List<@Valid OBReadOffer1DataOfferInner> offer) {
-    this.offer = offer;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadOffer1Data addOfferItem(OBReadOffer1DataOfferInner offerItem) {
+        if (this.offer == null) {
+            this.offer = new ArrayList<>();
+        }
+        this.offer.add(offerItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get offer
+     *
+     * @return offer
+     */
+    @Valid
+    @Schema(name = "Offer", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Offer")
+    public List<@Valid OBReadOffer1DataOfferInner> getOffer() {
+        return offer;
     }
-    OBReadOffer1Data obReadOffer1Data = (OBReadOffer1Data) o;
-    return Objects.equals(this.offer, obReadOffer1Data.offer);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(offer);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadOffer1Data {\n");
-    sb.append("    offer: ").append(toIndentedString(offer)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setOffer(List<@Valid OBReadOffer1DataOfferInner> offer) {
+        this.offer = offer;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadOffer1Data obReadOffer1Data = (OBReadOffer1Data) o;
+        return Objects.equals(this.offer, obReadOffer1Data.offer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(offer);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadOffer1Data {\n");
+        sb.append("    offer: ").append(toIndentedString(offer)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInner.java
@@ -15,22 +15,31 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerAmount;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerFee;
+import uk.org.openbanking.datamodel.account.OBReadOffer1DataOfferInnerOfferType;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadOffer1DataOfferInner
@@ -40,381 +49,353 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadOffer1DataOfferInner {
 
-  private String accountId;
+    private String accountId;
 
-  private String offerId;
+    private String offerId;
 
-  /**
-   * Offer type, in a coded form.
-   */
-  public enum OfferTypeEnum {
-    BALANCETRANSFER("BalanceTransfer"),
-    
-    LIMITINCREASE("LimitIncrease"),
-    
-    MONEYTRANSFER("MoneyTransfer"),
-    
-    OTHER("Other"),
-    
-    PROMOTIONALRATE("PromotionalRate");
+    private OBReadOffer1DataOfferInnerOfferType offerType;
 
-    private String value;
+    private String description;
 
-    OfferTypeEnum(String value) {
-      this.value = value;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime startDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime endDateTime;
+
+    private String rate;
+
+    private Integer value;
+
+    private String term;
+
+    private String URL;
+
+    private OBReadOffer1DataOfferInnerAmount amount;
+
+    private OBReadOffer1DataOfferInnerFee fee;
+
+    public OBReadOffer1DataOfferInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadOffer1DataOfferInner(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBReadOffer1DataOfferInner accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBReadOffer1DataOfferInner offerId(String offerId) {
+        this.offerId = offerId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner.
+     *
+     * @return offerId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "OfferId", description = "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OfferId")
+    public String getOfferId() {
+        return offerId;
+    }
+
+    public void setOfferId(String offerId) {
+        this.offerId = offerId;
+    }
+
+    public OBReadOffer1DataOfferInner offerType(OBReadOffer1DataOfferInnerOfferType offerType) {
+        this.offerType = offerType;
+        return this;
+    }
+
+    /**
+     * Get offerType
+     *
+     * @return offerType
+     */
+    @Valid
+    @Schema(name = "OfferType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OfferType")
+    public OBReadOffer1DataOfferInnerOfferType getOfferType() {
+        return offerType;
+    }
+
+    public void setOfferType(OBReadOffer1DataOfferInnerOfferType offerType) {
+        this.offerType = offerType;
+    }
+
+    public OBReadOffer1DataOfferInner description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Further details of the offer.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Description", description = "Further details of the offer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBReadOffer1DataOfferInner startDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the offer starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return startDateTime
+     */
+    @Valid
+    @Schema(name = "StartDateTime", description = "Date and time at which the offer starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StartDateTime")
+    public DateTime getStartDateTime() {
+        return startDateTime;
+    }
+
+    public void setStartDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+    }
+
+    public OBReadOffer1DataOfferInner endDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the offer ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return endDateTime
+     */
+    @Valid
+    @Schema(name = "EndDateTime", description = "Date and time at which the offer ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EndDateTime")
+    public DateTime getEndDateTime() {
+        return endDateTime;
+    }
+
+    public void setEndDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+    }
+
+    public OBReadOffer1DataOfferInner rate(String rate) {
+        this.rate = rate;
+        return this;
+    }
+
+    /**
+     * Rate associated with the offer type.
+     *
+     * @return rate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "Rate", description = "Rate associated with the offer type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Rate")
+    public String getRate() {
+        return rate;
+    }
+
+    public void setRate(String rate) {
+        this.rate = rate;
+    }
+
+    public OBReadOffer1DataOfferInner value(Integer value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Value associated with the offer type.
+     *
+     * @return value
+     */
+
+    @Schema(name = "Value", description = "Value associated with the offer type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Value")
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+
+    public OBReadOffer1DataOfferInner term(String term) {
+        this.term = term;
+        return this;
+    }
+
+    /**
+     * Further details of the term of the offer.
+     *
+     * @return term
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Term", description = "Further details of the term of the offer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Term")
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public OBReadOffer1DataOfferInner URL(String URL) {
+        this.URL = URL;
+        return this;
+    }
+
+    /**
+     * URL (Uniform Resource Locator) where documentation on the offer can be found
+     *
+     * @return URL
+     */
+    @Size(min = 1, max = 256)
+    @Schema(name = "URL", description = "URL (Uniform Resource Locator) where documentation on the offer can be found", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("URL")
+    public String getURL() {
+        return URL;
+    }
+
+    public void setURL(String URL) {
+        this.URL = URL;
+    }
+
+    public OBReadOffer1DataOfferInner amount(OBReadOffer1DataOfferInnerAmount amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Amount")
+    public OBReadOffer1DataOfferInnerAmount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBReadOffer1DataOfferInnerAmount amount) {
+        this.amount = amount;
+    }
+
+    public OBReadOffer1DataOfferInner fee(OBReadOffer1DataOfferInnerFee fee) {
+        this.fee = fee;
+        return this;
+    }
+
+    /**
+     * Get fee
+     *
+     * @return fee
+     */
+    @Valid
+    @Schema(name = "Fee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Fee")
+    public OBReadOffer1DataOfferInnerFee getFee() {
+        return fee;
+    }
+
+    public void setFee(OBReadOffer1DataOfferInnerFee fee) {
+        this.fee = fee;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadOffer1DataOfferInner obReadOffer1DataOfferInner = (OBReadOffer1DataOfferInner) o;
+        return Objects.equals(this.accountId, obReadOffer1DataOfferInner.accountId) &&
+                Objects.equals(this.offerId, obReadOffer1DataOfferInner.offerId) &&
+                Objects.equals(this.offerType, obReadOffer1DataOfferInner.offerType) &&
+                Objects.equals(this.description, obReadOffer1DataOfferInner.description) &&
+                Objects.equals(this.startDateTime, obReadOffer1DataOfferInner.startDateTime) &&
+                Objects.equals(this.endDateTime, obReadOffer1DataOfferInner.endDateTime) &&
+                Objects.equals(this.rate, obReadOffer1DataOfferInner.rate) &&
+                Objects.equals(this.value, obReadOffer1DataOfferInner.value) &&
+                Objects.equals(this.term, obReadOffer1DataOfferInner.term) &&
+                Objects.equals(this.URL, obReadOffer1DataOfferInner.URL) &&
+                Objects.equals(this.amount, obReadOffer1DataOfferInner.amount) &&
+                Objects.equals(this.fee, obReadOffer1DataOfferInner.fee);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, offerId, offerType, description, startDateTime, endDateTime, rate, value, term, URL, amount, fee);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadOffer1DataOfferInner {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    offerId: ").append(toIndentedString(offerId)).append("\n");
+        sb.append("    offerType: ").append(toIndentedString(offerType)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
+        sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
+        sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("    term: ").append(toIndentedString(term)).append("\n");
+        sb.append("    URL: ").append(toIndentedString(URL)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    fee: ").append(toIndentedString(fee)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static OfferTypeEnum fromValue(String value) {
-      for (OfferTypeEnum b : OfferTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private OfferTypeEnum offerType;
-
-  private String description;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime startDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime endDateTime;
-
-  private String rate;
-
-  private Integer value;
-
-  private String term;
-
-  private String URL;
-
-  private OBReadOffer1DataOfferInnerAmount amount;
-
-  private OBReadOffer1DataOfferInnerFee fee;
-
-  public OBReadOffer1DataOfferInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadOffer1DataOfferInner(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBReadOffer1DataOfferInner accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBReadOffer1DataOfferInner offerId(String offerId) {
-    this.offerId = offerId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner.
-   * @return offerId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "OfferId", description = "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OfferId")
-  public String getOfferId() {
-    return offerId;
-  }
-
-  public void setOfferId(String offerId) {
-    this.offerId = offerId;
-  }
-
-  public OBReadOffer1DataOfferInner offerType(OfferTypeEnum offerType) {
-    this.offerType = offerType;
-    return this;
-  }
-
-  /**
-   * Offer type, in a coded form.
-   * @return offerType
-  */
-  
-  @Schema(name = "OfferType", description = "Offer type, in a coded form.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OfferType")
-  public OfferTypeEnum getOfferType() {
-    return offerType;
-  }
-
-  public void setOfferType(OfferTypeEnum offerType) {
-    this.offerType = offerType;
-  }
-
-  public OBReadOffer1DataOfferInner description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Further details of the offer.
-   * @return description
-  */
-  @Size(min = 1, max = 500) 
-  @Schema(name = "Description", description = "Further details of the offer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBReadOffer1DataOfferInner startDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the offer starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return startDateTime
-  */
-  @Valid 
-  @Schema(name = "StartDateTime", description = "Date and time at which the offer starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StartDateTime")
-  public DateTime getStartDateTime() {
-    return startDateTime;
-  }
-
-  public void setStartDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-  }
-
-  public OBReadOffer1DataOfferInner endDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the offer ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return endDateTime
-  */
-  @Valid 
-  @Schema(name = "EndDateTime", description = "Date and time at which the offer ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("EndDateTime")
-  public DateTime getEndDateTime() {
-    return endDateTime;
-  }
-
-  public void setEndDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-  }
-
-  public OBReadOffer1DataOfferInner rate(String rate) {
-    this.rate = rate;
-    return this;
-  }
-
-  /**
-   * Rate associated with the offer type.
-   * @return rate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "Rate", description = "Rate associated with the offer type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Rate")
-  public String getRate() {
-    return rate;
-  }
-
-  public void setRate(String rate) {
-    this.rate = rate;
-  }
-
-  public OBReadOffer1DataOfferInner value(Integer value) {
-    this.value = value;
-    return this;
-  }
-
-  /**
-   * Value associated with the offer type.
-   * @return value
-  */
-  
-  @Schema(name = "Value", description = "Value associated with the offer type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Value")
-  public Integer getValue() {
-    return value;
-  }
-
-  public void setValue(Integer value) {
-    this.value = value;
-  }
-
-  public OBReadOffer1DataOfferInner term(String term) {
-    this.term = term;
-    return this;
-  }
-
-  /**
-   * Further details of the term of the offer.
-   * @return term
-  */
-  @Size(min = 1, max = 500) 
-  @Schema(name = "Term", description = "Further details of the term of the offer.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Term")
-  public String getTerm() {
-    return term;
-  }
-
-  public void setTerm(String term) {
-    this.term = term;
-  }
-
-  public OBReadOffer1DataOfferInner URL(String URL) {
-    this.URL = URL;
-    return this;
-  }
-
-  /**
-   * URL (Uniform Resource Locator) where documentation on the offer can be found
-   * @return URL
-  */
-  @Size(min = 1, max = 256) 
-  @Schema(name = "URL", description = "URL (Uniform Resource Locator) where documentation on the offer can be found", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("URL")
-  public String getURL() {
-    return URL;
-  }
-
-  public void setURL(String URL) {
-    this.URL = URL;
-  }
-
-  public OBReadOffer1DataOfferInner amount(OBReadOffer1DataOfferInnerAmount amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Amount")
-  public OBReadOffer1DataOfferInnerAmount getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBReadOffer1DataOfferInnerAmount amount) {
-    this.amount = amount;
-  }
-
-  public OBReadOffer1DataOfferInner fee(OBReadOffer1DataOfferInnerFee fee) {
-    this.fee = fee;
-    return this;
-  }
-
-  /**
-   * Get fee
-   * @return fee
-  */
-  @Valid 
-  @Schema(name = "Fee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Fee")
-  public OBReadOffer1DataOfferInnerFee getFee() {
-    return fee;
-  }
-
-  public void setFee(OBReadOffer1DataOfferInnerFee fee) {
-    this.fee = fee;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadOffer1DataOfferInner obReadOffer1DataOfferInner = (OBReadOffer1DataOfferInner) o;
-    return Objects.equals(this.accountId, obReadOffer1DataOfferInner.accountId) &&
-        Objects.equals(this.offerId, obReadOffer1DataOfferInner.offerId) &&
-        Objects.equals(this.offerType, obReadOffer1DataOfferInner.offerType) &&
-        Objects.equals(this.description, obReadOffer1DataOfferInner.description) &&
-        Objects.equals(this.startDateTime, obReadOffer1DataOfferInner.startDateTime) &&
-        Objects.equals(this.endDateTime, obReadOffer1DataOfferInner.endDateTime) &&
-        Objects.equals(this.rate, obReadOffer1DataOfferInner.rate) &&
-        Objects.equals(this.value, obReadOffer1DataOfferInner.value) &&
-        Objects.equals(this.term, obReadOffer1DataOfferInner.term) &&
-        Objects.equals(this.URL, obReadOffer1DataOfferInner.URL) &&
-        Objects.equals(this.amount, obReadOffer1DataOfferInner.amount) &&
-        Objects.equals(this.fee, obReadOffer1DataOfferInner.fee);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, offerId, offerType, description, startDateTime, endDateTime, rate, value, term, URL, amount, fee);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadOffer1DataOfferInner {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    offerId: ").append(toIndentedString(offerId)).append("\n");
-    sb.append("    offerType: ").append(toIndentedString(offerType)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
-    sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
-    sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
-    sb.append("    value: ").append(toIndentedString(value)).append("\n");
-    sb.append("    term: ").append(toIndentedString(term)).append("\n");
-    sb.append("    URL: ").append(toIndentedString(URL)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    fee: ").append(toIndentedString(fee)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerAmount.java
@@ -34,99 +34,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadOffer1DataOfferInnerAmount {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBReadOffer1DataOfferInnerAmount() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadOffer1DataOfferInnerAmount(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBReadOffer1DataOfferInnerAmount amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBReadOffer1DataOfferInnerAmount currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadOffer1DataOfferInnerAmount() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadOffer1DataOfferInnerAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBReadOffer1DataOfferInnerAmount obReadOffer1DataOfferInnerAmount = (OBReadOffer1DataOfferInnerAmount) o;
-    return Objects.equals(this.amount, obReadOffer1DataOfferInnerAmount.amount) &&
-        Objects.equals(this.currency, obReadOffer1DataOfferInnerAmount.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadOffer1DataOfferInnerAmount {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadOffer1DataOfferInnerAmount amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBReadOffer1DataOfferInnerAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadOffer1DataOfferInnerAmount obReadOffer1DataOfferInnerAmount = (OBReadOffer1DataOfferInnerAmount) o;
+        return Objects.equals(this.amount, obReadOffer1DataOfferInnerAmount.amount) &&
+                Objects.equals(this.currency, obReadOffer1DataOfferInnerAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadOffer1DataOfferInnerAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerFee.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerFee.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Fee associated with the offer type.
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadOffer1DataOfferInnerFee {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBReadOffer1DataOfferInnerFee() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadOffer1DataOfferInnerFee(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBReadOffer1DataOfferInnerFee amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBReadOffer1DataOfferInnerFee currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadOffer1DataOfferInnerFee() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadOffer1DataOfferInnerFee(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBReadOffer1DataOfferInnerFee obReadOffer1DataOfferInnerFee = (OBReadOffer1DataOfferInnerFee) o;
-    return Objects.equals(this.amount, obReadOffer1DataOfferInnerFee.amount) &&
-        Objects.equals(this.currency, obReadOffer1DataOfferInnerFee.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadOffer1DataOfferInnerFee {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadOffer1DataOfferInnerFee amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBReadOffer1DataOfferInnerFee currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadOffer1DataOfferInnerFee obReadOffer1DataOfferInnerFee = (OBReadOffer1DataOfferInnerFee) o;
+        return Objects.equals(this.amount, obReadOffer1DataOfferInnerFee.amount) &&
+                Objects.equals(this.currency, obReadOffer1DataOfferInnerFee.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadOffer1DataOfferInnerFee {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerOfferType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOfferInnerOfferType.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Offer type, in a coded form.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadOffer1DataOfferInnerOfferType {
+
+    BALANCETRANSFER("BalanceTransfer"),
+
+    LIMITINCREASE("LimitIncrease"),
+
+    MONEYTRANSFER("MoneyTransfer"),
+
+    OTHER("Other"),
+
+    PROMOTIONALRATE("PromotionalRate");
+
+    private String value;
+
+    OBReadOffer1DataOfferInnerOfferType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadOffer1DataOfferInnerOfferType fromValue(String value) {
+        for (OBReadOffer1DataOfferInnerOfferType b : OBReadOffer1DataOfferInnerOfferType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadParty2 {
 
-  private OBReadParty2Data data;
+    private OBReadParty2Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadParty2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadParty2(OBReadParty2Data data) {
-    this.data = data;
-  }
-
-  public OBReadParty2 data(OBReadParty2Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadParty2Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadParty2Data data) {
-    this.data = data;
-  }
-
-  public OBReadParty2 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadParty2 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadParty2() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadParty2(OBReadParty2Data data) {
+        this.data = data;
     }
-    OBReadParty2 obReadParty2 = (OBReadParty2) o;
-    return Objects.equals(this.data, obReadParty2.data) &&
-        Objects.equals(this.links, obReadParty2.links) &&
-        Objects.equals(this.meta, obReadParty2.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadParty2 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadParty2 data(OBReadParty2Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadParty2Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadParty2Data data) {
+        this.data = data;
+    }
+
+    public OBReadParty2 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadParty2 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadParty2 obReadParty2 = (OBReadParty2) o;
+        return Objects.equals(this.data, obReadParty2.data) &&
+                Objects.equals(this.links, obReadParty2.links) &&
+                Objects.equals(this.meta, obReadParty2.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadParty2 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
@@ -32,63 +32,64 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadParty2Data {
 
-  private OBParty2 party;
+    private OBParty2 party;
 
-  public OBReadParty2Data party(OBParty2 party) {
-    this.party = party;
-    return this;
-  }
-
-  /**
-   * Get party
-   * @return party
-  */
-  @Valid 
-  @Schema(name = "Party", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Party")
-  public OBParty2 getParty() {
-    return party;
-  }
-
-  public void setParty(OBParty2 party) {
-    this.party = party;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadParty2Data party(OBParty2 party) {
+        this.party = party;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get party
+     *
+     * @return party
+     */
+    @Valid
+    @Schema(name = "Party", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Party")
+    public OBParty2 getParty() {
+        return party;
     }
-    OBReadParty2Data obReadParty2Data = (OBReadParty2Data) o;
-    return Objects.equals(this.party, obReadParty2Data.party);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(party);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadParty2Data {\n");
-    sb.append("    party: ").append(toIndentedString(party)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setParty(OBParty2 party) {
+        this.party = party;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadParty2Data obReadParty2Data = (OBReadParty2Data) o;
+        return Objects.equals(this.party, obReadParty2Data.party);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(party);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadParty2Data {\n");
+        sb.append("    party: ").append(toIndentedString(party)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadParty3 {
 
-  private OBReadParty3Data data;
+    private OBReadParty3Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadParty3() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadParty3(OBReadParty3Data data) {
-    this.data = data;
-  }
-
-  public OBReadParty3 data(OBReadParty3Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadParty3Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadParty3Data data) {
-    this.data = data;
-  }
-
-  public OBReadParty3 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadParty3 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadParty3() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadParty3(OBReadParty3Data data) {
+        this.data = data;
     }
-    OBReadParty3 obReadParty3 = (OBReadParty3) o;
-    return Objects.equals(this.data, obReadParty3.data) &&
-        Objects.equals(this.links, obReadParty3.links) &&
-        Objects.equals(this.meta, obReadParty3.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadParty3 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadParty3 data(OBReadParty3Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadParty3Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadParty3Data data) {
+        this.data = data;
+    }
+
+    public OBReadParty3 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadParty3 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadParty3 obReadParty3 = (OBReadParty3) o;
+        return Objects.equals(this.data, obReadParty3.data) &&
+                Objects.equals(this.links, obReadParty3.links) &&
+                Objects.equals(this.meta, obReadParty3.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadParty3 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
@@ -34,72 +34,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadParty3Data {
 
-  @Valid
-  private List<@Valid OBParty2> party;
+    @Valid
+    private List<@Valid OBParty2> party;
 
-  public OBReadParty3Data party(List<@Valid OBParty2> party) {
-    this.party = party;
-    return this;
-  }
-
-  public OBReadParty3Data addPartyItem(OBParty2 partyItem) {
-    if (this.party == null) {
-      this.party = new ArrayList<>();
+    public OBReadParty3Data party(List<@Valid OBParty2> party) {
+        this.party = party;
+        return this;
     }
-    this.party.add(partyItem);
-    return this;
-  }
 
-  /**
-   * Get party
-   * @return party
-  */
-  @Valid 
-  @Schema(name = "Party", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Party")
-  public List<@Valid OBParty2> getParty() {
-    return party;
-  }
-
-  public void setParty(List<@Valid OBParty2> party) {
-    this.party = party;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadParty3Data addPartyItem(OBParty2 partyItem) {
+        if (this.party == null) {
+            this.party = new ArrayList<>();
+        }
+        this.party.add(partyItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get party
+     *
+     * @return party
+     */
+    @Valid
+    @Schema(name = "Party", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Party")
+    public List<@Valid OBParty2> getParty() {
+        return party;
     }
-    OBReadParty3Data obReadParty3Data = (OBReadParty3Data) o;
-    return Objects.equals(this.party, obReadParty3Data.party);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(party);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadParty3Data {\n");
-    sb.append("    party: ").append(toIndentedString(party)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setParty(List<@Valid OBParty2> party) {
+        this.party = party;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadParty3Data obReadParty3Data = (OBReadParty3Data) o;
+        return Objects.equals(this.party, obReadParty3Data.party);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(party);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadParty3Data {\n");
+        sb.append("    party: ").append(toIndentedString(party)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
@@ -34,122 +34,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2 {
 
-  private OBReadProduct2Data data;
+    private OBReadProduct2Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadProduct2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2(OBReadProduct2Data data) {
-    this.data = data;
-  }
-
-  public OBReadProduct2 data(OBReadProduct2Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadProduct2Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadProduct2Data data) {
-    this.data = data;
-  }
-
-  public OBReadProduct2 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadProduct2 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2(OBReadProduct2Data data) {
+        this.data = data;
     }
-    OBReadProduct2 obReadProduct2 = (OBReadProduct2) o;
-    return Objects.equals(this.data, obReadProduct2.data) &&
-        Objects.equals(this.links, obReadProduct2.links) &&
-        Objects.equals(this.meta, obReadProduct2.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2 data(OBReadProduct2Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadProduct2Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadProduct2Data data) {
+        this.data = data;
+    }
+
+    public OBReadProduct2 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadProduct2 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2 obReadProduct2 = (OBReadProduct2) o;
+        return Objects.equals(this.data, obReadProduct2.data) &&
+                Objects.equals(this.links, obReadProduct2.links) &&
+                Objects.equals(this.meta, obReadProduct2.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
@@ -15,16 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Aligning with the read write specs structure.
@@ -35,72 +48,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2Data {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInner> product;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInner> product;
 
-  public OBReadProduct2Data product(List<@Valid OBReadProduct2DataProductInner> product) {
-    this.product = product;
-    return this;
-  }
-
-  public OBReadProduct2Data addProductItem(OBReadProduct2DataProductInner productItem) {
-    if (this.product == null) {
-      this.product = new ArrayList<>();
+    public OBReadProduct2Data product(List<@Valid OBReadProduct2DataProductInner> product) {
+        this.product = product;
+        return this;
     }
-    this.product.add(productItem);
-    return this;
-  }
 
-  /**
-   * Get product
-   * @return product
-  */
-  @Valid 
-  @Schema(name = "Product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Product")
-  public List<@Valid OBReadProduct2DataProductInner> getProduct() {
-    return product;
-  }
-
-  public void setProduct(List<@Valid OBReadProduct2DataProductInner> product) {
-    this.product = product;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2Data addProductItem(OBReadProduct2DataProductInner productItem) {
+        if (this.product == null) {
+            this.product = new ArrayList<>();
+        }
+        this.product.add(productItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get product
+     *
+     * @return product
+     */
+    @Valid
+    @Schema(name = "Product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Product")
+    public List<@Valid OBReadProduct2DataProductInner> getProduct() {
+        return product;
     }
-    OBReadProduct2Data obReadProduct2Data = (OBReadProduct2Data) o;
-    return Objects.equals(this.product, obReadProduct2Data.product);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(product);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2Data {\n");
-    sb.append("    product: ").append(toIndentedString(product)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setProduct(List<@Valid OBReadProduct2DataProductInner> product) {
+        this.product = product;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2Data obReadProduct2Data = (OBReadProduct2Data) o;
+        return Objects.equals(this.product, obReadProduct2Data.product);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(product);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2Data {\n");
+        sb.append("    product: ").append(toIndentedString(product)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInner.java
@@ -15,18 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBBCAData1;
+import uk.org.openbanking.datamodel.account.OBPCAData1;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerProductType;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Product details associated with the Account
@@ -37,308 +48,278 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInner {
 
-  private String productName;
+    private String productName;
 
-  private String productId;
+    private String productId;
 
-  private String accountId;
+    private String accountId;
 
-  private String secondaryProductId;
+    private String secondaryProductId;
 
-  /**
-   * Product type : Personal Current Account, Business Current Account
-   */
-  public enum ProductTypeEnum {
-    BUSINESSCURRENTACCOUNT("BusinessCurrentAccount"),
-    
-    COMMERCIALCREDITCARD("CommercialCreditCard"),
-    
-    OTHER("Other"),
-    
-    PERSONALCURRENTACCOUNT("PersonalCurrentAccount"),
-    
-    SMELOAN("SMELoan");
+    private OBReadProduct2DataProductInnerProductType productType;
 
-    private String value;
+    private String marketingStateId;
 
-    ProductTypeEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductType otherProductType;
+
+    private OBBCAData1 BCA;
+
+    private OBPCAData1 PCA;
+
+    public OBReadProduct2DataProductInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInner(String accountId, OBReadProduct2DataProductInnerProductType productType) {
+        this.accountId = accountId;
+        this.productType = productType;
+    }
+
+    public OBReadProduct2DataProductInner productName(String productName) {
+        this.productName = productName;
+        return this;
+    }
+
+    /**
+     * The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise.
+     *
+     * @return productName
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "ProductName", description = "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProductName")
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public OBReadProduct2DataProductInner productId(String productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    /**
+     * The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers.
+     *
+     * @return productId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "ProductId", description = "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProductId")
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public OBReadProduct2DataProductInner accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBReadProduct2DataProductInner secondaryProductId(String secondaryProductId) {
+        this.secondaryProductId = secondaryProductId;
+        return this;
+    }
+
+    /**
+     * Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products.
+     *
+     * @return secondaryProductId
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "SecondaryProductId", description = "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryProductId")
+    public String getSecondaryProductId() {
+        return secondaryProductId;
+    }
+
+    public void setSecondaryProductId(String secondaryProductId) {
+        this.secondaryProductId = secondaryProductId;
+    }
+
+    public OBReadProduct2DataProductInner productType(OBReadProduct2DataProductInnerProductType productType) {
+        this.productType = productType;
+        return this;
+    }
+
+    /**
+     * Get productType
+     *
+     * @return productType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ProductType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ProductType")
+    public OBReadProduct2DataProductInnerProductType getProductType() {
+        return productType;
+    }
+
+    public void setProductType(OBReadProduct2DataProductInnerProductType productType) {
+        this.productType = productType;
+    }
+
+    public OBReadProduct2DataProductInner marketingStateId(String marketingStateId) {
+        this.marketingStateId = marketingStateId;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Product Marketing State.
+     *
+     * @return marketingStateId
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "MarketingStateId", description = "Unique and unambiguous identification of a  Product Marketing State.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MarketingStateId")
+    public String getMarketingStateId() {
+        return marketingStateId;
+    }
+
+    public void setMarketingStateId(String marketingStateId) {
+        this.marketingStateId = marketingStateId;
+    }
+
+    public OBReadProduct2DataProductInner otherProductType(OBReadProduct2DataProductInnerOtherProductType otherProductType) {
+        this.otherProductType = otherProductType;
+        return this;
+    }
+
+    /**
+     * Get otherProductType
+     *
+     * @return otherProductType
+     */
+    @Valid
+    @Schema(name = "OtherProductType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherProductType")
+    public OBReadProduct2DataProductInnerOtherProductType getOtherProductType() {
+        return otherProductType;
+    }
+
+    public void setOtherProductType(OBReadProduct2DataProductInnerOtherProductType otherProductType) {
+        this.otherProductType = otherProductType;
+    }
+
+    public OBReadProduct2DataProductInner BCA(OBBCAData1 BCA) {
+        this.BCA = BCA;
+        return this;
+    }
+
+    /**
+     * Get BCA
+     *
+     * @return BCA
+     */
+    @Valid
+    @Schema(name = "BCA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BCA")
+    public OBBCAData1 getBCA() {
+        return BCA;
+    }
+
+    public void setBCA(OBBCAData1 BCA) {
+        this.BCA = BCA;
+    }
+
+    public OBReadProduct2DataProductInner PCA(OBPCAData1 PCA) {
+        this.PCA = PCA;
+        return this;
+    }
+
+    /**
+     * Get PCA
+     *
+     * @return PCA
+     */
+    @Valid
+    @Schema(name = "PCA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PCA")
+    public OBPCAData1 getPCA() {
+        return PCA;
+    }
+
+    public void setPCA(OBPCAData1 PCA) {
+        this.PCA = PCA;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInner obReadProduct2DataProductInner = (OBReadProduct2DataProductInner) o;
+        return Objects.equals(this.productName, obReadProduct2DataProductInner.productName) &&
+                Objects.equals(this.productId, obReadProduct2DataProductInner.productId) &&
+                Objects.equals(this.accountId, obReadProduct2DataProductInner.accountId) &&
+                Objects.equals(this.secondaryProductId, obReadProduct2DataProductInner.secondaryProductId) &&
+                Objects.equals(this.productType, obReadProduct2DataProductInner.productType) &&
+                Objects.equals(this.marketingStateId, obReadProduct2DataProductInner.marketingStateId) &&
+                Objects.equals(this.otherProductType, obReadProduct2DataProductInner.otherProductType) &&
+                Objects.equals(this.BCA, obReadProduct2DataProductInner.BCA) &&
+                Objects.equals(this.PCA, obReadProduct2DataProductInner.PCA);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productName, productId, accountId, secondaryProductId, productType, marketingStateId, otherProductType, BCA, PCA);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInner {\n");
+        sb.append("    productName: ").append(toIndentedString(productName)).append("\n");
+        sb.append("    productId: ").append(toIndentedString(productId)).append("\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    secondaryProductId: ").append(toIndentedString(secondaryProductId)).append("\n");
+        sb.append("    productType: ").append(toIndentedString(productType)).append("\n");
+        sb.append("    marketingStateId: ").append(toIndentedString(marketingStateId)).append("\n");
+        sb.append("    otherProductType: ").append(toIndentedString(otherProductType)).append("\n");
+        sb.append("    BCA: ").append(toIndentedString(BCA)).append("\n");
+        sb.append("    PCA: ").append(toIndentedString(PCA)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static ProductTypeEnum fromValue(String value) {
-      for (ProductTypeEnum b : ProductTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private ProductTypeEnum productType;
-
-  private String marketingStateId;
-
-  private OBReadProduct2DataProductInnerOtherProductType otherProductType;
-
-  private OBBCAData1 BCA;
-
-  private OBPCAData1 PCA;
-
-  public OBReadProduct2DataProductInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInner(String accountId, ProductTypeEnum productType) {
-    this.accountId = accountId;
-    this.productType = productType;
-  }
-
-  public OBReadProduct2DataProductInner productName(String productName) {
-    this.productName = productName;
-    return this;
-  }
-
-  /**
-   * The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise.
-   * @return productName
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "ProductName", description = "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProductName")
-  public String getProductName() {
-    return productName;
-  }
-
-  public void setProductName(String productName) {
-    this.productName = productName;
-  }
-
-  public OBReadProduct2DataProductInner productId(String productId) {
-    this.productId = productId;
-    return this;
-  }
-
-  /**
-   * The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers.
-   * @return productId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "ProductId", description = "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProductId")
-  public String getProductId() {
-    return productId;
-  }
-
-  public void setProductId(String productId) {
-    this.productId = productId;
-  }
-
-  public OBReadProduct2DataProductInner accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBReadProduct2DataProductInner secondaryProductId(String secondaryProductId) {
-    this.secondaryProductId = secondaryProductId;
-    return this;
-  }
-
-  /**
-   * Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products.
-   * @return secondaryProductId
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "SecondaryProductId", description = "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SecondaryProductId")
-  public String getSecondaryProductId() {
-    return secondaryProductId;
-  }
-
-  public void setSecondaryProductId(String secondaryProductId) {
-    this.secondaryProductId = secondaryProductId;
-  }
-
-  public OBReadProduct2DataProductInner productType(ProductTypeEnum productType) {
-    this.productType = productType;
-    return this;
-  }
-
-  /**
-   * Product type : Personal Current Account, Business Current Account
-   * @return productType
-  */
-  @NotNull 
-  @Schema(name = "ProductType", description = "Product type : Personal Current Account, Business Current Account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ProductType")
-  public ProductTypeEnum getProductType() {
-    return productType;
-  }
-
-  public void setProductType(ProductTypeEnum productType) {
-    this.productType = productType;
-  }
-
-  public OBReadProduct2DataProductInner marketingStateId(String marketingStateId) {
-    this.marketingStateId = marketingStateId;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Product Marketing State.
-   * @return marketingStateId
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "MarketingStateId", description = "Unique and unambiguous identification of a  Product Marketing State.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MarketingStateId")
-  public String getMarketingStateId() {
-    return marketingStateId;
-  }
-
-  public void setMarketingStateId(String marketingStateId) {
-    this.marketingStateId = marketingStateId;
-  }
-
-  public OBReadProduct2DataProductInner otherProductType(OBReadProduct2DataProductInnerOtherProductType otherProductType) {
-    this.otherProductType = otherProductType;
-    return this;
-  }
-
-  /**
-   * Get otherProductType
-   * @return otherProductType
-  */
-  @Valid 
-  @Schema(name = "OtherProductType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherProductType")
-  public OBReadProduct2DataProductInnerOtherProductType getOtherProductType() {
-    return otherProductType;
-  }
-
-  public void setOtherProductType(OBReadProduct2DataProductInnerOtherProductType otherProductType) {
-    this.otherProductType = otherProductType;
-  }
-
-  public OBReadProduct2DataProductInner BCA(OBBCAData1 BCA) {
-    this.BCA = BCA;
-    return this;
-  }
-
-  /**
-   * Get BCA
-   * @return BCA
-  */
-  @Valid 
-  @Schema(name = "BCA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BCA")
-  public OBBCAData1 getBCA() {
-    return BCA;
-  }
-
-  public void setBCA(OBBCAData1 BCA) {
-    this.BCA = BCA;
-  }
-
-  public OBReadProduct2DataProductInner PCA(OBPCAData1 PCA) {
-    this.PCA = PCA;
-    return this;
-  }
-
-  /**
-   * Get PCA
-   * @return PCA
-  */
-  @Valid 
-  @Schema(name = "PCA", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("PCA")
-  public OBPCAData1 getPCA() {
-    return PCA;
-  }
-
-  public void setPCA(OBPCAData1 PCA) {
-    this.PCA = PCA;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInner obReadProduct2DataProductInner = (OBReadProduct2DataProductInner) o;
-    return Objects.equals(this.productName, obReadProduct2DataProductInner.productName) &&
-        Objects.equals(this.productId, obReadProduct2DataProductInner.productId) &&
-        Objects.equals(this.accountId, obReadProduct2DataProductInner.accountId) &&
-        Objects.equals(this.secondaryProductId, obReadProduct2DataProductInner.secondaryProductId) &&
-        Objects.equals(this.productType, obReadProduct2DataProductInner.productType) &&
-        Objects.equals(this.marketingStateId, obReadProduct2DataProductInner.marketingStateId) &&
-        Objects.equals(this.otherProductType, obReadProduct2DataProductInner.otherProductType) &&
-        Objects.equals(this.BCA, obReadProduct2DataProductInner.BCA) &&
-        Objects.equals(this.PCA, obReadProduct2DataProductInner.PCA);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(productName, productId, accountId, secondaryProductId, productType, marketingStateId, otherProductType, BCA, PCA);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInner {\n");
-    sb.append("    productName: ").append(toIndentedString(productName)).append("\n");
-    sb.append("    productId: ").append(toIndentedString(productId)).append("\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    secondaryProductId: ").append(toIndentedString(secondaryProductId)).append("\n");
-    sb.append("    productType: ").append(toIndentedString(productType)).append("\n");
-    sb.append("    marketingStateId: ").append(toIndentedString(marketingStateId)).append("\n");
-    sb.append("    otherProductType: ").append(toIndentedString(otherProductType)).append("\n");
-    sb.append("    BCA: ").append(toIndentedString(BCA)).append("\n");
-    sb.append("    PCA: ").append(toIndentedString(PCA)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductType.java
@@ -15,20 +15,35 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterest;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterest;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraft;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeProductDetails;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepayment;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Other product type details associated with the account.
@@ -39,285 +54,287 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductType {
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails;
+    private OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest;
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft;
+    private OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest;
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment;
+    private OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBReadProduct2DataProductInnerOtherProductType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the product
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Name", description = "Long name associated with the product", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description of the Product associated with the account
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description of the Product associated with the account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType productDetails(OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails) {
-    this.productDetails = productDetails;
-    return this;
-  }
-
-  /**
-   * Get productDetails
-   * @return productDetails
-  */
-  @Valid 
-  @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProductDetails")
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails getProductDetails() {
-    return productDetails;
-  }
-
-  public void setProductDetails(OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails) {
-    this.productDetails = productDetails;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType creditInterest(OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest) {
-    this.creditInterest = creditInterest;
-    return this;
-  }
-
-  /**
-   * Get creditInterest
-   * @return creditInterest
-  */
-  @Valid 
-  @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditInterest")
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest getCreditInterest() {
-    return creditInterest;
-  }
-
-  public void setCreditInterest(OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest) {
-    this.creditInterest = creditInterest;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType overdraft(OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft) {
-    this.overdraft = overdraft;
-    return this;
-  }
-
-  /**
-   * Get overdraft
-   * @return overdraft
-  */
-  @Valid 
-  @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Overdraft")
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft getOverdraft() {
-    return overdraft;
-  }
-
-  public void setOverdraft(OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft) {
-    this.overdraft = overdraft;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType loanInterest(OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest) {
-    this.loanInterest = loanInterest;
-    return this;
-  }
-
-  /**
-   * Get loanInterest
-   * @return loanInterest
-  */
-  @Valid 
-  @Schema(name = "LoanInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanInterest")
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest getLoanInterest() {
-    return loanInterest;
-  }
-
-  public void setLoanInterest(OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest) {
-    this.loanInterest = loanInterest;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType repayment(OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment) {
-    this.repayment = repayment;
-    return this;
-  }
-
-  /**
-   * Get repayment
-   * @return repayment
-  */
-  @Valid 
-  @Schema(name = "Repayment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Repayment")
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment getRepayment() {
-    return repayment;
-  }
-
-  public void setRepayment(OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment) {
-    this.repayment = repayment;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType otherFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType addOtherFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner otherFeesChargesItem) {
-    if (this.otherFeesCharges == null) {
-      this.otherFeesCharges = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductType() {
+        super();
     }
-    this.otherFeesCharges.add(otherFeesChargesItem);
-    return this;
-  }
 
-  /**
-   * Get otherFeesCharges
-   * @return otherFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OtherFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeesCharges")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> getOtherFeesCharges() {
-    return otherFeesCharges;
-  }
-
-  public void setOtherFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges) {
-    this.otherFeesCharges = otherFeesCharges;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductType putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductType name(String name) {
+        this.name = name;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Long name associated with the product
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "Long name associated with the product", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
     }
-    OBReadProduct2DataProductInnerOtherProductType obReadProduct2DataProductInnerOtherProductType = (OBReadProduct2DataProductInnerOtherProductType) o;
-    return Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductType.description) &&
-        Objects.equals(this.productDetails, obReadProduct2DataProductInnerOtherProductType.productDetails) &&
-        Objects.equals(this.creditInterest, obReadProduct2DataProductInnerOtherProductType.creditInterest) &&
-        Objects.equals(this.overdraft, obReadProduct2DataProductInnerOtherProductType.overdraft) &&
-        Objects.equals(this.loanInterest, obReadProduct2DataProductInnerOtherProductType.loanInterest) &&
-        Objects.equals(this.repayment, obReadProduct2DataProductInnerOtherProductType.repayment) &&
-        Objects.equals(this.otherFeesCharges, obReadProduct2DataProductInnerOtherProductType.otherFeesCharges) &&
-        Objects.equals(this.supplementaryData, obReadProduct2DataProductInnerOtherProductType.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(name, description, productDetails, creditInterest, overdraft, loanInterest, repayment, otherFeesCharges, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductType {\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
-    sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
-    sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
-    sb.append("    loanInterest: ").append(toIndentedString(loanInterest)).append("\n");
-    sb.append("    repayment: ").append(toIndentedString(repayment)).append("\n");
-    sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setName(String name) {
+        this.name = name;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBReadProduct2DataProductInnerOtherProductType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description of the Product associated with the account
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description of the Product associated with the account", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType productDetails(OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails) {
+        this.productDetails = productDetails;
+        return this;
+    }
+
+    /**
+     * Get productDetails
+     *
+     * @return productDetails
+     */
+    @Valid
+    @Schema(name = "ProductDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProductDetails")
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails getProductDetails() {
+        return productDetails;
+    }
+
+    public void setProductDetails(OBReadProduct2DataProductInnerOtherProductTypeProductDetails productDetails) {
+        this.productDetails = productDetails;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType creditInterest(OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest) {
+        this.creditInterest = creditInterest;
+        return this;
+    }
+
+    /**
+     * Get creditInterest
+     *
+     * @return creditInterest
+     */
+    @Valid
+    @Schema(name = "CreditInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditInterest")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest getCreditInterest() {
+        return creditInterest;
+    }
+
+    public void setCreditInterest(OBReadProduct2DataProductInnerOtherProductTypeCreditInterest creditInterest) {
+        this.creditInterest = creditInterest;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType overdraft(OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft) {
+        this.overdraft = overdraft;
+        return this;
+    }
+
+    /**
+     * Get overdraft
+     *
+     * @return overdraft
+     */
+    @Valid
+    @Schema(name = "Overdraft", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Overdraft")
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft getOverdraft() {
+        return overdraft;
+    }
+
+    public void setOverdraft(OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraft) {
+        this.overdraft = overdraft;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType loanInterest(OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest) {
+        this.loanInterest = loanInterest;
+        return this;
+    }
+
+    /**
+     * Get loanInterest
+     *
+     * @return loanInterest
+     */
+    @Valid
+    @Schema(name = "LoanInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanInterest")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest getLoanInterest() {
+        return loanInterest;
+    }
+
+    public void setLoanInterest(OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterest) {
+        this.loanInterest = loanInterest;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType repayment(OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment) {
+        this.repayment = repayment;
+        return this;
+    }
+
+    /**
+     * Get repayment
+     *
+     * @return repayment
+     */
+    @Valid
+    @Schema(name = "Repayment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Repayment")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment getRepayment() {
+        return repayment;
+    }
+
+    public void setRepayment(OBReadProduct2DataProductInnerOtherProductTypeRepayment repayment) {
+        this.repayment = repayment;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType otherFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType addOtherFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner otherFeesChargesItem) {
+        if (this.otherFeesCharges == null) {
+            this.otherFeesCharges = new ArrayList<>();
+        }
+        this.otherFeesCharges.add(otherFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Get otherFeesCharges
+     *
+     * @return otherFeesCharges
+     */
+    @Valid
+    @Schema(name = "OtherFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeesCharges")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> getOtherFeesCharges() {
+        return otherFeesCharges;
+    }
+
+    public void setOtherFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner> otherFeesCharges) {
+        this.otherFeesCharges = otherFeesCharges;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductType supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductType obReadProduct2DataProductInnerOtherProductType = (OBReadProduct2DataProductInnerOtherProductType) o;
+        return Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductType.description) &&
+                Objects.equals(this.productDetails, obReadProduct2DataProductInnerOtherProductType.productDetails) &&
+                Objects.equals(this.creditInterest, obReadProduct2DataProductInnerOtherProductType.creditInterest) &&
+                Objects.equals(this.overdraft, obReadProduct2DataProductInnerOtherProductType.overdraft) &&
+                Objects.equals(this.loanInterest, obReadProduct2DataProductInnerOtherProductType.loanInterest) &&
+                Objects.equals(this.repayment, obReadProduct2DataProductInnerOtherProductType.repayment) &&
+                Objects.equals(this.otherFeesCharges, obReadProduct2DataProductInnerOtherProductType.otherFeesCharges) &&
+                Objects.equals(this.supplementaryData, obReadProduct2DataProductInnerOtherProductType.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, productDetails, creditInterest, overdraft, loanInterest, repayment, otherFeesCharges, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductType {\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    productDetails: ").append(toIndentedString(productDetails)).append("\n");
+        sb.append("    creditInterest: ").append(toIndentedString(creditInterest)).append("\n");
+        sb.append("    overdraft: ").append(toIndentedString(overdraft)).append("\n");
+        sb.append("    loanInterest: ").append(toIndentedString(loanInterest)).append("\n");
+        sb.append("    repayment: ").append(toIndentedString(repayment)).append("\n");
+        sb.append("    otherFeesCharges: ").append(toIndentedString(otherFeesCharges)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
@@ -15,18 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about the interest that may be payable to the Account holders
@@ -37,83 +48,86 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeCreditInterest {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet = new ArrayList<>();
 
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest tierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest addTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBandSetItem) {
-    if (this.tierBandSet == null) {
-      this.tierBandSet = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest() {
+        super();
     }
-    this.tierBandSet.add(tierBandSetItem);
-    return this;
-  }
 
-  /**
-   * Get tierBandSet
-   * @return tierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandSet")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> getTierBandSet() {
-    return tierBandSet;
-  }
-
-  public void setTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
-    this.tierBandSet = tierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest tierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeCreditInterest obReadProduct2DataProductInnerOtherProductTypeCreditInterest = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterest) o;
-    return Objects.equals(this.tierBandSet, obReadProduct2DataProductInnerOtherProductTypeCreditInterest.tierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandSet);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterest {\n");
-    sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterest addTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBandSetItem) {
+        if (this.tierBandSet == null) {
+            this.tierBandSet = new ArrayList<>();
+        }
+        this.tierBandSet.add(tierBandSetItem);
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get tierBandSet
+     *
+     * @return tierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandSet")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> getTierBandSet() {
+        return tierBandSet;
+    }
+
+    public void setTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner> tierBandSet) {
+        this.tierBandSet = tierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeCreditInterest obReadProduct2DataProductInnerOtherProductTypeCreditInterest = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterest) o;
+        return Objects.equals(this.tierBandSet, obReadProduct2DataProductInnerOtherProductTypeCreditInterest.tierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterest {\n");
+        sb.append("    tierBandSet: ").append(toIndentedString(tierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
@@ -15,20 +15,34 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBInterestCalculationMethod1Code;
+import uk.org.openbanking.datamodel.account.OBOtherCodeType10;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * The group of tiers or bands for which credit interest can be applied.
@@ -39,312 +53,249 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner {
 
-  /**
-   * The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance
-   */
-  public enum TierBandMethodEnum {
-    INBA("INBA"),
-    
-    INTI("INTI"),
-    
-    INWH("INWH");
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod tierBandMethod;
 
-    private String value;
+    private OBInterestCalculationMethod1Code calculationMethod;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination destination;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBOtherCodeType10 otherCalculationMethod;
+
+    private OBOtherCodeType10 otherDestination;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand = new ArrayList<>();
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod tierBandMethod, OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination destination, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.destination = destination;
+        this.tierBand = tierBand;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner calculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
+        this.calculationMethod = calculationMethod;
+        return this;
+    }
+
+    /**
+     * Get calculationMethod
+     *
+     * @return calculationMethod
+     */
+    @Valid
+    @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationMethod")
+    public OBInterestCalculationMethod1Code getCalculationMethod() {
+        return calculationMethod;
+    }
+
+    public void setCalculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
+        this.calculationMethod = calculationMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner destination(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    /**
+     * Get destination
+     *
+     * @return destination
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Destination", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Destination")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination getDestination() {
+        return destination;
+    }
+
+    public void setDestination(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination destination) {
+        this.destination = destination;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner otherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
+        this.otherCalculationMethod = otherCalculationMethod;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationMethod
+     *
+     * @return otherCalculationMethod
+     */
+    @Valid
+    @Schema(name = "OtherCalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationMethod")
+    public OBOtherCodeType10 getOtherCalculationMethod() {
+        return otherCalculationMethod;
+    }
+
+    public void setOtherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
+        this.otherCalculationMethod = otherCalculationMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner otherDestination(OBOtherCodeType10 otherDestination) {
+        this.otherDestination = otherDestination;
+        return this;
+    }
+
+    /**
+     * Get otherDestination
+     *
+     * @return otherDestination
+     */
+    @Valid
+    @Schema(name = "OtherDestination", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherDestination")
+    public OBOtherCodeType10 getOtherDestination() {
+        return otherDestination;
+    }
+
+    public void setOtherDestination(OBOtherCodeType10 otherDestination) {
+        this.otherDestination = otherDestination;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
+        this.tierBand = tierBand;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner addTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierBandItem) {
+        if (this.tierBand == null) {
+            this.tierBand = new ArrayList<>();
+        }
+        this.tierBand.add(tierBandItem);
+        return this;
+    }
+
+    /**
+     * Get tierBand
+     *
+     * @return tierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBand", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBand")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> getTierBand() {
+        return tierBand;
+    }
+
+    public void setTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
+        this.tierBand = tierBand;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner) o;
+        return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.tierBandMethod) &&
+                Objects.equals(this.calculationMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.calculationMethod) &&
+                Objects.equals(this.destination, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.destination) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.notes) &&
+                Objects.equals(this.otherCalculationMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.otherCalculationMethod) &&
+                Objects.equals(this.otherDestination, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.otherDestination) &&
+                Objects.equals(this.tierBand, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.tierBand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, calculationMethod, destination, notes, otherCalculationMethod, otherDestination, tierBand);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
+        sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherCalculationMethod: ").append(toIndentedString(otherCalculationMethod)).append("\n");
+        sb.append("    otherDestination: ").append(toIndentedString(otherDestination)).append("\n");
+        sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  private OBInterestCalculationMethod1Code calculationMethod;
-
-  /**
-   * Describes whether accrued interest is payable only to the BCA or to another bank account
-   */
-  public enum DestinationEnum {
-    INOT("INOT"),
-    
-    INPA("INPA"),
-    
-    INSC("INSC");
-
-    private String value;
-
-    DestinationEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DestinationEnum fromValue(String value) {
-      for (DestinationEnum b : DestinationEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DestinationEnum destination;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBOtherCodeType10 otherCalculationMethod;
-
-  private OBOtherCodeType10 otherDestination;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand = new ArrayList<>();
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner(TierBandMethodEnum tierBandMethod, DestinationEnum destination, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.destination = destination;
-    this.tierBand = tierBand;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner calculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
-    this.calculationMethod = calculationMethod;
-    return this;
-  }
-
-  /**
-   * Get calculationMethod
-   * @return calculationMethod
-  */
-  @Valid 
-  @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationMethod")
-  public OBInterestCalculationMethod1Code getCalculationMethod() {
-    return calculationMethod;
-  }
-
-  public void setCalculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
-    this.calculationMethod = calculationMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner destination(DestinationEnum destination) {
-    this.destination = destination;
-    return this;
-  }
-
-  /**
-   * Describes whether accrued interest is payable only to the BCA or to another bank account
-   * @return destination
-  */
-  @NotNull 
-  @Schema(name = "Destination", description = "Describes whether accrued interest is payable only to the BCA or to another bank account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Destination")
-  public DestinationEnum getDestination() {
-    return destination;
-  }
-
-  public void setDestination(DestinationEnum destination) {
-    this.destination = destination;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner otherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
-    this.otherCalculationMethod = otherCalculationMethod;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationMethod
-   * @return otherCalculationMethod
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationMethod")
-  public OBOtherCodeType10 getOtherCalculationMethod() {
-    return otherCalculationMethod;
-  }
-
-  public void setOtherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
-    this.otherCalculationMethod = otherCalculationMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner otherDestination(OBOtherCodeType10 otherDestination) {
-    this.otherDestination = otherDestination;
-    return this;
-  }
-
-  /**
-   * Get otherDestination
-   * @return otherDestination
-  */
-  @Valid 
-  @Schema(name = "OtherDestination", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherDestination")
-  public OBOtherCodeType10 getOtherDestination() {
-    return otherDestination;
-  }
-
-  public void setOtherDestination(OBOtherCodeType10 otherDestination) {
-    this.otherDestination = otherDestination;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner tierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
-    this.tierBand = tierBand;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner addTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierBandItem) {
-    if (this.tierBand == null) {
-      this.tierBand = new ArrayList<>();
-    }
-    this.tierBand.add(tierBandItem);
-    return this;
-  }
-
-  /**
-   * Get tierBand
-   * @return tierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBand", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBand")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> getTierBand() {
-    return tierBand;
-  }
-
-  public void setTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner> tierBand) {
-    this.tierBand = tierBand;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner) o;
-    return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.tierBandMethod) &&
-        Objects.equals(this.calculationMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.calculationMethod) &&
-        Objects.equals(this.destination, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.destination) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.notes) &&
-        Objects.equals(this.otherCalculationMethod, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.otherCalculationMethod) &&
-        Objects.equals(this.otherDestination, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.otherDestination) &&
-        Objects.equals(this.tierBand, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.tierBand);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, calculationMethod, destination, notes, otherCalculationMethod, otherDestination, tierBand);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
-    sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherCalculationMethod: ").append(toIndentedString(otherCalculationMethod)).append("\n");
-    sb.append("    otherDestination: ").append(toIndentedString(otherDestination)).append("\n");
-    sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Describes whether accrued interest is payable only to the BCA or to another bank account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination {
+
+    INOT("INOT"),
+
+    INPA("INPA"),
+
+    INSC("INSC");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
@@ -15,27 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBInterestFixedVariableType1Code;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType11;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType12;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Tier Band Details
@@ -46,576 +38,416 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMinimum;
+    private String tierValueMinimum;
 
-  private String tierValueMaximum;
+    private String tierValueMaximum;
 
-  /**
-   * How often is credit interest calculated for the account.
-   */
-  public enum CalculationFrequencyEnum {
-    FQAT("FQAT"),
-    
-    FQDY("FQDY"),
-    
-    FQHY("FQHY"),
-    
-    FQMY("FQMY"),
-    
-    FQOT("FQOT"),
-    
-    FQQY("FQQY"),
-    
-    FQSD("FQSD"),
-    
-    FQWY("FQWY"),
-    
-    FQYY("FQYY");
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency calculationFrequency;
 
-    private String value;
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency applicationFrequency;
 
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage depositInterestAppliedCoverage;
+
+    private OBInterestFixedVariableType1Code fixedVariableInterestRateType;
+
+    private String AER;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType bankInterestRateType;
+
+    private String bankInterestRate;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType;
+
+    private OBOtherCodeType11 otherApplicationFrequency;
+
+    private OBOtherCodeType12 otherCalculationFrequency;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner(String tierValueMinimum, OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency applicationFrequency, OBInterestFixedVariableType1Code fixedVariableInterestRateType, String AER) {
+        this.tierValueMinimum = tierValueMinimum;
+        this.applicationFrequency = applicationFrequency;
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        this.AER = AER;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for the Product.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for the Product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+        return this;
+    }
+
+    /**
+     * Minimum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMinimum
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMinimum")
+    public String getTierValueMinimum() {
+        return tierValueMinimum;
+    }
+
+    public void setTierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+        return this;
+    }
+
+    /**
+     * Maximum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMaximum
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMaximum")
+    public String getTierValueMaximum() {
+        return tierValueMaximum;
+    }
+
+    public void setTierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner calculationFrequency(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner applicationFrequency(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner depositInterestAppliedCoverage(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+        return this;
+    }
+
+    /**
+     * Get depositInterestAppliedCoverage
+     *
+     * @return depositInterestAppliedCoverage
+     */
+    @Valid
+    @Schema(name = "DepositInterestAppliedCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DepositInterestAppliedCoverage")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage getDepositInterestAppliedCoverage() {
+        return depositInterestAppliedCoverage;
+    }
+
+    public void setDepositInterestAppliedCoverage(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner fixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get fixedVariableInterestRateType
+     *
+     * @return fixedVariableInterestRateType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FixedVariableInterestRateType")
+    public OBInterestFixedVariableType1Code getFixedVariableInterestRateType() {
+        return fixedVariableInterestRateType;
+    }
+
+    public void setFixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner AER(String AER) {
+        this.AER = AER;
+        return this;
+    }
+
+    /**
+     * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
+     *
+     * @return AER
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AER")
+    public String getAER() {
+        return AER;
+    }
+
+    public void setAER(String AER) {
+        this.AER = AER;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner bankInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get bankInterestRateType
+     *
+     * @return bankInterestRateType
+     */
+    @Valid
+    @Schema(name = "BankInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRateType")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType getBankInterestRateType() {
+        return bankInterestRateType;
+    }
+
+    public void setBankInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner bankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+        return this;
+    }
+
+    /**
+     * Bank Interest for the product
+     *
+     * @return bankInterestRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BankInterestRate", description = "Bank Interest for the product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRate")
+    public String getBankInterestRate() {
+        return bankInterestRate;
+    }
+
+    public void setBankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherBankInterestType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+        return this;
+    }
+
+    /**
+     * Get otherBankInterestType
+     *
+     * @return otherBankInterestType
+     */
+    @Valid
+    @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherBankInterestType")
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType getOtherBankInterestType() {
+        return otherBankInterestType;
+    }
+
+    public void setOtherBankInterestType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OBOtherCodeType11 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OBOtherCodeType12 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner) o;
+        return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.identification) &&
+                Objects.equals(this.tierValueMinimum, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.tierValueMinimum) &&
+                Objects.equals(this.tierValueMaximum, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.tierValueMaximum) &&
+                Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.calculationFrequency) &&
+                Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.applicationFrequency) &&
+                Objects.equals(this.depositInterestAppliedCoverage, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.depositInterestAppliedCoverage) &&
+                Objects.equals(this.fixedVariableInterestRateType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.fixedVariableInterestRateType) &&
+                Objects.equals(this.AER, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.AER) &&
+                Objects.equals(this.bankInterestRateType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.bankInterestRateType) &&
+                Objects.equals(this.bankInterestRate, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.bankInterestRate) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.notes) &&
+                Objects.equals(this.otherBankInterestType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherBankInterestType) &&
+                Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
+        sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
+        sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
+        sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
+        sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
+        sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  /**
-   * How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.
-   */
-  public enum ApplicationFrequencyEnum {
-    FQAT("FQAT"),
-    
-    FQDY("FQDY"),
-    
-    FQHY("FQHY"),
-    
-    FQMY("FQMY"),
-    
-    FQOT("FQOT"),
-    
-    FQQY("FQQY"),
-    
-    FQSD("FQSD"),
-    
-    FQWY("FQWY"),
-    
-    FQYY("FQYY");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * Amount on which Interest applied.
-   */
-  public enum DepositInterestAppliedCoverageEnum {
-    INBA("INBA"),
-    
-    INTI("INTI"),
-    
-    INWH("INWH");
-
-    private String value;
-
-    DepositInterestAppliedCoverageEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DepositInterestAppliedCoverageEnum fromValue(String value) {
-      for (DepositInterestAppliedCoverageEnum b : DepositInterestAppliedCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage;
-
-  private OBInterestFixedVariableType1Code fixedVariableInterestRateType;
-
-  private String AER;
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.
-   */
-  public enum BankInterestRateTypeEnum {
-    INBB("INBB"),
-    
-    INFR("INFR"),
-    
-    INGR("INGR"),
-    
-    INLR("INLR"),
-    
-    INNE("INNE"),
-    
-    INOT("INOT");
-
-    private String value;
-
-    BankInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static BankInterestRateTypeEnum fromValue(String value) {
-      for (BankInterestRateTypeEnum b : BankInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private BankInterestRateTypeEnum bankInterestRateType;
-
-  private String bankInterestRate;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType;
-
-  private OBOtherCodeType11 otherApplicationFrequency;
-
-  private OBOtherCodeType12 otherCalculationFrequency;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner(String tierValueMinimum, ApplicationFrequencyEnum applicationFrequency, OBInterestFixedVariableType1Code fixedVariableInterestRateType, String AER) {
-    this.tierValueMinimum = tierValueMinimum;
-    this.applicationFrequency = applicationFrequency;
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    this.AER = AER;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for the Product.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for the Product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-    return this;
-  }
-
-  /**
-   * Minimum deposit value for which the credit interest tier applies.
-   * @return tierValueMinimum
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMinimum")
-  public String getTierValueMinimum() {
-    return tierValueMinimum;
-  }
-
-  public void setTierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner tierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-    return this;
-  }
-
-  /**
-   * Maximum deposit value for which the credit interest tier applies.
-   * @return tierValueMaximum
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMaximum")
-  public String getTierValueMaximum() {
-    return tierValueMaximum;
-  }
-
-  public void setTierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is credit interest calculated for the account.
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How often is credit interest calculated for the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner depositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-    return this;
-  }
-
-  /**
-   * Amount on which Interest applied.
-   * @return depositInterestAppliedCoverage
-  */
-  
-  @Schema(name = "DepositInterestAppliedCoverage", description = "Amount on which Interest applied.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DepositInterestAppliedCoverage")
-  public DepositInterestAppliedCoverageEnum getDepositInterestAppliedCoverage() {
-    return depositInterestAppliedCoverage;
-  }
-
-  public void setDepositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner fixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    return this;
-  }
-
-  /**
-   * Get fixedVariableInterestRateType
-   * @return fixedVariableInterestRateType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FixedVariableInterestRateType")
-  public OBInterestFixedVariableType1Code getFixedVariableInterestRateType() {
-    return fixedVariableInterestRateType;
-  }
-
-  public void setFixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner AER(String AER) {
-    this.AER = AER;
-    return this;
-  }
-
-  /**
-   * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
-   * @return AER
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AER")
-  public String getAER() {
-    return AER;
-  }
-
-  public void setAER(String AER) {
-    this.AER = AER;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner bankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-    return this;
-  }
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.
-   * @return bankInterestRateType
-  */
-  
-  @Schema(name = "BankInterestRateType", description = "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRateType")
-  public BankInterestRateTypeEnum getBankInterestRateType() {
-    return bankInterestRateType;
-  }
-
-  public void setBankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner bankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-    return this;
-  }
-
-  /**
-   * Bank Interest for the product
-   * @return bankInterestRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BankInterestRate", description = "Bank Interest for the product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRate")
-  public String getBankInterestRate() {
-    return bankInterestRate;
-  }
-
-  public void setBankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherBankInterestType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-    return this;
-  }
-
-  /**
-   * Get otherBankInterestType
-   * @return otherBankInterestType
-  */
-  @Valid 
-  @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherBankInterestType")
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType getOtherBankInterestType() {
-    return otherBankInterestType;
-  }
-
-  public void setOtherBankInterestType(OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OBOtherCodeType11 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner otherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OBOtherCodeType12 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner) o;
-    return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.identification) &&
-        Objects.equals(this.tierValueMinimum, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.tierValueMinimum) &&
-        Objects.equals(this.tierValueMaximum, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.tierValueMaximum) &&
-        Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.calculationFrequency) &&
-        Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.applicationFrequency) &&
-        Objects.equals(this.depositInterestAppliedCoverage, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.depositInterestAppliedCoverage) &&
-        Objects.equals(this.fixedVariableInterestRateType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.fixedVariableInterestRateType) &&
-        Objects.equals(this.AER, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.AER) &&
-        Objects.equals(this.bankInterestRateType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.bankInterestRateType) &&
-        Objects.equals(this.bankInterestRate, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.bankInterestRate) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.notes) &&
-        Objects.equals(this.otherBankInterestType, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherBankInterestType) &&
-        Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.otherCalculationFrequency);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
-    sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
-    sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
-    sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
-    sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
-    sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency {
+
+    FQAT("FQAT"),
+
+    FQDY("FQDY"),
+
+    FQHY("FQHY"),
+
+    FQMY("FQMY"),
+
+    FQOT("FQOT"),
+
+    FQQY("FQQY"),
+
+    FQSD("FQSD"),
+
+    FQWY("FQWY"),
+
+    FQYY("FQYY");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType {
+
+    INBB("INBB"),
+
+    INFR("INFR"),
+
+    INGR("INGR"),
+
+    INLR("INLR"),
+
+    INNE("INNE"),
+
+    INOT("INOT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * How often is credit interest calculated for the account.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency {
+
+    FQAT("FQAT"),
+
+    FQDY("FQDY"),
+
+    FQHY("FQHY"),
+
+    FQMY("FQMY"),
+
+    FQOT("FQOT"),
+
+    FQQY("FQQY"),
+
+    FQSD("FQSD"),
+
+    FQWY("FQWY"),
+
+    FQYY("FQYY");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Amount on which Interest applied.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage {
+
+    INBA("INBA"),
+
+    INTI("INTI"),
+
+    INWH("INWH");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
@@ -15,19 +15,16 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other interest rate types which are not available in the standard code list
@@ -38,123 +35,128 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType = (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how credit interest is paid/applied. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the product holder's account balance
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod {
+
+    INBA("INBA"),
+
+    INTI("INTI"),
+
+    INWH("INWH");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod b : OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
@@ -15,18 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about the interest that may be payable to the SME Loan holders
@@ -37,116 +48,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterest {
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet = new ArrayList<>();
 
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
-    this.loanInterestTierBandSet = loanInterestTierBandSet;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterestTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
-    this.loanInterestTierBandSet = loanInterestTierBandSet;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest addLoanInterestTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestTierBandSetItem) {
-    if (this.loanInterestTierBandSet == null) {
-      this.loanInterestTierBandSet = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
+        this.loanInterestTierBandSet = loanInterestTierBandSet;
     }
-    this.loanInterestTierBandSet.add(loanInterestTierBandSetItem);
-    return this;
-  }
 
-  /**
-   * Get loanInterestTierBandSet
-   * @return loanInterestTierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "LoanInterestTierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("LoanInterestTierBandSet")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> getLoanInterestTierBandSet() {
-    return loanInterestTierBandSet;
-  }
-
-  public void setLoanInterestTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
-    this.loanInterestTierBandSet = loanInterestTierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterest obReadProduct2DataProductInnerOtherProductTypeLoanInterest = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterest) o;
-    return Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterest.notes) &&
-        Objects.equals(this.loanInterestTierBandSet, obReadProduct2DataProductInnerOtherProductTypeLoanInterest.loanInterestTierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(notes, loanInterestTierBandSet);
-  }
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
 
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterest {\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    loanInterestTierBandSet: ").append(toIndentedString(loanInterestTierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest loanInterestTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
+        this.loanInterestTierBandSet = loanInterestTierBandSet;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterest addLoanInterestTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestTierBandSetItem) {
+        if (this.loanInterestTierBandSet == null) {
+            this.loanInterestTierBandSet = new ArrayList<>();
+        }
+        this.loanInterestTierBandSet.add(loanInterestTierBandSetItem);
+        return this;
+    }
+
+    /**
+     * Get loanInterestTierBandSet
+     *
+     * @return loanInterestTierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "LoanInterestTierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("LoanInterestTierBandSet")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> getLoanInterestTierBandSet() {
+        return loanInterestTierBandSet;
+    }
+
+    public void setLoanInterestTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner> loanInterestTierBandSet) {
+        this.loanInterestTierBandSet = loanInterestTierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterest obReadProduct2DataProductInnerOtherProductTypeLoanInterest = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterest) o;
+        return Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterest.notes) &&
+                Objects.equals(this.loanInterestTierBandSet, obReadProduct2DataProductInnerOtherProductTypeLoanInterest.loanInterestTierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notes, loanInterestTierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterest {\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    loanInterestTierBandSet: ").append(toIndentedString(loanInterestTierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
@@ -15,27 +15,18 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBInterestCalculationMethod1Code;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType10;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * The group of tiers or bands for which debit interest can be applied.
@@ -46,284 +37,258 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner {
 
-  /**
-   * The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance
-   */
-  public enum TierBandMethodEnum {
-    INBA("INBA"),
-    
-    INTI("INTI"),
-    
-    INWH("INWH");
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod tierBandMethod;
 
-    private String value;
+    private String identification;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private OBInterestCalculationMethod1Code calculationMethod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBOtherCodeType10 otherCalculationMethod;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand = new ArrayList<>();
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod tierBandMethod, OBInterestCalculationMethod1Code calculationMethod, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.calculationMethod = calculationMethod;
+        this.loanInterestTierBand = loanInterestTierBand;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner tierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Loan interest tierbandset identification. Used by  loan providers for internal use purpose.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Loan interest tierbandset identification. Used by  loan providers for internal use purpose.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner calculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
+        this.calculationMethod = calculationMethod;
+        return this;
+    }
+
+    /**
+     * Get calculationMethod
+     *
+     * @return calculationMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CalculationMethod")
+    public OBInterestCalculationMethod1Code getCalculationMethod() {
+        return calculationMethod;
+    }
+
+    public void setCalculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
+        this.calculationMethod = calculationMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner otherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
+        this.otherCalculationMethod = otherCalculationMethod;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationMethod
+     *
+     * @return otherCalculationMethod
+     */
+    @Valid
+    @Schema(name = "OtherCalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationMethod")
+    public OBOtherCodeType10 getOtherCalculationMethod() {
+        return otherCalculationMethod;
+    }
+
+    public void setOtherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
+        this.otherCalculationMethod = otherCalculationMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
+        this.loanInterestTierBand = loanInterestTierBand;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addLoanInterestTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanInterestTierBandItem) {
+        if (this.loanInterestTierBand == null) {
+            this.loanInterestTierBand = new ArrayList<>();
+        }
+        this.loanInterestTierBand.add(loanInterestTierBandItem);
+        return this;
+    }
+
+    /**
+     * Get loanInterestTierBand
+     *
+     * @return loanInterestTierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "LoanInterestTierBand", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("LoanInterestTierBand")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> getLoanInterestTierBand() {
+        return loanInterestTierBand;
+    }
+
+    public void setLoanInterestTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
+        this.loanInterestTierBand = loanInterestTierBand;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
+        this.loanInterestFeesCharges = loanInterestFeesCharges;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addLoanInterestFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeesChargesItem) {
+        if (this.loanInterestFeesCharges == null) {
+            this.loanInterestFeesCharges = new ArrayList<>();
+        }
+        this.loanInterestFeesCharges.add(loanInterestFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Get loanInterestFeesCharges
+     *
+     * @return loanInterestFeesCharges
+     */
+    @Valid
+    @Schema(name = "LoanInterestFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanInterestFeesCharges")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> getLoanInterestFeesCharges() {
+        return loanInterestFeesCharges;
+    }
+
+    public void setLoanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
+        this.loanInterestFeesCharges = loanInterestFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner) o;
+        return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.tierBandMethod) &&
+                Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.identification) &&
+                Objects.equals(this.calculationMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.calculationMethod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.notes) &&
+                Objects.equals(this.otherCalculationMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.otherCalculationMethod) &&
+                Objects.equals(this.loanInterestTierBand, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.loanInterestTierBand) &&
+                Objects.equals(this.loanInterestFeesCharges, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.loanInterestFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, identification, calculationMethod, notes, otherCalculationMethod, loanInterestTierBand, loanInterestFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherCalculationMethod: ").append(toIndentedString(otherCalculationMethod)).append("\n");
+        sb.append("    loanInterestTierBand: ").append(toIndentedString(loanInterestTierBand)).append("\n");
+        sb.append("    loanInterestFeesCharges: ").append(toIndentedString(loanInterestFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  private String identification;
-
-  private OBInterestCalculationMethod1Code calculationMethod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBOtherCodeType10 otherCalculationMethod;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand = new ArrayList<>();
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner(TierBandMethodEnum tierBandMethod, OBInterestCalculationMethod1Code calculationMethod, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.calculationMethod = calculationMethod;
-    this.loanInterestTierBand = loanInterestTierBand;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Loan interest tierbandset identification. Used by  loan providers for internal use purpose.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Loan interest tierbandset identification. Used by  loan providers for internal use purpose.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner calculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
-    this.calculationMethod = calculationMethod;
-    return this;
-  }
-
-  /**
-   * Get calculationMethod
-   * @return calculationMethod
-  */
-  @NotNull @Valid 
-  @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CalculationMethod")
-  public OBInterestCalculationMethod1Code getCalculationMethod() {
-    return calculationMethod;
-  }
-
-  public void setCalculationMethod(OBInterestCalculationMethod1Code calculationMethod) {
-    this.calculationMethod = calculationMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner otherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
-    this.otherCalculationMethod = otherCalculationMethod;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationMethod
-   * @return otherCalculationMethod
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationMethod")
-  public OBOtherCodeType10 getOtherCalculationMethod() {
-    return otherCalculationMethod;
-  }
-
-  public void setOtherCalculationMethod(OBOtherCodeType10 otherCalculationMethod) {
-    this.otherCalculationMethod = otherCalculationMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
-    this.loanInterestTierBand = loanInterestTierBand;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addLoanInterestTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanInterestTierBandItem) {
-    if (this.loanInterestTierBand == null) {
-      this.loanInterestTierBand = new ArrayList<>();
-    }
-    this.loanInterestTierBand.add(loanInterestTierBandItem);
-    return this;
-  }
-
-  /**
-   * Get loanInterestTierBand
-   * @return loanInterestTierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "LoanInterestTierBand", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("LoanInterestTierBand")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> getLoanInterestTierBand() {
-    return loanInterestTierBand;
-  }
-
-  public void setLoanInterestTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner> loanInterestTierBand) {
-    this.loanInterestTierBand = loanInterestTierBand;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner loanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
-    this.loanInterestFeesCharges = loanInterestFeesCharges;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner addLoanInterestFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeesChargesItem) {
-    if (this.loanInterestFeesCharges == null) {
-      this.loanInterestFeesCharges = new ArrayList<>();
-    }
-    this.loanInterestFeesCharges.add(loanInterestFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Get loanInterestFeesCharges
-   * @return loanInterestFeesCharges
-  */
-  @Valid 
-  @Schema(name = "LoanInterestFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanInterestFeesCharges")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> getLoanInterestFeesCharges() {
-    return loanInterestFeesCharges;
-  }
-
-  public void setLoanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
-    this.loanInterestFeesCharges = loanInterestFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner) o;
-    return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.tierBandMethod) &&
-        Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.identification) &&
-        Objects.equals(this.calculationMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.calculationMethod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.notes) &&
-        Objects.equals(this.otherCalculationMethod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.otherCalculationMethod) &&
-        Objects.equals(this.loanInterestTierBand, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.loanInterestTierBand) &&
-        Objects.equals(this.loanInterestFeesCharges, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.loanInterestFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, identification, calculationMethod, notes, otherCalculationMethod, loanInterestTierBand, loanInterestFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherCalculationMethod: ").append(toIndentedString(otherCalculationMethod)).append("\n");
-    sb.append("    loanInterestTierBand: ").append(toIndentedString(loanInterestTierBand)).append("\n");
-    sb.append("    loanInterestFeesCharges: ").append(toIndentedString(loanInterestFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
@@ -15,26 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBInterestFixedVariableType1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Tier Band Details
@@ -45,541 +38,426 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMinimum;
+    private String tierValueMinimum;
 
-  private String tierValueMaximum;
+    private String tierValueMaximum;
 
-  private Integer tierValueMinTerm;
+    private Integer tierValueMinTerm;
 
-  /**
-   * The unit of period (days, weeks, months etc.) of the Minimum Term
-   */
-  public enum MinTermPeriodEnum {
-    PACT("PACT"),
-    
-    PDAY("PDAY"),
-    
-    PHYR("PHYR"),
-    
-    PMTH("PMTH"),
-    
-    PQTR("PQTR"),
-    
-    PWEK("PWEK"),
-    
-    PYER("PYER");
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod minTermPeriod;
 
-    private String value;
+    private Integer tierValueMaxTerm;
 
-    MinTermPeriodEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod maxTermPeriod;
+
+    private OBInterestFixedVariableType1Code fixedVariableInterestRateType;
+
+    private String repAPR;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType loanProviderInterestRateType;
+
+    private String loanProviderInterestRate;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner(String tierValueMinimum, Integer tierValueMinTerm, OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod minTermPeriod, OBInterestFixedVariableType1Code fixedVariableInterestRateType, String repAPR) {
+        this.tierValueMinimum = tierValueMinimum;
+        this.tierValueMinTerm = tierValueMinTerm;
+        this.minTermPeriod = minTermPeriod;
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        this.repAPR = repAPR;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a SME Loan.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a SME Loan.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+        return this;
+    }
+
+    /**
+     * Minimum loan value for which the loan interest tier applies.
+     *
+     * @return tierValueMinimum
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMinimum", description = "Minimum loan value for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMinimum")
+    public String getTierValueMinimum() {
+        return tierValueMinimum;
+    }
+
+    public void setTierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+        return this;
+    }
+
+    /**
+     * Maximum loan value for which the loan interest tier applies.
+     *
+     * @return tierValueMaximum
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMaximum", description = "Maximum loan value for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMaximum")
+    public String getTierValueMaximum() {
+        return tierValueMaximum;
+    }
+
+    public void setTierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMinTerm(Integer tierValueMinTerm) {
+        this.tierValueMinTerm = tierValueMinTerm;
+        return this;
+    }
+
+    /**
+     * Minimum loan term for which the loan interest tier applies.
+     *
+     * @return tierValueMinTerm
+     */
+    @NotNull
+    @Schema(name = "TierValueMinTerm", description = "Minimum loan term for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMinTerm")
+    public Integer getTierValueMinTerm() {
+        return tierValueMinTerm;
+    }
+
+    public void setTierValueMinTerm(Integer tierValueMinTerm) {
+        this.tierValueMinTerm = tierValueMinTerm;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner minTermPeriod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod minTermPeriod) {
+        this.minTermPeriod = minTermPeriod;
+        return this;
+    }
+
+    /**
+     * Get minTermPeriod
+     *
+     * @return minTermPeriod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinTermPeriod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinTermPeriod")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod getMinTermPeriod() {
+        return minTermPeriod;
+    }
+
+    public void setMinTermPeriod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod minTermPeriod) {
+        this.minTermPeriod = minTermPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMaxTerm(Integer tierValueMaxTerm) {
+        this.tierValueMaxTerm = tierValueMaxTerm;
+        return this;
+    }
+
+    /**
+     * Maximum loan term for which the loan interest tier applies.
+     *
+     * @return tierValueMaxTerm
+     */
+
+    @Schema(name = "TierValueMaxTerm", description = "Maximum loan term for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMaxTerm")
+    public Integer getTierValueMaxTerm() {
+        return tierValueMaxTerm;
+    }
+
+    public void setTierValueMaxTerm(Integer tierValueMaxTerm) {
+        this.tierValueMaxTerm = tierValueMaxTerm;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner maxTermPeriod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod maxTermPeriod) {
+        this.maxTermPeriod = maxTermPeriod;
+        return this;
+    }
+
+    /**
+     * Get maxTermPeriod
+     *
+     * @return maxTermPeriod
+     */
+    @Valid
+    @Schema(name = "MaxTermPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaxTermPeriod")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod getMaxTermPeriod() {
+        return maxTermPeriod;
+    }
+
+    public void setMaxTermPeriod(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod maxTermPeriod) {
+        this.maxTermPeriod = maxTermPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner fixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get fixedVariableInterestRateType
+     *
+     * @return fixedVariableInterestRateType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FixedVariableInterestRateType")
+    public OBInterestFixedVariableType1Code getFixedVariableInterestRateType() {
+        return fixedVariableInterestRateType;
+    }
+
+    public void setFixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner repAPR(String repAPR) {
+        this.repAPR = repAPR;
+        return this;
+    }
+
+    /**
+     * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees.
+     *
+     * @return repAPR
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "RepAPR", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("RepAPR")
+    public String getRepAPR() {
+        return repAPR;
+    }
+
+    public void setRepAPR(String repAPR) {
+        this.repAPR = repAPR;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType loanProviderInterestRateType) {
+        this.loanProviderInterestRateType = loanProviderInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get loanProviderInterestRateType
+     *
+     * @return loanProviderInterestRateType
+     */
+    @Valid
+    @Schema(name = "LoanProviderInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanProviderInterestRateType")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType getLoanProviderInterestRateType() {
+        return loanProviderInterestRateType;
+    }
+
+    public void setLoanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType loanProviderInterestRateType) {
+        this.loanProviderInterestRateType = loanProviderInterestRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanProviderInterestRate(String loanProviderInterestRate) {
+        this.loanProviderInterestRate = loanProviderInterestRate;
+        return this;
+    }
+
+    /**
+     * Loan provider Interest for the SME Loan product
+     *
+     * @return loanProviderInterestRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "LoanProviderInterestRate", description = "Loan provider Interest for the SME Loan product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanProviderInterestRate")
+    public String getLoanProviderInterestRate() {
+        return loanProviderInterestRate;
+    }
+
+    public void setLoanProviderInterestRate(String loanProviderInterestRate) {
+        this.loanProviderInterestRate = loanProviderInterestRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner otherLoanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType) {
+        this.otherLoanProviderInterestRateType = otherLoanProviderInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get otherLoanProviderInterestRateType
+     *
+     * @return otherLoanProviderInterestRateType
+     */
+    @Valid
+    @Schema(name = "OtherLoanProviderInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherLoanProviderInterestRateType")
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType getOtherLoanProviderInterestRateType() {
+        return otherLoanProviderInterestRateType;
+    }
+
+    public void setOtherLoanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType) {
+        this.otherLoanProviderInterestRateType = otherLoanProviderInterestRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
+        this.loanInterestFeesCharges = loanInterestFeesCharges;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner addLoanInterestFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeesChargesItem) {
+        if (this.loanInterestFeesCharges == null) {
+            this.loanInterestFeesCharges = new ArrayList<>();
+        }
+        this.loanInterestFeesCharges.add(loanInterestFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Get loanInterestFeesCharges
+     *
+     * @return loanInterestFeesCharges
+     */
+    @Valid
+    @Schema(name = "LoanInterestFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanInterestFeesCharges")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> getLoanInterestFeesCharges() {
+        return loanInterestFeesCharges;
+    }
+
+    public void setLoanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
+        this.loanInterestFeesCharges = loanInterestFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner) o;
+        return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.identification) &&
+                Objects.equals(this.tierValueMinimum, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMinimum) &&
+                Objects.equals(this.tierValueMaximum, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMaximum) &&
+                Objects.equals(this.tierValueMinTerm, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMinTerm) &&
+                Objects.equals(this.minTermPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.minTermPeriod) &&
+                Objects.equals(this.tierValueMaxTerm, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMaxTerm) &&
+                Objects.equals(this.maxTermPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.maxTermPeriod) &&
+                Objects.equals(this.fixedVariableInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.fixedVariableInterestRateType) &&
+                Objects.equals(this.repAPR, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.repAPR) &&
+                Objects.equals(this.loanProviderInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanProviderInterestRateType) &&
+                Objects.equals(this.loanProviderInterestRate, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanProviderInterestRate) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.notes) &&
+                Objects.equals(this.otherLoanProviderInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.otherLoanProviderInterestRateType) &&
+                Objects.equals(this.loanInterestFeesCharges, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanInterestFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMinimum, tierValueMaximum, tierValueMinTerm, minTermPeriod, tierValueMaxTerm, maxTermPeriod, fixedVariableInterestRateType, repAPR, loanProviderInterestRateType, loanProviderInterestRate, notes, otherLoanProviderInterestRateType, loanInterestFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
+        sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
+        sb.append("    tierValueMinTerm: ").append(toIndentedString(tierValueMinTerm)).append("\n");
+        sb.append("    minTermPeriod: ").append(toIndentedString(minTermPeriod)).append("\n");
+        sb.append("    tierValueMaxTerm: ").append(toIndentedString(tierValueMaxTerm)).append("\n");
+        sb.append("    maxTermPeriod: ").append(toIndentedString(maxTermPeriod)).append("\n");
+        sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
+        sb.append("    repAPR: ").append(toIndentedString(repAPR)).append("\n");
+        sb.append("    loanProviderInterestRateType: ").append(toIndentedString(loanProviderInterestRateType)).append("\n");
+        sb.append("    loanProviderInterestRate: ").append(toIndentedString(loanProviderInterestRate)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherLoanProviderInterestRateType: ").append(toIndentedString(otherLoanProviderInterestRateType)).append("\n");
+        sb.append("    loanInterestFeesCharges: ").append(toIndentedString(loanInterestFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static MinTermPeriodEnum fromValue(String value) {
-      for (MinTermPeriodEnum b : MinTermPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private MinTermPeriodEnum minTermPeriod;
-
-  private Integer tierValueMaxTerm;
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the Maximum Term
-   */
-  public enum MaxTermPeriodEnum {
-    PACT("PACT"),
-    
-    PDAY("PDAY"),
-    
-    PHYR("PHYR"),
-    
-    PMTH("PMTH"),
-    
-    PQTR("PQTR"),
-    
-    PWEK("PWEK"),
-    
-    PYER("PYER");
-
-    private String value;
-
-    MaxTermPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MaxTermPeriodEnum fromValue(String value) {
-      for (MaxTermPeriodEnum b : MaxTermPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MaxTermPeriodEnum maxTermPeriod;
-
-  private OBInterestFixedVariableType1Code fixedVariableInterestRateType;
-
-  private String repAPR;
-
-  /**
-   * Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.
-   */
-  public enum LoanProviderInterestRateTypeEnum {
-    INBB("INBB"),
-    
-    INFR("INFR"),
-    
-    INGR("INGR"),
-    
-    INLR("INLR"),
-    
-    INNE("INNE"),
-    
-    INOT("INOT");
-
-    private String value;
-
-    LoanProviderInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static LoanProviderInterestRateTypeEnum fromValue(String value) {
-      for (LoanProviderInterestRateTypeEnum b : LoanProviderInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private LoanProviderInterestRateTypeEnum loanProviderInterestRateType;
-
-  private String loanProviderInterestRate;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner(String tierValueMinimum, Integer tierValueMinTerm, MinTermPeriodEnum minTermPeriod, OBInterestFixedVariableType1Code fixedVariableInterestRateType, String repAPR) {
-    this.tierValueMinimum = tierValueMinimum;
-    this.tierValueMinTerm = tierValueMinTerm;
-    this.minTermPeriod = minTermPeriod;
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    this.repAPR = repAPR;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a SME Loan.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a SME Loan.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-    return this;
-  }
-
-  /**
-   * Minimum loan value for which the loan interest tier applies.
-   * @return tierValueMinimum
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMinimum", description = "Minimum loan value for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMinimum")
-  public String getTierValueMinimum() {
-    return tierValueMinimum;
-  }
-
-  public void setTierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-    return this;
-  }
-
-  /**
-   * Maximum loan value for which the loan interest tier applies.
-   * @return tierValueMaximum
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMaximum", description = "Maximum loan value for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMaximum")
-  public String getTierValueMaximum() {
-    return tierValueMaximum;
-  }
-
-  public void setTierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMinTerm(Integer tierValueMinTerm) {
-    this.tierValueMinTerm = tierValueMinTerm;
-    return this;
-  }
-
-  /**
-   * Minimum loan term for which the loan interest tier applies.
-   * @return tierValueMinTerm
-  */
-  @NotNull 
-  @Schema(name = "TierValueMinTerm", description = "Minimum loan term for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMinTerm")
-  public Integer getTierValueMinTerm() {
-    return tierValueMinTerm;
-  }
-
-  public void setTierValueMinTerm(Integer tierValueMinTerm) {
-    this.tierValueMinTerm = tierValueMinTerm;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner minTermPeriod(MinTermPeriodEnum minTermPeriod) {
-    this.minTermPeriod = minTermPeriod;
-    return this;
-  }
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the Minimum Term
-   * @return minTermPeriod
-  */
-  @NotNull 
-  @Schema(name = "MinTermPeriod", description = "The unit of period (days, weeks, months etc.) of the Minimum Term", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinTermPeriod")
-  public MinTermPeriodEnum getMinTermPeriod() {
-    return minTermPeriod;
-  }
-
-  public void setMinTermPeriod(MinTermPeriodEnum minTermPeriod) {
-    this.minTermPeriod = minTermPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner tierValueMaxTerm(Integer tierValueMaxTerm) {
-    this.tierValueMaxTerm = tierValueMaxTerm;
-    return this;
-  }
-
-  /**
-   * Maximum loan term for which the loan interest tier applies.
-   * @return tierValueMaxTerm
-  */
-  
-  @Schema(name = "TierValueMaxTerm", description = "Maximum loan term for which the loan interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMaxTerm")
-  public Integer getTierValueMaxTerm() {
-    return tierValueMaxTerm;
-  }
-
-  public void setTierValueMaxTerm(Integer tierValueMaxTerm) {
-    this.tierValueMaxTerm = tierValueMaxTerm;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner maxTermPeriod(MaxTermPeriodEnum maxTermPeriod) {
-    this.maxTermPeriod = maxTermPeriod;
-    return this;
-  }
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the Maximum Term
-   * @return maxTermPeriod
-  */
-  
-  @Schema(name = "MaxTermPeriod", description = "The unit of period (days, weeks, months etc.) of the Maximum Term", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaxTermPeriod")
-  public MaxTermPeriodEnum getMaxTermPeriod() {
-    return maxTermPeriod;
-  }
-
-  public void setMaxTermPeriod(MaxTermPeriodEnum maxTermPeriod) {
-    this.maxTermPeriod = maxTermPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner fixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    return this;
-  }
-
-  /**
-   * Get fixedVariableInterestRateType
-   * @return fixedVariableInterestRateType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FixedVariableInterestRateType")
-  public OBInterestFixedVariableType1Code getFixedVariableInterestRateType() {
-    return fixedVariableInterestRateType;
-  }
-
-  public void setFixedVariableInterestRateType(OBInterestFixedVariableType1Code fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner repAPR(String repAPR) {
-    this.repAPR = repAPR;
-    return this;
-  }
-
-  /**
-   * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees.
-   * @return repAPR
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "RepAPR", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.  For SME Loan, this APR is the representative APR which includes any account fees.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("RepAPR")
-  public String getRepAPR() {
-    return repAPR;
-  }
-
-  public void setRepAPR(String repAPR) {
-    this.repAPR = repAPR;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanProviderInterestRateType(LoanProviderInterestRateTypeEnum loanProviderInterestRateType) {
-    this.loanProviderInterestRateType = loanProviderInterestRateType;
-    return this;
-  }
-
-  /**
-   * Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.
-   * @return loanProviderInterestRateType
-  */
-  
-  @Schema(name = "LoanProviderInterestRateType", description = "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanProviderInterestRateType")
-  public LoanProviderInterestRateTypeEnum getLoanProviderInterestRateType() {
-    return loanProviderInterestRateType;
-  }
-
-  public void setLoanProviderInterestRateType(LoanProviderInterestRateTypeEnum loanProviderInterestRateType) {
-    this.loanProviderInterestRateType = loanProviderInterestRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanProviderInterestRate(String loanProviderInterestRate) {
-    this.loanProviderInterestRate = loanProviderInterestRate;
-    return this;
-  }
-
-  /**
-   * Loan provider Interest for the SME Loan product
-   * @return loanProviderInterestRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "LoanProviderInterestRate", description = "Loan provider Interest for the SME Loan product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanProviderInterestRate")
-  public String getLoanProviderInterestRate() {
-    return loanProviderInterestRate;
-  }
-
-  public void setLoanProviderInterestRate(String loanProviderInterestRate) {
-    this.loanProviderInterestRate = loanProviderInterestRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner otherLoanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType) {
-    this.otherLoanProviderInterestRateType = otherLoanProviderInterestRateType;
-    return this;
-  }
-
-  /**
-   * Get otherLoanProviderInterestRateType
-   * @return otherLoanProviderInterestRateType
-  */
-  @Valid 
-  @Schema(name = "OtherLoanProviderInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherLoanProviderInterestRateType")
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType getOtherLoanProviderInterestRateType() {
-    return otherLoanProviderInterestRateType;
-  }
-
-  public void setOtherLoanProviderInterestRateType(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType otherLoanProviderInterestRateType) {
-    this.otherLoanProviderInterestRateType = otherLoanProviderInterestRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner loanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
-    this.loanInterestFeesCharges = loanInterestFeesCharges;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner addLoanInterestFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeesChargesItem) {
-    if (this.loanInterestFeesCharges == null) {
-      this.loanInterestFeesCharges = new ArrayList<>();
-    }
-    this.loanInterestFeesCharges.add(loanInterestFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Get loanInterestFeesCharges
-   * @return loanInterestFeesCharges
-  */
-  @Valid 
-  @Schema(name = "LoanInterestFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanInterestFeesCharges")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> getLoanInterestFeesCharges() {
-    return loanInterestFeesCharges;
-  }
-
-  public void setLoanInterestFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner> loanInterestFeesCharges) {
-    this.loanInterestFeesCharges = loanInterestFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner) o;
-    return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.identification) &&
-        Objects.equals(this.tierValueMinimum, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMinimum) &&
-        Objects.equals(this.tierValueMaximum, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMaximum) &&
-        Objects.equals(this.tierValueMinTerm, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMinTerm) &&
-        Objects.equals(this.minTermPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.minTermPeriod) &&
-        Objects.equals(this.tierValueMaxTerm, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.tierValueMaxTerm) &&
-        Objects.equals(this.maxTermPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.maxTermPeriod) &&
-        Objects.equals(this.fixedVariableInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.fixedVariableInterestRateType) &&
-        Objects.equals(this.repAPR, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.repAPR) &&
-        Objects.equals(this.loanProviderInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanProviderInterestRateType) &&
-        Objects.equals(this.loanProviderInterestRate, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanProviderInterestRate) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.notes) &&
-        Objects.equals(this.otherLoanProviderInterestRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.otherLoanProviderInterestRateType) &&
-        Objects.equals(this.loanInterestFeesCharges, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.loanInterestFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, tierValueMinTerm, minTermPeriod, tierValueMaxTerm, maxTermPeriod, fixedVariableInterestRateType, repAPR, loanProviderInterestRateType, loanProviderInterestRate, notes, otherLoanProviderInterestRateType, loanInterestFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
-    sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
-    sb.append("    tierValueMinTerm: ").append(toIndentedString(tierValueMinTerm)).append("\n");
-    sb.append("    minTermPeriod: ").append(toIndentedString(minTermPeriod)).append("\n");
-    sb.append("    tierValueMaxTerm: ").append(toIndentedString(tierValueMaxTerm)).append("\n");
-    sb.append("    maxTermPeriod: ").append(toIndentedString(maxTermPeriod)).append("\n");
-    sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
-    sb.append("    repAPR: ").append(toIndentedString(repAPR)).append("\n");
-    sb.append("    loanProviderInterestRateType: ").append(toIndentedString(loanProviderInterestRateType)).append("\n");
-    sb.append("    loanProviderInterestRate: ").append(toIndentedString(loanProviderInterestRate)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherLoanProviderInterestRateType: ").append(toIndentedString(otherLoanProviderInterestRateType)).append("\n");
-    sb.append("    loanInterestFeesCharges: ").append(toIndentedString(loanInterestFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
@@ -15,24 +15,18 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits
@@ -43,116 +37,120 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail = new ArrayList<>();
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
-    this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
-    this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner addLoanInterestFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner loanInterestFeeChargeDetailItem) {
-    if (this.loanInterestFeeChargeDetail == null) {
-      this.loanInterestFeeChargeDetail = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner() {
+        super();
     }
-    this.loanInterestFeeChargeDetail.add(loanInterestFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Get loanInterestFeeChargeDetail
-   * @return loanInterestFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "LoanInterestFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("LoanInterestFeeChargeDetail")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> getLoanInterestFeeChargeDetail() {
-    return loanInterestFeeChargeDetail;
-  }
-
-  public void setLoanInterestFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
-    this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap) {
-    this.loanInterestFeeChargeCap = loanInterestFeeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner addLoanInterestFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner loanInterestFeeChargeCapItem) {
-    if (this.loanInterestFeeChargeCap == null) {
-      this.loanInterestFeeChargeCap = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
+        this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
     }
-    this.loanInterestFeeChargeCap.add(loanInterestFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get loanInterestFeeChargeCap
-   * @return loanInterestFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "LoanInterestFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LoanInterestFeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> getLoanInterestFeeChargeCap() {
-    return loanInterestFeeChargeCap;
-  }
-
-  public void setLoanInterestFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap) {
-    this.loanInterestFeeChargeCap = loanInterestFeeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
+        this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner addLoanInterestFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner loanInterestFeeChargeDetailItem) {
+        if (this.loanInterestFeeChargeDetail == null) {
+            this.loanInterestFeeChargeDetail = new ArrayList<>();
+        }
+        this.loanInterestFeeChargeDetail.add(loanInterestFeeChargeDetailItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner) o;
-    return Objects.equals(this.loanInterestFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.loanInterestFeeChargeDetail) &&
-        Objects.equals(this.loanInterestFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.loanInterestFeeChargeCap);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(loanInterestFeeChargeDetail, loanInterestFeeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner {\n");
-    sb.append("    loanInterestFeeChargeDetail: ").append(toIndentedString(loanInterestFeeChargeDetail)).append("\n");
-    sb.append("    loanInterestFeeChargeCap: ").append(toIndentedString(loanInterestFeeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get loanInterestFeeChargeDetail
+     *
+     * @return loanInterestFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "LoanInterestFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("LoanInterestFeeChargeDetail")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> getLoanInterestFeeChargeDetail() {
+        return loanInterestFeeChargeDetail;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setLoanInterestFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner> loanInterestFeeChargeDetail) {
+        this.loanInterestFeeChargeDetail = loanInterestFeeChargeDetail;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner loanInterestFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap) {
+        this.loanInterestFeeChargeCap = loanInterestFeeChargeCap;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner addLoanInterestFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner loanInterestFeeChargeCapItem) {
+        if (this.loanInterestFeeChargeCap == null) {
+            this.loanInterestFeeChargeCap = new ArrayList<>();
+        }
+        this.loanInterestFeeChargeCap.add(loanInterestFeeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Get loanInterestFeeChargeCap
+     *
+     * @return loanInterestFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "LoanInterestFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LoanInterestFeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> getLoanInterestFeeChargeCap() {
+        return loanInterestFeeChargeCap;
+    }
+
+    public void setLoanInterestFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner> loanInterestFeeChargeCap) {
+        this.loanInterestFeeChargeCap = loanInterestFeeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner) o;
+        return Objects.equals(this.loanInterestFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.loanInterestFeeChargeDetail) &&
+                Objects.equals(this.loanInterestFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.loanInterestFeeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(loanInterestFeeChargeDetail, loanInterestFeeChargeCap);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner {\n");
+        sb.append("    loanInterestFeeChargeDetail: ").append(toIndentedString(loanInterestFeeChargeDetail)).append("\n");
+        sb.append("    loanInterestFeeChargeCap: ").append(toIndentedString(loanInterestFeeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
@@ -15,26 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code4;
-import uk.org.openbanking.datamodel.account.OBMinMaxType1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Details about any caps (minimum/maximum charges) that apply to a particular fee/charge
@@ -45,295 +38,256 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    FEPF("FEPF"),
-    
-    FTOT("FTOT"),
-    
-    FYAF("FYAF"),
-    
-    FYAM("FYAM"),
-    
-    FYAQ("FYAQ"),
-    
-    FYCP("FYCP"),
-    
-    FYDB("FYDB"),
-    
-    FYMI("FYMI"),
-    
-    FYXX("FYXX");
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType = new ArrayList<>();
 
-    private String value;
+    private OBMinMaxType1Code minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Integer feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private OBFeeFrequency1Code4 cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType, OBMinMaxType1Code minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public OBMinMaxType1Code getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Integer getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner cappingPeriod(OBFeeFrequency1Code4 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public OBFeeFrequency1Code4 getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(OBFeeFrequency1Code4 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private OBMinMaxType1Code minMaxType;
-
-  private Integer feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  private OBFeeFrequency1Code4 cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner(List<FeeTypeEnum> feeType, OBMinMaxType1Code minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Get minMaxType
-   * @return minMaxType
-  */
-  @NotNull @Valid 
-  @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public OBMinMaxType1Code getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Integer getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner cappingPeriod(OBFeeFrequency1Code4 cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Get cappingPeriod
-   * @return cappingPeriod
-  */
-  @Valid 
-  @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public OBFeeFrequency1Code4 getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(OBFeeFrequency1Code4 cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/charge type which is being capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner {
+
+    FEPF("FEPF"),
+
+    FTOT("FTOT"),
+
+    FYAF("FYAF"),
+
+    FYAM("FYAM"),
+
+    FYAQ("FYAQ"),
+
+    FYCP("FYCP"),
+
+    FYDB("FYDB"),
+
+    FYMI("FYMI"),
+
+    FYXX("FYXX");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner b : OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
@@ -15,31 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code2;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code3;
-import uk.org.openbanking.datamodel.account.OBFeeType1Code;
-import uk.org.openbanking.datamodel.account.OBInterestRateType1Code1;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType15;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType16;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType17;
-import uk.org.openbanking.datamodel.account.OBOtherFeeChargeDetailType;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other fees/charges details
@@ -50,349 +38,364 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner {
 
-  private OBFeeType1Code feeType;
+    private OBFeeType1Code feeType;
 
-  private Boolean negotiableIndicator;
+    private Boolean negotiableIndicator;
 
-  private String feeAmount;
+    private String feeAmount;
 
-  private String feeRate;
+    private String feeRate;
 
-  private OBInterestRateType1Code1 feeRateType;
+    private OBInterestRateType1Code1 feeRateType;
 
-  private OBFeeFrequency1Code2 applicationFrequency;
+    private OBFeeFrequency1Code2 applicationFrequency;
 
-  private OBFeeFrequency1Code3 calculationFrequency;
+    private OBFeeFrequency1Code3 calculationFrequency;
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  private OBOtherFeeChargeDetailType otherFeeType;
+    private OBOtherFeeChargeDetailType otherFeeType;
 
-  private OBOtherCodeType15 otherFeeRateType;
+    private OBOtherCodeType15 otherFeeRateType;
 
-  private OBOtherCodeType16 otherApplicationFrequency;
+    private OBOtherCodeType16 otherApplicationFrequency;
 
-  private OBOtherCodeType17 otherCalculationFrequency;
+    private OBOtherCodeType17 otherCalculationFrequency;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner(OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency, OBFeeFrequency1Code3 calculationFrequency) {
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public OBFeeType1Code getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Fee/charge which is usually negotiable rather than a fixed amount
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Get feeRateType
-   * @return feeRateType
-  */
-  @Valid 
-  @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public OBInterestRateType1Code1 getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get applicationFrequency
-   * @return applicationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public OBFeeFrequency1Code2 getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get calculationFrequency
-   * @return calculationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public OBFeeFrequency1Code3 getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OBOtherFeeChargeDetailType getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherFeeRateType(OBOtherCodeType15 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OBOtherCodeType15 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OBOtherCodeType15 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OBOtherCodeType16 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OBOtherCodeType17 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner(OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency, OBFeeFrequency1Code3 calculationFrequency) {
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+        this.calculationFrequency = calculationFrequency;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherCalculationFrequency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public OBFeeType1Code getFeeType() {
+        return feeType;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setFeeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Fee/charge which is usually negotiable rather than a fixed amount
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public OBInterestRateType1Code1 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public OBFeeFrequency1Code2 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public OBFeeFrequency1Code3 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OBOtherFeeChargeDetailType getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherFeeRateType(OBOtherCodeType15 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OBOtherCodeType15 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OBOtherCodeType15 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OBOtherCodeType16 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OBOtherCodeType17 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType {
+
+    INBB("INBB"),
+
+    INFR("INFR"),
+
+    INGR("INGR"),
+
+    INLR("INLR"),
+
+    INNE("INNE"),
+
+    INOT("INOT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType b : OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The unit of period (days, weeks, months etc.) of the Maximum Term
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod {
+
+    PACT("PACT"),
+
+    PDAY("PDAY"),
+
+    PHYR("PHYR"),
+
+    PMTH("PMTH"),
+
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod b : OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The unit of period (days, weeks, months etc.) of the Minimum Term
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod {
+
+    PACT("PACT"),
+
+    PDAY("PDAY"),
+
+    PHYR("PHYR"),
+
+    PMTH("PMTH"),
+
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod b : OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
@@ -15,19 +15,16 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other loan interest rate types which are not available in the standard code list
@@ -38,123 +35,128 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType = (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how credit interest is charged. It can be:- 1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases. 2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance. 3. Whole The same interest rate is applied irrespective of the SME Loan balance
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod {
+
+    INBA("INBA"),
+
+    INTI("INTI"),
+
+    INWH("INWH");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod b : OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
@@ -15,20 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
@@ -39,225 +52,195 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner {
 
-  /**
-   * TariffType which defines the fee and charges.
-   */
-  public enum TariffTypeEnum {
-    TTEL("TTEL"),
-    
-    TTMX("TTMX"),
-    
-    TTOT("TTOT");
+    private OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType tariffType;
 
-    private String value;
+    private String tariffName;
 
-    TariffTypeEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail = new ArrayList<>();
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner tariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType tariffType) {
+        this.tariffType = tariffType;
+        return this;
+    }
+
+    /**
+     * Get tariffType
+     *
+     * @return tariffType
+     */
+    @Valid
+    @Schema(name = "TariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TariffType")
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType getTariffType() {
+        return tariffType;
+    }
+
+    public void setTariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType tariffType) {
+        this.tariffType = tariffType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner tariffName(String tariffName) {
+        this.tariffName = tariffName;
+        return this;
+    }
+
+    /**
+     * Name of the tariff
+     *
+     * @return tariffName
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "TariffName", description = "Name of the tariff", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TariffName")
+    public String getTariffName() {
+        return tariffName;
+    }
+
+    public void setTariffName(String tariffName) {
+        this.tariffName = tariffName;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner otherTariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType) {
+        this.otherTariffType = otherTariffType;
+        return this;
+    }
+
+    /**
+     * Get otherTariffType
+     *
+     * @return otherTariffType
+     */
+    @Valid
+    @Schema(name = "OtherTariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherTariffType")
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType getOtherTariffType() {
+        return otherTariffType;
+    }
+
+    public void setOtherTariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType) {
+        this.otherTariffType = otherTariffType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner feeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner addFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeChargeDetailItem) {
+        if (this.feeChargeDetail == null) {
+            this.feeChargeDetail = new ArrayList<>();
+        }
+        this.feeChargeDetail.add(feeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Get feeChargeDetail
+     *
+     * @return feeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeChargeDetail")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> getFeeChargeDetail() {
+        return feeChargeDetail;
+    }
+
+    public void setFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner feeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner addFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Get feeChargeCap
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner) o;
+        return Objects.equals(this.tariffType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.tariffType) &&
+                Objects.equals(this.tariffName, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.tariffName) &&
+                Objects.equals(this.otherTariffType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.otherTariffType) &&
+                Objects.equals(this.feeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.feeChargeDetail) &&
+                Objects.equals(this.feeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.feeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tariffType, tariffName, otherTariffType, feeChargeDetail, feeChargeCap);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner {\n");
+        sb.append("    tariffType: ").append(toIndentedString(tariffType)).append("\n");
+        sb.append("    tariffName: ").append(toIndentedString(tariffName)).append("\n");
+        sb.append("    otherTariffType: ").append(toIndentedString(otherTariffType)).append("\n");
+        sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TariffTypeEnum fromValue(String value) {
-      for (TariffTypeEnum b : TariffTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TariffTypeEnum tariffType;
-
-  private String tariffName;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail = new ArrayList<>();
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner tariffType(TariffTypeEnum tariffType) {
-    this.tariffType = tariffType;
-    return this;
-  }
-
-  /**
-   * TariffType which defines the fee and charges.
-   * @return tariffType
-  */
-  
-  @Schema(name = "TariffType", description = "TariffType which defines the fee and charges.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TariffType")
-  public TariffTypeEnum getTariffType() {
-    return tariffType;
-  }
-
-  public void setTariffType(TariffTypeEnum tariffType) {
-    this.tariffType = tariffType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner tariffName(String tariffName) {
-    this.tariffName = tariffName;
-    return this;
-  }
-
-  /**
-   * Name of the tariff
-   * @return tariffName
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "TariffName", description = "Name of the tariff", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TariffName")
-  public String getTariffName() {
-    return tariffName;
-  }
-
-  public void setTariffName(String tariffName) {
-    this.tariffName = tariffName;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner otherTariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType) {
-    this.otherTariffType = otherTariffType;
-    return this;
-  }
-
-  /**
-   * Get otherTariffType
-   * @return otherTariffType
-  */
-  @Valid 
-  @Schema(name = "OtherTariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherTariffType")
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType getOtherTariffType() {
-    return otherTariffType;
-  }
-
-  public void setOtherTariffType(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType otherTariffType) {
-    this.otherTariffType = otherTariffType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner feeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner addFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeChargeDetailItem) {
-    if (this.feeChargeDetail == null) {
-      this.feeChargeDetail = new ArrayList<>();
-    }
-    this.feeChargeDetail.add(feeChargeDetailItem);
-    return this;
-  }
-
-  /**
-   * Get feeChargeDetail
-   * @return feeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "FeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeChargeDetail")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> getFeeChargeDetail() {
-    return feeChargeDetail;
-  }
-
-  public void setFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner feeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner addFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
-    }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
-
-  /**
-   * Get feeChargeCap
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner) o;
-    return Objects.equals(this.tariffType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.tariffType) &&
-        Objects.equals(this.tariffName, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.tariffName) &&
-        Objects.equals(this.otherTariffType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.otherTariffType) &&
-        Objects.equals(this.feeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.feeChargeDetail) &&
-        Objects.equals(this.feeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.feeChargeCap);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tariffType, tariffName, otherTariffType, feeChargeDetail, feeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner {\n");
-    sb.append("    tariffType: ").append(toIndentedString(tariffType)).append("\n");
-    sb.append("    tariffName: ").append(toIndentedString(tariffName)).append("\n");
-    sb.append("    otherTariffType: ").append(toIndentedString(otherTariffType)).append("\n");
-    sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
@@ -15,35 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBFeeCategory1Code;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code2;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code3;
-import uk.org.openbanking.datamodel.account.OBFeeType1Code;
-import uk.org.openbanking.datamodel.account.OBInterestRateType1Code1;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType10;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType16;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType17;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType18;
-import uk.org.openbanking.datamodel.account.OBOtherFeeChargeDetailType;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other fees/charges details
@@ -54,454 +38,473 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner {
 
-  private OBFeeCategory1Code feeCategory;
+    private OBFeeCategory1Code feeCategory;
 
-  private OBFeeType1Code feeType;
+    private OBFeeType1Code feeType;
 
-  private Boolean negotiableIndicator;
+    private Boolean negotiableIndicator;
 
-  private String feeAmount;
+    private String feeAmount;
 
-  private String feeRate;
+    private String feeRate;
 
-  private OBInterestRateType1Code1 feeRateType;
+    private OBInterestRateType1Code1 feeRateType;
 
-  private OBFeeFrequency1Code2 applicationFrequency;
+    private OBFeeFrequency1Code2 applicationFrequency;
 
-  private OBFeeFrequency1Code3 calculationFrequency;
+    private OBFeeFrequency1Code3 calculationFrequency;
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap;
 
-  private OBOtherCodeType10 otherFeeCategoryType;
+    private OBOtherCodeType10 otherFeeCategoryType;
 
-  private OBOtherFeeChargeDetailType otherFeeType;
+    private OBOtherFeeChargeDetailType otherFeeType;
 
-  private OBOtherCodeType18 otherFeeRateType;
+    private OBOtherCodeType18 otherFeeRateType;
 
-  private OBOtherCodeType16 otherApplicationFrequency;
+    private OBOtherCodeType16 otherApplicationFrequency;
 
-  private OBOtherCodeType17 otherCalculationFrequency;
+    private OBOtherCodeType17 otherCalculationFrequency;
 
-  private OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange;
+    private OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner(OBFeeCategory1Code feeCategory, OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency) {
-    this.feeCategory = feeCategory;
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeCategory(OBFeeCategory1Code feeCategory) {
-    this.feeCategory = feeCategory;
-    return this;
-  }
-
-  /**
-   * Get feeCategory
-   * @return feeCategory
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeCategory")
-  public OBFeeCategory1Code getFeeCategory() {
-    return feeCategory;
-  }
-
-  public void setFeeCategory(OBFeeCategory1Code feeCategory) {
-    this.feeCategory = feeCategory;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public OBFeeType1Code getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Fee/charge which is usually negotiable rather than a fixed amount
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Get feeRateType
-   * @return feeRateType
-  */
-  @Valid 
-  @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public OBInterestRateType1Code1 getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get applicationFrequency
-   * @return applicationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public OBFeeFrequency1Code2 getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get calculationFrequency
-   * @return calculationFrequency
-  */
-  @Valid 
-  @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public OBFeeFrequency1Code3 getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner addFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner(OBFeeCategory1Code feeCategory, OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency) {
+        this.feeCategory = feeCategory;
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
     }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get feeChargeCap
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeCategoryType(OBOtherCodeType10 otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeCategoryType
-   * @return otherFeeCategoryType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeCategoryType")
-  public OBOtherCodeType10 getOtherFeeCategoryType() {
-    return otherFeeCategoryType;
-  }
-
-  public void setOtherFeeCategoryType(OBOtherCodeType10 otherFeeCategoryType) {
-    this.otherFeeCategoryType = otherFeeCategoryType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OBOtherFeeChargeDetailType getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OBOtherCodeType18 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OBOtherCodeType16 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OBOtherCodeType17 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeApplicableRange(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-    return this;
-  }
-
-  /**
-   * Get feeApplicableRange
-   * @return feeApplicableRange
-  */
-  @Valid 
-  @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeApplicableRange")
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange getFeeApplicableRange() {
-    return feeApplicableRange;
-  }
-
-  public void setFeeApplicableRange(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange) {
-    this.feeApplicableRange = feeApplicableRange;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeCategory(OBFeeCategory1Code feeCategory) {
+        this.feeCategory = feeCategory;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get feeCategory
+     *
+     * @return feeCategory
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeCategory")
+    public OBFeeCategory1Code getFeeCategory() {
+        return feeCategory;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner) o;
-    return Objects.equals(this.feeCategory, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeCategory) &&
-        Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.notes) &&
-        Objects.equals(this.feeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeChargeCap) &&
-        Objects.equals(this.otherFeeCategoryType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeCategoryType) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherCalculationFrequency) &&
-        Objects.equals(this.feeApplicableRange, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeApplicableRange);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeCategory, feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, feeChargeCap, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeApplicableRange);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner {\n");
-    sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setFeeCategory(OBFeeCategory1Code feeCategory) {
+        this.feeCategory = feeCategory;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public OBFeeType1Code getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Fee/charge which is usually negotiable rather than a fixed amount
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public OBInterestRateType1Code1 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public OBFeeFrequency1Code2 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public OBFeeFrequency1Code3 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner addFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Get feeChargeCap
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeCategoryType(OBOtherCodeType10 otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeCategoryType
+     *
+     * @return otherFeeCategoryType
+     */
+    @Valid
+    @Schema(name = "OtherFeeCategoryType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeCategoryType")
+    public OBOtherCodeType10 getOtherFeeCategoryType() {
+        return otherFeeCategoryType;
+    }
+
+    public void setOtherFeeCategoryType(OBOtherCodeType10 otherFeeCategoryType) {
+        this.otherFeeCategoryType = otherFeeCategoryType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OBOtherFeeChargeDetailType getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OBOtherCodeType18 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OBOtherCodeType16 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OBOtherCodeType17 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner feeApplicableRange(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+        return this;
+    }
+
+    /**
+     * Get feeApplicableRange
+     *
+     * @return feeApplicableRange
+     */
+    @Valid
+    @Schema(name = "FeeApplicableRange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeApplicableRange")
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange getFeeApplicableRange() {
+        return feeApplicableRange;
+    }
+
+    public void setFeeApplicableRange(OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange feeApplicableRange) {
+        this.feeApplicableRange = feeApplicableRange;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner) o;
+        return Objects.equals(this.feeCategory, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeCategory) &&
+                Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.notes) &&
+                Objects.equals(this.feeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeChargeCap) &&
+                Objects.equals(this.otherFeeCategoryType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeCategoryType) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.otherCalculationFrequency) &&
+                Objects.equals(this.feeApplicableRange, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.feeApplicableRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeCategory, feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, feeChargeCap, otherFeeCategoryType, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, feeApplicableRange);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner {\n");
+        sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("    otherFeeCategoryType: ").append(toIndentedString(otherFeeCategoryType)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("    feeApplicableRange: ").append(toIndentedString(feeApplicableRange)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
@@ -15,19 +15,14 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Range or amounts or rates for which the fee/charge applies
@@ -38,135 +33,139 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange {
 
-  private String minimumAmount;
+    private String minimumAmount;
 
-  private String maximumAmount;
+    private String maximumAmount;
 
-  private String minimumRate;
+    private String minimumRate;
 
-  private String maximumRate;
+    private String maximumRate;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange minimumAmount(String minimumAmount) {
-    this.minimumAmount = minimumAmount;
-    return this;
-  }
-
-  /**
-   * Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)
-   * @return minimumAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MinimumAmount", description = "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MinimumAmount")
-  public String getMinimumAmount() {
-    return minimumAmount;
-  }
-
-  public void setMinimumAmount(String minimumAmount) {
-    this.minimumAmount = minimumAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange maximumAmount(String maximumAmount) {
-    this.maximumAmount = maximumAmount;
-    return this;
-  }
-
-  /**
-   * Maximum Amount on which fee is applicable (where it is expressed as an amount)
-   * @return maximumAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MaximumAmount", description = "Maximum Amount on which fee is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaximumAmount")
-  public String getMaximumAmount() {
-    return maximumAmount;
-  }
-
-  public void setMaximumAmount(String maximumAmount) {
-    this.maximumAmount = maximumAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange minimumRate(String minimumRate) {
-    this.minimumRate = minimumRate;
-    return this;
-  }
-
-  /**
-   * Minimum rate on which fee/charge is applicable(where it is expressed as an rate)
-   * @return minimumRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MinimumRate", description = "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MinimumRate")
-  public String getMinimumRate() {
-    return minimumRate;
-  }
-
-  public void setMinimumRate(String minimumRate) {
-    this.minimumRate = minimumRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange maximumRate(String maximumRate) {
-    this.maximumRate = maximumRate;
-    return this;
-  }
-
-  /**
-   * Maximum rate on which fee/charge is applicable(where it is expressed as an rate)
-   * @return maximumRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MaximumRate", description = "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaximumRate")
-  public String getMaximumRate() {
-    return maximumRate;
-  }
-
-  public void setMaximumRate(String maximumRate) {
-    this.maximumRate = maximumRate;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange minimumAmount(String minimumAmount) {
+        this.minimumAmount = minimumAmount;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)
+     *
+     * @return minimumAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MinimumAmount", description = "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MinimumAmount")
+    public String getMinimumAmount() {
+        return minimumAmount;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange) o;
-    return Objects.equals(this.minimumAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.minimumAmount) &&
-        Objects.equals(this.maximumAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.maximumAmount) &&
-        Objects.equals(this.minimumRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.minimumRate) &&
-        Objects.equals(this.maximumRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.maximumRate);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(minimumAmount, maximumAmount, minimumRate, maximumRate);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange {\n");
-    sb.append("    minimumAmount: ").append(toIndentedString(minimumAmount)).append("\n");
-    sb.append("    maximumAmount: ").append(toIndentedString(maximumAmount)).append("\n");
-    sb.append("    minimumRate: ").append(toIndentedString(minimumRate)).append("\n");
-    sb.append("    maximumRate: ").append(toIndentedString(maximumRate)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setMinimumAmount(String minimumAmount) {
+        this.minimumAmount = minimumAmount;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange maximumAmount(String maximumAmount) {
+        this.maximumAmount = maximumAmount;
+        return this;
+    }
+
+    /**
+     * Maximum Amount on which fee is applicable (where it is expressed as an amount)
+     *
+     * @return maximumAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MaximumAmount", description = "Maximum Amount on which fee is applicable (where it is expressed as an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaximumAmount")
+    public String getMaximumAmount() {
+        return maximumAmount;
+    }
+
+    public void setMaximumAmount(String maximumAmount) {
+        this.maximumAmount = maximumAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange minimumRate(String minimumRate) {
+        this.minimumRate = minimumRate;
+        return this;
+    }
+
+    /**
+     * Minimum rate on which fee/charge is applicable(where it is expressed as an rate)
+     *
+     * @return minimumRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MinimumRate", description = "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MinimumRate")
+    public String getMinimumRate() {
+        return minimumRate;
+    }
+
+    public void setMinimumRate(String minimumRate) {
+        this.minimumRate = minimumRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange maximumRate(String maximumRate) {
+        this.maximumRate = maximumRate;
+        return this;
+    }
+
+    /**
+     * Maximum rate on which fee/charge is applicable(where it is expressed as an rate)
+     *
+     * @return maximumRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MaximumRate", description = "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaximumRate")
+    public String getMaximumRate() {
+        return maximumRate;
+    }
+
+    public void setMaximumRate(String maximumRate) {
+        this.maximumRate = maximumRate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange) o;
+        return Objects.equals(this.minimumAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.minimumAmount) &&
+                Objects.equals(this.maximumAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.maximumAmount) &&
+                Objects.equals(this.minimumRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.minimumRate) &&
+                Objects.equals(this.maximumRate, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.maximumRate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumAmount, maximumAmount, minimumRate, maximumRate);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange {\n");
+        sb.append("    minimumAmount: ").append(toIndentedString(minimumAmount)).append("\n");
+        sb.append("    maximumAmount: ").append(toIndentedString(maximumAmount)).append("\n");
+        sb.append("    minimumRate: ").append(toIndentedString(minimumRate)).append("\n");
+        sb.append("    maximumRate: ").append(toIndentedString(maximumRate)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
@@ -15,26 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBMinMaxType1Code;
-import uk.org.openbanking.datamodel.account.OBPeriod1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
@@ -45,295 +38,256 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    FEPF("FEPF"),
-    
-    FTOT("FTOT"),
-    
-    FYAF("FYAF"),
-    
-    FYAM("FYAM"),
-    
-    FYAQ("FYAQ"),
-    
-    FYCP("FYCP"),
-    
-    FYDB("FYDB"),
-    
-    FYMI("FYMI"),
-    
-    FYXX("FYXX");
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType = new ArrayList<>();
 
-    private String value;
+    private OBMinMaxType1Code minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Integer feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private OBPeriod1Code cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType, OBMinMaxType1Code minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public OBMinMaxType1Code getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Integer getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public OBPeriod1Code getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private OBMinMaxType1Code minMaxType;
-
-  private Integer feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  private OBPeriod1Code cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner(List<FeeTypeEnum> feeType, OBMinMaxType1Code minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Get minMaxType
-   * @return minMaxType
-  */
-  @NotNull @Valid 
-  @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public OBMinMaxType1Code getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Integer getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Get cappingPeriod
-   * @return cappingPeriod
-  */
-  @Valid 
-  @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public OBPeriod1Code getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
@@ -15,19 +15,16 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other tariff type which is not in the standard list.
@@ -38,123 +35,128 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType = (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * TariffType which defines the fee and charges.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType {
+
+    TTEL("TTEL"),
+
+    TTMX("TTMX"),
+
+    TTOT("TTOT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType b : OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
@@ -15,18 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Borrowing details
@@ -37,116 +48,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraft {
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet = new ArrayList<>();
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraftTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraft addOverdraftTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftTierBandSetItem) {
-    if (this.overdraftTierBandSet == null) {
-      this.overdraftTierBandSet = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
     }
-    this.overdraftTierBandSet.add(overdraftTierBandSetItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftTierBandSet
-   * @return overdraftTierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBandSet")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> getOverdraftTierBandSet() {
-    return overdraftTierBandSet;
-  }
-
-  public void setOverdraftTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraft obReadProduct2DataProductInnerOtherProductTypeOverdraft = (OBReadProduct2DataProductInnerOtherProductTypeOverdraft) o;
-    return Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraft.notes) &&
-        Objects.equals(this.overdraftTierBandSet, obReadProduct2DataProductInnerOtherProductTypeOverdraft.overdraftTierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(notes, overdraftTierBandSet);
-  }
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
 
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraft {\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft overdraftTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraft addOverdraftTierBandSetItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftTierBandSetItem) {
+        if (this.overdraftTierBandSet == null) {
+            this.overdraftTierBandSet = new ArrayList<>();
+        }
+        this.overdraftTierBandSet.add(overdraftTierBandSetItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftTierBandSet
+     *
+     * @return overdraftTierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBandSet", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBandSet")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> getOverdraftTierBandSet() {
+        return overdraftTierBandSet;
+    }
+
+    public void setOverdraftTierBandSet(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraft obReadProduct2DataProductInnerOtherProductTypeOverdraft = (OBReadProduct2DataProductInnerOtherProductTypeOverdraft) o;
+        return Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraft.notes) &&
+                Objects.equals(this.overdraftTierBandSet, obReadProduct2DataProductInnerOtherProductTypeOverdraft.overdraftTierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notes, overdraftTierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraft {\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -40,344 +38,281 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner {
 
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   */
-  public enum TierBandMethodEnum {
-    INBA("INBA"),
-    
-    INTI("INTI"),
-    
-    INWH("INWH");
+    private OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod tierBandMethod;
 
-    private String value;
+    private OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType overdraftType;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private String identification;
+
+    private Boolean authorisedIndicator;
+
+    private String bufferAmount;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand = new ArrayList<>();
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod tierBandMethod, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner tierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftType(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType overdraftType) {
+        this.overdraftType = overdraftType;
+        return this;
+    }
+
+    /**
+     * Get overdraftType
+     *
+     * @return overdraftType
+     */
+    @Valid
+    @Schema(name = "OverdraftType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftType")
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType getOverdraftType() {
+        return overdraftType;
+    }
+
+    public void setOverdraftType(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType overdraftType) {
+        this.overdraftType = overdraftType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft product.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner authorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
+     *
+     * @return authorisedIndicator
+     */
+
+    @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AuthorisedIndicator")
+    public Boolean getAuthorisedIndicator() {
+        return authorisedIndicator;
+    }
+
+    public void setAuthorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner bufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+        return this;
+    }
+
+    /**
+     * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
+     *
+     * @return bufferAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BufferAmount")
+    public String getBufferAmount() {
+        return bufferAmount;
+    }
+
+    public void setBufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addOverdraftTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftTierBandItem) {
+        if (this.overdraftTierBand == null) {
+            this.overdraftTierBand = new ArrayList<>();
+        }
+        this.overdraftTierBand.add(overdraftTierBandItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftTierBand
+     *
+     * @return overdraftTierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBand", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBand")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> getOverdraftTierBand() {
+        return overdraftTierBand;
+    }
+
+    public void setOverdraftTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addOverdraftFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftFeesCharges
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner) o;
+        return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.tierBandMethod) &&
+                Objects.equals(this.overdraftType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftType) &&
+                Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.identification) &&
+                Objects.equals(this.authorisedIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.authorisedIndicator) &&
+                Objects.equals(this.bufferAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.bufferAmount) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.notes) &&
+                Objects.equals(this.overdraftTierBand, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftTierBand) &&
+                Objects.equals(this.overdraftFeesCharges, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
+        sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   */
-  public enum OverdraftTypeEnum {
-    OVCO("OVCO"),
-    
-    OVOD("OVOD"),
-    
-    OVOT("OVOT");
-
-    private String value;
-
-    OverdraftTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static OverdraftTypeEnum fromValue(String value) {
-      for (OverdraftTypeEnum b : OverdraftTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private OverdraftTypeEnum overdraftType;
-
-  private String identification;
-
-  private Boolean authorisedIndicator;
-
-  private String bufferAmount;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand = new ArrayList<>();
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner(TierBandMethodEnum tierBandMethod, List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-    return this;
-  }
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   * @return overdraftType
-  */
-  
-  @Schema(name = "OverdraftType", description = "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftType")
-  public OverdraftTypeEnum getOverdraftType() {
-    return overdraftType;
-  }
-
-  public void setOverdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft product.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner authorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
-   * @return authorisedIndicator
-  */
-  
-  @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AuthorisedIndicator")
-  public Boolean getAuthorisedIndicator() {
-    return authorisedIndicator;
-  }
-
-  public void setAuthorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner bufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-    return this;
-  }
-
-  /**
-   * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
-   * @return bufferAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BufferAmount")
-  public String getBufferAmount() {
-    return bufferAmount;
-  }
-
-  public void setBufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addOverdraftTierBandItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftTierBandItem) {
-    if (this.overdraftTierBand == null) {
-      this.overdraftTierBand = new ArrayList<>();
-    }
-    this.overdraftTierBand.add(overdraftTierBandItem);
-    return this;
-  }
-
-  /**
-   * Get overdraftTierBand
-   * @return overdraftTierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBand", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBand")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> getOverdraftTierBand() {
-    return overdraftTierBand;
-  }
-
-  public void setOverdraftTierBand(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner overdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner addOverdraftFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Get overdraftFeesCharges
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner) o;
-    return Objects.equals(this.tierBandMethod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.tierBandMethod) &&
-        Objects.equals(this.overdraftType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftType) &&
-        Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.identification) &&
-        Objects.equals(this.authorisedIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.authorisedIndicator) &&
-        Objects.equals(this.bufferAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.bufferAmount) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.notes) &&
-        Objects.equals(this.overdraftTierBand, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftTierBand) &&
-        Objects.equals(this.overdraftFeesCharges, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
-    sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
@@ -15,24 +15,18 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * Overdraft fees and charges details
@@ -43,116 +37,120 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftFeeChargeCap
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftFeeChargeDetail
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner) o;
-    return Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get overdraftFeeChargeCap
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftFeeChargeDetail
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner) o;
+        return Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
@@ -15,24 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Provides overdraft details for a specific tier or band
@@ -43,414 +38,344 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMin;
+    private String tierValueMin;
 
-  private String tierValueMax;
+    private String tierValueMax;
 
-  private String EAR;
+    private String EAR;
 
-  private Integer agreementLengthMin;
+    private Integer agreementLengthMin;
 
-  private Integer agreementLengthMax;
+    private Integer agreementLengthMax;
 
-  /**
-   * Specifies the period of a fixed length overdraft agreement
-   */
-  public enum AgreementPeriodEnum {
-    PACT("PACT"),
-    
-    PDAY("PDAY"),
-    
-    PHYR("PHYR"),
-    
-    PMTH("PMTH"),
-    
-    PQTR("PQTR"),
-    
-    PWEK("PWEK"),
-    
-    PYER("PYER");
+    private OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod agreementPeriod;
 
-    private String value;
+    private OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage overdraftInterestChargingCoverage;
 
-    AgreementPeriodEnum(String value) {
-      this.value = value;
+    private Boolean bankGuaranteedIndicator;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner tierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+        return this;
+    }
+
+    /**
+     * Minimum value of Overdraft Tier/Band
+     *
+     * @return tierValueMin
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMin")
+    public String getTierValueMin() {
+        return tierValueMin;
+    }
+
+    public void setTierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner tierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+        return this;
+    }
+
+    /**
+     * Maximum value of Overdraft Tier/Band
+     *
+     * @return tierValueMax
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMax")
+    public String getTierValueMax() {
+        return tierValueMax;
+    }
+
+    public void setTierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner EAR(String EAR) {
+        this.EAR = EAR;
+        return this;
+    }
+
+    /**
+     * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
+     *
+     * @return EAR
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EAR")
+    public String getEAR() {
+        return EAR;
+    }
+
+    public void setEAR(String EAR) {
+        this.EAR = EAR;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementLengthMin(Integer agreementLengthMin) {
+        this.agreementLengthMin = agreementLengthMin;
+        return this;
+    }
+
+    /**
+     * Specifies the minimum length of a band for a fixed overdraft agreement
+     *
+     * @return agreementLengthMin
+     */
+
+    @Schema(name = "AgreementLengthMin", description = "Specifies the minimum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementLengthMin")
+    public Integer getAgreementLengthMin() {
+        return agreementLengthMin;
+    }
+
+    public void setAgreementLengthMin(Integer agreementLengthMin) {
+        this.agreementLengthMin = agreementLengthMin;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementLengthMax(Integer agreementLengthMax) {
+        this.agreementLengthMax = agreementLengthMax;
+        return this;
+    }
+
+    /**
+     * Specifies the maximum length of a band for a fixed overdraft agreement
+     *
+     * @return agreementLengthMax
+     */
+
+    @Schema(name = "AgreementLengthMax", description = "Specifies the maximum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementLengthMax")
+    public Integer getAgreementLengthMax() {
+        return agreementLengthMax;
+    }
+
+    public void setAgreementLengthMax(Integer agreementLengthMax) {
+        this.agreementLengthMax = agreementLengthMax;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementPeriod(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod agreementPeriod) {
+        this.agreementPeriod = agreementPeriod;
+        return this;
+    }
+
+    /**
+     * Get agreementPeriod
+     *
+     * @return agreementPeriod
+     */
+    @Valid
+    @Schema(name = "AgreementPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementPeriod")
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod getAgreementPeriod() {
+        return agreementPeriod;
+    }
+
+    public void setAgreementPeriod(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod agreementPeriod) {
+        this.agreementPeriod = agreementPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftInterestChargingCoverage(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+        return this;
+    }
+
+    /**
+     * Get overdraftInterestChargingCoverage
+     *
+     * @return overdraftInterestChargingCoverage
+     */
+    @Valid
+    @Schema(name = "OverdraftInterestChargingCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftInterestChargingCoverage")
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage getOverdraftInterestChargingCoverage() {
+        return overdraftInterestChargingCoverage;
+    }
+
+    public void setOverdraftInterestChargingCoverage(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.
+     *
+     * @return bankGuaranteedIndicator
+     */
+
+    @Schema(name = "BankGuaranteedIndicator", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankGuaranteedIndicator")
+    public Boolean getBankGuaranteedIndicator() {
+        return bankGuaranteedIndicator;
+    }
+
+    public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner addOverdraftFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftFeesCharges
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner) o;
+        return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.identification) &&
+                Objects.equals(this.tierValueMin, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.tierValueMin) &&
+                Objects.equals(this.tierValueMax, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.tierValueMax) &&
+                Objects.equals(this.EAR, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.EAR) &&
+                Objects.equals(this.agreementLengthMin, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementLengthMin) &&
+                Objects.equals(this.agreementLengthMax, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementLengthMax) &&
+                Objects.equals(this.agreementPeriod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementPeriod) &&
+                Objects.equals(this.overdraftInterestChargingCoverage, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.overdraftInterestChargingCoverage) &&
+                Objects.equals(this.bankGuaranteedIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.bankGuaranteedIndicator) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.notes) &&
+                Objects.equals(this.overdraftFeesCharges, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMin, tierValueMax, EAR, agreementLengthMin, agreementLengthMax, agreementPeriod, overdraftInterestChargingCoverage, bankGuaranteedIndicator, notes, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
+        sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
+        sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
+        sb.append("    agreementLengthMin: ").append(toIndentedString(agreementLengthMin)).append("\n");
+        sb.append("    agreementLengthMax: ").append(toIndentedString(agreementLengthMax)).append("\n");
+        sb.append("    agreementPeriod: ").append(toIndentedString(agreementPeriod)).append("\n");
+        sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
+        sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static AgreementPeriodEnum fromValue(String value) {
-      for (AgreementPeriodEnum b : AgreementPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private AgreementPeriodEnum agreementPeriod;
-
-  /**
-   * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.
-   */
-  public enum OverdraftInterestChargingCoverageEnum {
-    INBA("INBA"),
-    
-    INTI("INTI"),
-    
-    INWH("INWH");
-
-    private String value;
-
-    OverdraftInterestChargingCoverageEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static OverdraftInterestChargingCoverageEnum fromValue(String value) {
-      for (OverdraftInterestChargingCoverageEnum b : OverdraftInterestChargingCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage;
-
-  private Boolean bankGuaranteedIndicator;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner tierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-    return this;
-  }
-
-  /**
-   * Minimum value of Overdraft Tier/Band
-   * @return tierValueMin
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMin")
-  public String getTierValueMin() {
-    return tierValueMin;
-  }
-
-  public void setTierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner tierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-    return this;
-  }
-
-  /**
-   * Maximum value of Overdraft Tier/Band
-   * @return tierValueMax
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMax")
-  public String getTierValueMax() {
-    return tierValueMax;
-  }
-
-  public void setTierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner EAR(String EAR) {
-    this.EAR = EAR;
-    return this;
-  }
-
-  /**
-   * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
-   * @return EAR
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("EAR")
-  public String getEAR() {
-    return EAR;
-  }
-
-  public void setEAR(String EAR) {
-    this.EAR = EAR;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementLengthMin(Integer agreementLengthMin) {
-    this.agreementLengthMin = agreementLengthMin;
-    return this;
-  }
-
-  /**
-   * Specifies the minimum length of a band for a fixed overdraft agreement
-   * @return agreementLengthMin
-  */
-  
-  @Schema(name = "AgreementLengthMin", description = "Specifies the minimum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementLengthMin")
-  public Integer getAgreementLengthMin() {
-    return agreementLengthMin;
-  }
-
-  public void setAgreementLengthMin(Integer agreementLengthMin) {
-    this.agreementLengthMin = agreementLengthMin;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementLengthMax(Integer agreementLengthMax) {
-    this.agreementLengthMax = agreementLengthMax;
-    return this;
-  }
-
-  /**
-   * Specifies the maximum length of a band for a fixed overdraft agreement
-   * @return agreementLengthMax
-  */
-  
-  @Schema(name = "AgreementLengthMax", description = "Specifies the maximum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementLengthMax")
-  public Integer getAgreementLengthMax() {
-    return agreementLengthMax;
-  }
-
-  public void setAgreementLengthMax(Integer agreementLengthMax) {
-    this.agreementLengthMax = agreementLengthMax;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner agreementPeriod(AgreementPeriodEnum agreementPeriod) {
-    this.agreementPeriod = agreementPeriod;
-    return this;
-  }
-
-  /**
-   * Specifies the period of a fixed length overdraft agreement
-   * @return agreementPeriod
-  */
-  
-  @Schema(name = "AgreementPeriod", description = "Specifies the period of a fixed length overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementPeriod")
-  public AgreementPeriodEnum getAgreementPeriod() {
-    return agreementPeriod;
-  }
-
-  public void setAgreementPeriod(AgreementPeriodEnum agreementPeriod) {
-    this.agreementPeriod = agreementPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-    return this;
-  }
-
-  /**
-   * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.
-   * @return overdraftInterestChargingCoverage
-  */
-  
-  @Schema(name = "OverdraftInterestChargingCoverage", description = "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftInterestChargingCoverage")
-  public OverdraftInterestChargingCoverageEnum getOverdraftInterestChargingCoverage() {
-    return overdraftInterestChargingCoverage;
-  }
-
-  public void setOverdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.
-   * @return bankGuaranteedIndicator
-  */
-  
-  @Schema(name = "BankGuaranteedIndicator", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankGuaranteedIndicator")
-  public Boolean getBankGuaranteedIndicator() {
-    return bankGuaranteedIndicator;
-  }
-
-  public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner overdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner addOverdraftFeesChargesItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Get overdraftFeesCharges
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner) o;
-    return Objects.equals(this.identification, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.identification) &&
-        Objects.equals(this.tierValueMin, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.tierValueMin) &&
-        Objects.equals(this.tierValueMax, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.tierValueMax) &&
-        Objects.equals(this.EAR, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.EAR) &&
-        Objects.equals(this.agreementLengthMin, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementLengthMin) &&
-        Objects.equals(this.agreementLengthMax, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementLengthMax) &&
-        Objects.equals(this.agreementPeriod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.agreementPeriod) &&
-        Objects.equals(this.overdraftInterestChargingCoverage, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.overdraftInterestChargingCoverage) &&
-        Objects.equals(this.bankGuaranteedIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.bankGuaranteedIndicator) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.notes) &&
-        Objects.equals(this.overdraftFeesCharges, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMin, tierValueMax, EAR, agreementLengthMin, agreementLengthMax, agreementPeriod, overdraftInterestChargingCoverage, bankGuaranteedIndicator, notes, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
-    sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
-    sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
-    sb.append("    agreementLengthMin: ").append(toIndentedString(agreementLengthMin)).append("\n");
-    sb.append("    agreementLengthMax: ").append(toIndentedString(agreementLengthMax)).append("\n");
-    sb.append("    agreementPeriod: ").append(toIndentedString(agreementPeriod)).append("\n");
-    sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
-    sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Specifies the period of a fixed length overdraft agreement
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod {
+
+    PACT("PACT"),
+
+    PDAY("PDAY"),
+
+    PHYR("PHYR"),
+
+    PMTH("PMTH"),
+
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod b : OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
@@ -15,24 +15,18 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * Overdraft fees and charges
@@ -43,116 +37,120 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftFeeChargeCap
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftFeeChargeDetail
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner) o;
-    return Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get overdraftFeeChargeCap
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftFeeChargeDetail
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner) o;
+        return Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
@@ -15,26 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBMinMaxType1Code;
-import uk.org.openbanking.datamodel.account.OBPeriod1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
@@ -45,301 +38,256 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    FBAO("FBAO"),
-    
-    FBAR("FBAR"),
-    
-    FBEB("FBEB"),
-    
-    FBIT("FBIT"),
-    
-    FBOR("FBOR"),
-    
-    FBOS("FBOS"),
-    
-    FBSC("FBSC"),
-    
-    FBTO("FBTO"),
-    
-    FBUB("FBUB"),
-    
-    FBUT("FBUT"),
-    
-    FTOT("FTOT"),
-    
-    FTUT("FTUT");
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner> feeType = new ArrayList<>();
 
-    private String value;
+    private OBMinMaxType1Code minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Integer feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private OBPeriod1Code cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner> feeType, OBMinMaxType1Code minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public OBMinMaxType1Code getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Integer getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public OBPeriod1Code getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private OBMinMaxType1Code minMaxType;
-
-  private Integer feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  private OBPeriod1Code cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner(List<FeeTypeEnum> feeType, OBMinMaxType1Code minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Get minMaxType
-   * @return minMaxType
-  */
-  @NotNull @Valid 
-  @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public OBMinMaxType1Code getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Integer getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Get cappingPeriod
-   * @return cappingPeriod
-  */
-  @Valid 
-  @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public OBPeriod1Code getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Fee/charge type which is being capped
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner {
+
+    FBAO("FBAO"),
+
+    FBAR("FBAR"),
+
+    FBEB("FBEB"),
+
+    FBIT("FBIT"),
+
+    FBOR("FBOR"),
+
+    FBOS("FBOS"),
+
+    FBSC("FBSC"),
+
+    FBTO("FBTO"),
+
+    FBUB("FBUB"),
+
+    FBUT("FBUT"),
+
+    FTOT("FTOT"),
+
+    FTUT("FTUT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner b : OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
@@ -15,19 +15,16 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Other fee type code which is not available in the standard code set
@@ -38,123 +35,128 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
@@ -15,32 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code0;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code1;
-import uk.org.openbanking.datamodel.account.OBInterestRateType1Code0;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType11;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType12;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType13;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType14;
-import uk.org.openbanking.datamodel.account.OBOverdraftFeeType1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Details about the fees/charges
@@ -51,429 +38,446 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner {
 
-  private OBOverdraftFeeType1Code feeType;
+    private OBOverdraftFeeType1Code feeType;
 
-  private Boolean negotiableIndicator;
+    private Boolean negotiableIndicator;
 
-  private Boolean overdraftControlIndicator;
+    private Boolean overdraftControlIndicator;
 
-  private String incrementalBorrowingAmount;
+    private String incrementalBorrowingAmount;
 
-  private String feeAmount;
+    private String feeAmount;
 
-  private String feeRate;
+    private String feeRate;
 
-  private OBInterestRateType1Code0 feeRateType;
+    private OBInterestRateType1Code0 feeRateType;
 
-  private OBFeeFrequency1Code0 applicationFrequency;
+    private OBFeeFrequency1Code0 applicationFrequency;
 
-  private OBFeeFrequency1Code1 calculationFrequency;
+    private OBFeeFrequency1Code1 calculationFrequency;
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap;
 
-  private OBOtherCodeType13 otherFeeType;
+    private OBOtherCodeType13 otherFeeType;
 
-  private OBOtherCodeType14 otherFeeRateType;
+    private OBOtherCodeType14 otherFeeRateType;
 
-  private OBOtherCodeType11 otherApplicationFrequency;
+    private OBOtherCodeType11 otherApplicationFrequency;
 
-  private OBOtherCodeType12 otherCalculationFrequency;
+    private OBOtherCodeType12 otherCalculationFrequency;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner(OBOverdraftFeeType1Code feeType, OBFeeFrequency1Code0 applicationFrequency) {
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeType(OBOverdraftFeeType1Code feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public OBOverdraftFeeType1Code getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(OBOverdraftFeeType1Code feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates whether fee and charges are negotiable
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Indicates whether fee and charges are negotiable", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.
-   * @return overdraftControlIndicator
-  */
-  
-  @Schema(name = "OverdraftControlIndicator", description = "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftControlIndicator")
-  public Boolean getOverdraftControlIndicator() {
-    return overdraftControlIndicator;
-  }
-
-  public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner incrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-    return this;
-  }
-
-  /**
-   * Every additional tranche of an overdraft balance to which an overdraft fee is applied
-   * @return incrementalBorrowingAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("IncrementalBorrowingAmount")
-  public String getIncrementalBorrowingAmount() {
-    return incrementalBorrowingAmount;
-  }
-
-  public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeRateType(OBInterestRateType1Code0 feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Get feeRateType
-   * @return feeRateType
-  */
-  @Valid 
-  @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public OBInterestRateType1Code0 getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(OBInterestRateType1Code0 feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code0 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get applicationFrequency
-   * @return applicationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public OBFeeFrequency1Code0 getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(OBFeeFrequency1Code0 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code1 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get calculationFrequency
-   * @return calculationFrequency
-  */
-  @Valid 
-  @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public OBFeeFrequency1Code1 getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(OBFeeFrequency1Code1 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner(OBOverdraftFeeType1Code feeType, OBFeeFrequency1Code0 applicationFrequency) {
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get overdraftFeeChargeCap
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherFeeType(OBOtherCodeType13 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OBOtherCodeType13 getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OBOtherCodeType13 otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherFeeRateType(OBOtherCodeType14 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OBOtherCodeType14 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OBOtherCodeType14 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OBOtherCodeType11 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OBOtherCodeType12 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeType(OBOverdraftFeeType1Code feeType) {
+        this.feeType = feeType;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public OBOverdraftFeeType1Code getFeeType() {
+        return feeType;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.overdraftControlIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.overdraftControlIndicator) &&
-        Objects.equals(this.incrementalBorrowingAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.incrementalBorrowingAmount) &&
-        Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.notes) &&
-        Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.overdraftFeeChargeCap) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherCalculationFrequency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, negotiableIndicator, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, overdraftFeeChargeCap, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
-    sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setFeeType(OBOverdraftFeeType1Code feeType) {
+        this.feeType = feeType;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates whether fee and charges are negotiable
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Indicates whether fee and charges are negotiable", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.
+     *
+     * @return overdraftControlIndicator
+     */
+
+    @Schema(name = "OverdraftControlIndicator", description = "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftControlIndicator")
+    public Boolean getOverdraftControlIndicator() {
+        return overdraftControlIndicator;
+    }
+
+    public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner incrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+        return this;
+    }
+
+    /**
+     * Every additional tranche of an overdraft balance to which an overdraft fee is applied
+     *
+     * @return incrementalBorrowingAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("IncrementalBorrowingAmount")
+    public String getIncrementalBorrowingAmount() {
+        return incrementalBorrowingAmount;
+    }
+
+    public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner feeRateType(OBInterestRateType1Code0 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public OBInterestRateType1Code0 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(OBInterestRateType1Code0 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code0 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public OBFeeFrequency1Code0 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(OBFeeFrequency1Code0 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code1 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public OBFeeFrequency1Code1 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(OBFeeFrequency1Code1 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner overdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner addOverdraftFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Get overdraftFeeChargeCap
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
+    }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherFeeType(OBOtherCodeType13 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OBOtherCodeType13 getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OBOtherCodeType13 otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherFeeRateType(OBOtherCodeType14 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OBOtherCodeType14 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OBOtherCodeType14 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OBOtherCodeType11 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OBOtherCodeType11 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OBOtherCodeType12 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OBOtherCodeType12 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.overdraftControlIndicator, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.overdraftControlIndicator) &&
+                Objects.equals(this.incrementalBorrowingAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.incrementalBorrowingAmount) &&
+                Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.notes) &&
+                Objects.equals(this.overdraftFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.overdraftFeeChargeCap) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, negotiableIndicator, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, overdraftFeeChargeCap, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
+        sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage {
+
+    INBA("INBA"),
+
+    INTI("INTI"),
+
+    INWH("INWH");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage b : OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType {
+
+    OVCO("OVCO"),
+
+    OVOD("OVOD"),
+
+    OVOT("OVOT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType b : OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod {
+
+    INBA("INBA"),
+
+    INTI("INTI"),
+
+    INWH("INWH");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod b : OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
@@ -15,20 +15,32 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBOtherCodeType10;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadProduct2DataProductInnerOtherProductTypeProductDetails
@@ -38,331 +50,207 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeProductDetails {
 
-  /**
-   * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another. Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd 
-   */
-  public enum SegmentEnum {
-    GEAS("GEAS"),
-    
-    GEBA("GEBA"),
-    
-    GEBR("GEBR"),
-    
-    GEBU("GEBU"),
-    
-    GECI("GECI"),
-    
-    GECS("GECS"),
-    
-    GEFB("GEFB"),
-    
-    GEFG("GEFG"),
-    
-    GEG("GEG"),
-    
-    GEGR("GEGR"),
-    
-    GEGS("GEGS"),
-    
-    GEOT("GEOT"),
-    
-    GEOV("GEOV"),
-    
-    GEPA("GEPA"),
-    
-    GEPR("GEPR"),
-    
-    GERE("GERE"),
-    
-    GEST("GEST"),
-    
-    GEYA("GEYA"),
-    
-    GEYO("GEYO"),
-    
-    PSCA("PSCA"),
-    
-    PSES("PSES"),
-    
-    PSNC("PSNC"),
-    
-    PSNP("PSNP"),
-    
-    PSRG("PSRG"),
-    
-    PSSS("PSSS"),
-    
-    PSST("PSST"),
-    
-    PSSW("PSSW");
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner> segment;
 
-    private String value;
+    private Integer feeFreeLength;
 
-    SegmentEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod feeFreeLengthPeriod;
+
+    private String monthlyMaximumCharge;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBOtherCodeType10 otherSegment;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails segment(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner> segment) {
+        this.segment = segment;
+        return this;
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails addSegmentItem(OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner segmentItem) {
+        if (this.segment == null) {
+            this.segment = new ArrayList<>();
+        }
+        this.segment.add(segmentItem);
+        return this;
+    }
+
+    /**
+     * Get segment
+     *
+     * @return segment
+     */
+    @Valid
+    @Schema(name = "Segment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Segment")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner> getSegment() {
+        return segment;
+    }
+
+    public void setSegment(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner> segment) {
+        this.segment = segment;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails feeFreeLength(Integer feeFreeLength) {
+        this.feeFreeLength = feeFreeLength;
+        return this;
+    }
+
+    /**
+     * The length/duration of the fee free period
+     *
+     * @return feeFreeLength
+     */
+
+    @Schema(name = "FeeFreeLength", description = "The length/duration of the fee free period", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeFreeLength")
+    public Integer getFeeFreeLength() {
+        return feeFreeLength;
+    }
+
+    public void setFeeFreeLength(Integer feeFreeLength) {
+        this.feeFreeLength = feeFreeLength;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails feeFreeLengthPeriod(OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod feeFreeLengthPeriod) {
+        this.feeFreeLengthPeriod = feeFreeLengthPeriod;
+        return this;
+    }
+
+    /**
+     * Get feeFreeLengthPeriod
+     *
+     * @return feeFreeLengthPeriod
+     */
+    @Valid
+    @Schema(name = "FeeFreeLengthPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeFreeLengthPeriod")
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod getFeeFreeLengthPeriod() {
+        return feeFreeLengthPeriod;
+    }
+
+    public void setFeeFreeLengthPeriod(OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod feeFreeLengthPeriod) {
+        this.feeFreeLengthPeriod = feeFreeLengthPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails monthlyMaximumCharge(String monthlyMaximumCharge) {
+        this.monthlyMaximumCharge = monthlyMaximumCharge;
+        return this;
+    }
+
+    /**
+     * The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order
+     *
+     * @return monthlyMaximumCharge
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MonthlyMaximumCharge", description = "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MonthlyMaximumCharge")
+    public String getMonthlyMaximumCharge() {
+        return monthlyMaximumCharge;
+    }
+
+    public void setMonthlyMaximumCharge(String monthlyMaximumCharge) {
+        this.monthlyMaximumCharge = monthlyMaximumCharge;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeProductDetails otherSegment(OBOtherCodeType10 otherSegment) {
+        this.otherSegment = otherSegment;
+        return this;
+    }
+
+    /**
+     * Get otherSegment
+     *
+     * @return otherSegment
+     */
+    @Valid
+    @Schema(name = "OtherSegment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherSegment")
+    public OBOtherCodeType10 getOtherSegment() {
+        return otherSegment;
+    }
+
+    public void setOtherSegment(OBOtherCodeType10 otherSegment) {
+        this.otherSegment = otherSegment;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeProductDetails obReadProduct2DataProductInnerOtherProductTypeProductDetails = (OBReadProduct2DataProductInnerOtherProductTypeProductDetails) o;
+        return Objects.equals(this.segment, obReadProduct2DataProductInnerOtherProductTypeProductDetails.segment) &&
+                Objects.equals(this.feeFreeLength, obReadProduct2DataProductInnerOtherProductTypeProductDetails.feeFreeLength) &&
+                Objects.equals(this.feeFreeLengthPeriod, obReadProduct2DataProductInnerOtherProductTypeProductDetails.feeFreeLengthPeriod) &&
+                Objects.equals(this.monthlyMaximumCharge, obReadProduct2DataProductInnerOtherProductTypeProductDetails.monthlyMaximumCharge) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeProductDetails.notes) &&
+                Objects.equals(this.otherSegment, obReadProduct2DataProductInnerOtherProductTypeProductDetails.otherSegment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segment, feeFreeLength, feeFreeLengthPeriod, monthlyMaximumCharge, notes, otherSegment);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeProductDetails {\n");
+        sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
+        sb.append("    feeFreeLength: ").append(toIndentedString(feeFreeLength)).append("\n");
+        sb.append("    feeFreeLengthPeriod: ").append(toIndentedString(feeFreeLengthPeriod)).append("\n");
+        sb.append("    monthlyMaximumCharge: ").append(toIndentedString(monthlyMaximumCharge)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherSegment: ").append(toIndentedString(otherSegment)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static SegmentEnum fromValue(String value) {
-      for (SegmentEnum b : SegmentEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<SegmentEnum> segment;
-
-  private Integer feeFreeLength;
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the promotional length
-   */
-  public enum FeeFreeLengthPeriodEnum {
-    PACT("PACT"),
-    
-    PDAY("PDAY"),
-    
-    PHYR("PHYR"),
-    
-    PMTH("PMTH"),
-    
-    PQTR("PQTR"),
-    
-    PWEK("PWEK"),
-    
-    PYER("PYER");
-
-    private String value;
-
-    FeeFreeLengthPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeFreeLengthPeriodEnum fromValue(String value) {
-      for (FeeFreeLengthPeriodEnum b : FeeFreeLengthPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeFreeLengthPeriodEnum feeFreeLengthPeriod;
-
-  private String monthlyMaximumCharge;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBOtherCodeType10 otherSegment;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails segment(List<SegmentEnum> segment) {
-    this.segment = segment;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails addSegmentItem(SegmentEnum segmentItem) {
-    if (this.segment == null) {
-      this.segment = new ArrayList<>();
-    }
-    this.segment.add(segmentItem);
-    return this;
-  }
-
-  /**
-   * Get segment
-   * @return segment
-  */
-  
-  @Schema(name = "Segment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Segment")
-  public List<SegmentEnum> getSegment() {
-    return segment;
-  }
-
-  public void setSegment(List<SegmentEnum> segment) {
-    this.segment = segment;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails feeFreeLength(Integer feeFreeLength) {
-    this.feeFreeLength = feeFreeLength;
-    return this;
-  }
-
-  /**
-   * The length/duration of the fee free period
-   * @return feeFreeLength
-  */
-  
-  @Schema(name = "FeeFreeLength", description = "The length/duration of the fee free period", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeFreeLength")
-  public Integer getFeeFreeLength() {
-    return feeFreeLength;
-  }
-
-  public void setFeeFreeLength(Integer feeFreeLength) {
-    this.feeFreeLength = feeFreeLength;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails feeFreeLengthPeriod(FeeFreeLengthPeriodEnum feeFreeLengthPeriod) {
-    this.feeFreeLengthPeriod = feeFreeLengthPeriod;
-    return this;
-  }
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the promotional length
-   * @return feeFreeLengthPeriod
-  */
-  
-  @Schema(name = "FeeFreeLengthPeriod", description = "The unit of period (days, weeks, months etc.) of the promotional length", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeFreeLengthPeriod")
-  public FeeFreeLengthPeriodEnum getFeeFreeLengthPeriod() {
-    return feeFreeLengthPeriod;
-  }
-
-  public void setFeeFreeLengthPeriod(FeeFreeLengthPeriodEnum feeFreeLengthPeriod) {
-    this.feeFreeLengthPeriod = feeFreeLengthPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails monthlyMaximumCharge(String monthlyMaximumCharge) {
-    this.monthlyMaximumCharge = monthlyMaximumCharge;
-    return this;
-  }
-
-  /**
-   * The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order
-   * @return monthlyMaximumCharge
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MonthlyMaximumCharge", description = "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MonthlyMaximumCharge")
-  public String getMonthlyMaximumCharge() {
-    return monthlyMaximumCharge;
-  }
-
-  public void setMonthlyMaximumCharge(String monthlyMaximumCharge) {
-    this.monthlyMaximumCharge = monthlyMaximumCharge;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeProductDetails otherSegment(OBOtherCodeType10 otherSegment) {
-    this.otherSegment = otherSegment;
-    return this;
-  }
-
-  /**
-   * Get otherSegment
-   * @return otherSegment
-  */
-  @Valid 
-  @Schema(name = "OtherSegment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherSegment")
-  public OBOtherCodeType10 getOtherSegment() {
-    return otherSegment;
-  }
-
-  public void setOtherSegment(OBOtherCodeType10 otherSegment) {
-    this.otherSegment = otherSegment;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeProductDetails obReadProduct2DataProductInnerOtherProductTypeProductDetails = (OBReadProduct2DataProductInnerOtherProductTypeProductDetails) o;
-    return Objects.equals(this.segment, obReadProduct2DataProductInnerOtherProductTypeProductDetails.segment) &&
-        Objects.equals(this.feeFreeLength, obReadProduct2DataProductInnerOtherProductTypeProductDetails.feeFreeLength) &&
-        Objects.equals(this.feeFreeLengthPeriod, obReadProduct2DataProductInnerOtherProductTypeProductDetails.feeFreeLengthPeriod) &&
-        Objects.equals(this.monthlyMaximumCharge, obReadProduct2DataProductInnerOtherProductTypeProductDetails.monthlyMaximumCharge) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeProductDetails.notes) &&
-        Objects.equals(this.otherSegment, obReadProduct2DataProductInnerOtherProductTypeProductDetails.otherSegment);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(segment, feeFreeLength, feeFreeLengthPeriod, monthlyMaximumCharge, notes, otherSegment);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeProductDetails {\n");
-    sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
-    sb.append("    feeFreeLength: ").append(toIndentedString(feeFreeLength)).append("\n");
-    sb.append("    feeFreeLengthPeriod: ").append(toIndentedString(feeFreeLengthPeriod)).append("\n");
-    sb.append("    monthlyMaximumCharge: ").append(toIndentedString(monthlyMaximumCharge)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherSegment: ").append(toIndentedString(otherSegment)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The unit of period (days, weeks, months etc.) of the promotional length
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod {
+
+    PACT("PACT"),
+
+    PDAY("PDAY"),
+
+    PHYR("PHYR"),
+
+    PMTH("PMTH"),
+
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod b : OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another. Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner {
+
+    GEAS("GEAS"),
+
+    GEBA("GEBA"),
+
+    GEBR("GEBR"),
+
+    GEBU("GEBU"),
+
+    GECI("GECI"),
+
+    GECS("GECS"),
+
+    GEFB("GEFB"),
+
+    GEFG("GEFG"),
+
+    GEG("GEG"),
+
+    GEGR("GEGR"),
+
+    GEGS("GEGS"),
+
+    GEOT("GEOT"),
+
+    GEOV("GEOV"),
+
+    GEPA("GEPA"),
+
+    GEPR("GEPR"),
+
+    GERE("GERE"),
+
+    GEST("GEST"),
+
+    GEYA("GEYA"),
+
+    GEYO("GEYO"),
+
+    PSCA("PSCA"),
+
+    PSES("PSES"),
+
+    PSNC("PSNC"),
+
+    PSNP("PSNP"),
+
+    PSRG("PSRG"),
+
+    PSSS("PSSS"),
+
+    PSST("PSST"),
+
+    PSSW("PSSW");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner b : OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
@@ -15,19 +15,37 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Repayment details of the Loan product
@@ -38,424 +56,282 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepayment {
 
-  /**
-   * Repayment type
-   */
-  public enum RepaymentTypeEnum {
-    USBA("USBA"),
-    
-    USBU("USBU"),
-    
-    USCI("USCI"),
-    
-    USCS("USCS"),
-    
-    USER("USER"),
-    
-    USFA("USFA"),
-    
-    USFB("USFB"),
-    
-    USFI("USFI"),
-    
-    USIO("USIO"),
-    
-    USOT("USOT"),
-    
-    USPF("USPF"),
-    
-    USRW("USRW"),
-    
-    USSL("USSL");
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType repaymentType;
 
-    private String value;
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency repaymentFrequency;
 
-    RepaymentTypeEnum(String value) {
-      this.value = value;
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType amountType;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType;
+
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType repaymentType) {
+        this.repaymentType = repaymentType;
+        return this;
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Get repaymentType
+     *
+     * @return repaymentType
+     */
+    @Valid
+    @Schema(name = "RepaymentType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepaymentType")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType getRepaymentType() {
+        return repaymentType;
+    }
+
+    public void setRepaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType repaymentType) {
+        this.repaymentType = repaymentType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency repaymentFrequency) {
+        this.repaymentFrequency = repaymentFrequency;
+        return this;
+    }
+
+    /**
+     * Get repaymentFrequency
+     *
+     * @return repaymentFrequency
+     */
+    @Valid
+    @Schema(name = "RepaymentFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepaymentFrequency")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency getRepaymentFrequency() {
+        return repaymentFrequency;
+    }
+
+    public void setRepaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency repaymentFrequency) {
+        this.repaymentFrequency = repaymentFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment amountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType amountType) {
+        this.amountType = amountType;
+        return this;
+    }
+
+    /**
+     * Get amountType
+     *
+     * @return amountType
+     */
+    @Valid
+    @Schema(name = "AmountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AmountType")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType getAmountType() {
+        return amountType;
+    }
+
+    public void setAmountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType amountType) {
+        this.amountType = amountType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherRepaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType) {
+        this.otherRepaymentType = otherRepaymentType;
+        return this;
+    }
+
+    /**
+     * Get otherRepaymentType
+     *
+     * @return otherRepaymentType
+     */
+    @Valid
+    @Schema(name = "OtherRepaymentType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherRepaymentType")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType getOtherRepaymentType() {
+        return otherRepaymentType;
+    }
+
+    public void setOtherRepaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType) {
+        this.otherRepaymentType = otherRepaymentType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherRepaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency) {
+        this.otherRepaymentFrequency = otherRepaymentFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherRepaymentFrequency
+     *
+     * @return otherRepaymentFrequency
+     */
+    @Valid
+    @Schema(name = "OtherRepaymentFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherRepaymentFrequency")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency getOtherRepaymentFrequency() {
+        return otherRepaymentFrequency;
+    }
+
+    public void setOtherRepaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency) {
+        this.otherRepaymentFrequency = otherRepaymentFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherAmountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType) {
+        this.otherAmountType = otherAmountType;
+        return this;
+    }
+
+    /**
+     * Get otherAmountType
+     *
+     * @return otherAmountType
+     */
+    @Valid
+    @Schema(name = "OtherAmountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherAmountType")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType getOtherAmountType() {
+        return otherAmountType;
+    }
+
+    public void setOtherAmountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType) {
+        this.otherAmountType = otherAmountType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentFeeCharges(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges) {
+        this.repaymentFeeCharges = repaymentFeeCharges;
+        return this;
+    }
+
+    /**
+     * Get repaymentFeeCharges
+     *
+     * @return repaymentFeeCharges
+     */
+    @Valid
+    @Schema(name = "RepaymentFeeCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepaymentFeeCharges")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges getRepaymentFeeCharges() {
+        return repaymentFeeCharges;
+    }
+
+    public void setRepaymentFeeCharges(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges) {
+        this.repaymentFeeCharges = repaymentFeeCharges;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentHoliday(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday) {
+        this.repaymentHoliday = repaymentHoliday;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepayment addRepaymentHolidayItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner repaymentHolidayItem) {
+        if (this.repaymentHoliday == null) {
+            this.repaymentHoliday = new ArrayList<>();
+        }
+        this.repaymentHoliday.add(repaymentHolidayItem);
+        return this;
+    }
+
+    /**
+     * Get repaymentHoliday
+     *
+     * @return repaymentHoliday
+     */
+    @Valid
+    @Schema(name = "RepaymentHoliday", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepaymentHoliday")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> getRepaymentHoliday() {
+        return repaymentHoliday;
+    }
+
+    public void setRepaymentHoliday(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday) {
+        this.repaymentHoliday = repaymentHoliday;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepayment obReadProduct2DataProductInnerOtherProductTypeRepayment = (OBReadProduct2DataProductInnerOtherProductTypeRepayment) o;
+        return Objects.equals(this.repaymentType, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentType) &&
+                Objects.equals(this.repaymentFrequency, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentFrequency) &&
+                Objects.equals(this.amountType, obReadProduct2DataProductInnerOtherProductTypeRepayment.amountType) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepayment.notes) &&
+                Objects.equals(this.otherRepaymentType, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherRepaymentType) &&
+                Objects.equals(this.otherRepaymentFrequency, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherRepaymentFrequency) &&
+                Objects.equals(this.otherAmountType, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherAmountType) &&
+                Objects.equals(this.repaymentFeeCharges, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentFeeCharges) &&
+                Objects.equals(this.repaymentHoliday, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentHoliday);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repaymentType, repaymentFrequency, amountType, notes, otherRepaymentType, otherRepaymentFrequency, otherAmountType, repaymentFeeCharges, repaymentHoliday);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepayment {\n");
+        sb.append("    repaymentType: ").append(toIndentedString(repaymentType)).append("\n");
+        sb.append("    repaymentFrequency: ").append(toIndentedString(repaymentFrequency)).append("\n");
+        sb.append("    amountType: ").append(toIndentedString(amountType)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherRepaymentType: ").append(toIndentedString(otherRepaymentType)).append("\n");
+        sb.append("    otherRepaymentFrequency: ").append(toIndentedString(otherRepaymentFrequency)).append("\n");
+        sb.append("    otherAmountType: ").append(toIndentedString(otherAmountType)).append("\n");
+        sb.append("    repaymentFeeCharges: ").append(toIndentedString(repaymentFeeCharges)).append("\n");
+        sb.append("    repaymentHoliday: ").append(toIndentedString(repaymentHoliday)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static RepaymentTypeEnum fromValue(String value) {
-      for (RepaymentTypeEnum b : RepaymentTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private RepaymentTypeEnum repaymentType;
-
-  /**
-   * Repayment frequency
-   */
-  public enum RepaymentFrequencyEnum {
-    SMDA("SMDA"),
-    
-    SMFL("SMFL"),
-    
-    SMFO("SMFO"),
-    
-    SMHY("SMHY"),
-    
-    SMMO("SMMO"),
-    
-    SMOT("SMOT"),
-    
-    SMQU("SMQU"),
-    
-    SMWE("SMWE"),
-    
-    SMYE("SMYE");
-
-    private String value;
-
-    RepaymentFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static RepaymentFrequencyEnum fromValue(String value) {
-      for (RepaymentFrequencyEnum b : RepaymentFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private RepaymentFrequencyEnum repaymentFrequency;
-
-  /**
-   * The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc
-   */
-  public enum AmountTypeEnum {
-    RABD("RABD"),
-    
-    RABL("RABL"),
-    
-    RACI("RACI"),
-    
-    RAFC("RAFC"),
-    
-    RAIO("RAIO"),
-    
-    RALT("RALT"),
-    
-    USOT("USOT");
-
-    private String value;
-
-    AmountTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static AmountTypeEnum fromValue(String value) {
-      for (AmountTypeEnum b : AmountTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private AmountTypeEnum amountType;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType;
-
-  private OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentType(RepaymentTypeEnum repaymentType) {
-    this.repaymentType = repaymentType;
-    return this;
-  }
-
-  /**
-   * Repayment type
-   * @return repaymentType
-  */
-  
-  @Schema(name = "RepaymentType", description = "Repayment type", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepaymentType")
-  public RepaymentTypeEnum getRepaymentType() {
-    return repaymentType;
-  }
-
-  public void setRepaymentType(RepaymentTypeEnum repaymentType) {
-    this.repaymentType = repaymentType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentFrequency(RepaymentFrequencyEnum repaymentFrequency) {
-    this.repaymentFrequency = repaymentFrequency;
-    return this;
-  }
-
-  /**
-   * Repayment frequency
-   * @return repaymentFrequency
-  */
-  
-  @Schema(name = "RepaymentFrequency", description = "Repayment frequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepaymentFrequency")
-  public RepaymentFrequencyEnum getRepaymentFrequency() {
-    return repaymentFrequency;
-  }
-
-  public void setRepaymentFrequency(RepaymentFrequencyEnum repaymentFrequency) {
-    this.repaymentFrequency = repaymentFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment amountType(AmountTypeEnum amountType) {
-    this.amountType = amountType;
-    return this;
-  }
-
-  /**
-   * The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc
-   * @return amountType
-  */
-  
-  @Schema(name = "AmountType", description = "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AmountType")
-  public AmountTypeEnum getAmountType() {
-    return amountType;
-  }
-
-  public void setAmountType(AmountTypeEnum amountType) {
-    this.amountType = amountType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherRepaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType) {
-    this.otherRepaymentType = otherRepaymentType;
-    return this;
-  }
-
-  /**
-   * Get otherRepaymentType
-   * @return otherRepaymentType
-  */
-  @Valid 
-  @Schema(name = "OtherRepaymentType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherRepaymentType")
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType getOtherRepaymentType() {
-    return otherRepaymentType;
-  }
-
-  public void setOtherRepaymentType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType otherRepaymentType) {
-    this.otherRepaymentType = otherRepaymentType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherRepaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency) {
-    this.otherRepaymentFrequency = otherRepaymentFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherRepaymentFrequency
-   * @return otherRepaymentFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherRepaymentFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherRepaymentFrequency")
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency getOtherRepaymentFrequency() {
-    return otherRepaymentFrequency;
-  }
-
-  public void setOtherRepaymentFrequency(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency otherRepaymentFrequency) {
-    this.otherRepaymentFrequency = otherRepaymentFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment otherAmountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType) {
-    this.otherAmountType = otherAmountType;
-    return this;
-  }
-
-  /**
-   * Get otherAmountType
-   * @return otherAmountType
-  */
-  @Valid 
-  @Schema(name = "OtherAmountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherAmountType")
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType getOtherAmountType() {
-    return otherAmountType;
-  }
-
-  public void setOtherAmountType(OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType otherAmountType) {
-    this.otherAmountType = otherAmountType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentFeeCharges(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges) {
-    this.repaymentFeeCharges = repaymentFeeCharges;
-    return this;
-  }
-
-  /**
-   * Get repaymentFeeCharges
-   * @return repaymentFeeCharges
-  */
-  @Valid 
-  @Schema(name = "RepaymentFeeCharges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepaymentFeeCharges")
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges getRepaymentFeeCharges() {
-    return repaymentFeeCharges;
-  }
-
-  public void setRepaymentFeeCharges(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeCharges) {
-    this.repaymentFeeCharges = repaymentFeeCharges;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment repaymentHoliday(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday) {
-    this.repaymentHoliday = repaymentHoliday;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepayment addRepaymentHolidayItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner repaymentHolidayItem) {
-    if (this.repaymentHoliday == null) {
-      this.repaymentHoliday = new ArrayList<>();
-    }
-    this.repaymentHoliday.add(repaymentHolidayItem);
-    return this;
-  }
-
-  /**
-   * Get repaymentHoliday
-   * @return repaymentHoliday
-  */
-  @Valid 
-  @Schema(name = "RepaymentHoliday", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepaymentHoliday")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> getRepaymentHoliday() {
-    return repaymentHoliday;
-  }
-
-  public void setRepaymentHoliday(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner> repaymentHoliday) {
-    this.repaymentHoliday = repaymentHoliday;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeRepayment obReadProduct2DataProductInnerOtherProductTypeRepayment = (OBReadProduct2DataProductInnerOtherProductTypeRepayment) o;
-    return Objects.equals(this.repaymentType, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentType) &&
-        Objects.equals(this.repaymentFrequency, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentFrequency) &&
-        Objects.equals(this.amountType, obReadProduct2DataProductInnerOtherProductTypeRepayment.amountType) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepayment.notes) &&
-        Objects.equals(this.otherRepaymentType, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherRepaymentType) &&
-        Objects.equals(this.otherRepaymentFrequency, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherRepaymentFrequency) &&
-        Objects.equals(this.otherAmountType, obReadProduct2DataProductInnerOtherProductTypeRepayment.otherAmountType) &&
-        Objects.equals(this.repaymentFeeCharges, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentFeeCharges) &&
-        Objects.equals(this.repaymentHoliday, obReadProduct2DataProductInnerOtherProductTypeRepayment.repaymentHoliday);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(repaymentType, repaymentFrequency, amountType, notes, otherRepaymentType, otherRepaymentFrequency, otherAmountType, repaymentFeeCharges, repaymentHoliday);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepayment {\n");
-    sb.append("    repaymentType: ").append(toIndentedString(repaymentType)).append("\n");
-    sb.append("    repaymentFrequency: ").append(toIndentedString(repaymentFrequency)).append("\n");
-    sb.append("    amountType: ").append(toIndentedString(amountType)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherRepaymentType: ").append(toIndentedString(otherRepaymentType)).append("\n");
-    sb.append("    otherRepaymentFrequency: ").append(toIndentedString(otherRepaymentFrequency)).append("\n");
-    sb.append("    otherAmountType: ").append(toIndentedString(otherAmountType)).append("\n");
-    sb.append("    repaymentFeeCharges: ").append(toIndentedString(repaymentFeeCharges)).append("\n");
-    sb.append("    repaymentHoliday: ").append(toIndentedString(repaymentHoliday)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType {
+
+    RABD("RABD"),
+
+    RABL("RABL"),
+
+    RACI("RACI"),
+
+    RAFC("RAFC"),
+
+    RAIO("RAIO"),
+
+    RALT("RALT"),
+
+    USOT("USOT");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType b : OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
@@ -15,16 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other amount type which is not in the standard code list
@@ -35,123 +42,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
@@ -15,16 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other repayment frequency which is not in the standard code list
@@ -35,123 +42,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
@@ -15,16 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other repayment type which is not in the standard code list
@@ -35,123 +42,128 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\\\w{0,4}$") 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType) o;
-    return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.code) &&
-        Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.name) &&
-        Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\\\w{0,4}$")
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType) o;
+        return Objects.equals(this.code, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.code) &&
+                Objects.equals(this.name, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.name) &&
+                Objects.equals(this.description, obReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
@@ -15,18 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment.
@@ -37,116 +49,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges {
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail = new ArrayList<>();
 
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap;
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
-    this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
-    this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges addRepaymentFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner repaymentFeeChargeDetailItem) {
-    if (this.repaymentFeeChargeDetail == null) {
-      this.repaymentFeeChargeDetail = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges() {
+        super();
     }
-    this.repaymentFeeChargeDetail.add(repaymentFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Get repaymentFeeChargeDetail
-   * @return repaymentFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "RepaymentFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("RepaymentFeeChargeDetail")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> getRepaymentFeeChargeDetail() {
-    return repaymentFeeChargeDetail;
-  }
-
-  public void setRepaymentFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
-    this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap) {
-    this.repaymentFeeChargeCap = repaymentFeeChargeCap;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges addRepaymentFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner repaymentFeeChargeCapItem) {
-    if (this.repaymentFeeChargeCap == null) {
-      this.repaymentFeeChargeCap = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
+        this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
     }
-    this.repaymentFeeChargeCap.add(repaymentFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Get repaymentFeeChargeCap
-   * @return repaymentFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "RepaymentFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepaymentFeeChargeCap")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> getRepaymentFeeChargeCap() {
-    return repaymentFeeChargeCap;
-  }
-
-  public void setRepaymentFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap) {
-    this.repaymentFeeChargeCap = repaymentFeeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
+        this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges addRepaymentFeeChargeDetailItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner repaymentFeeChargeDetailItem) {
+        if (this.repaymentFeeChargeDetail == null) {
+            this.repaymentFeeChargeDetail = new ArrayList<>();
+        }
+        this.repaymentFeeChargeDetail.add(repaymentFeeChargeDetailItem);
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges) o;
-    return Objects.equals(this.repaymentFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.repaymentFeeChargeDetail) &&
-        Objects.equals(this.repaymentFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.repaymentFeeChargeCap);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(repaymentFeeChargeDetail, repaymentFeeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges {\n");
-    sb.append("    repaymentFeeChargeDetail: ").append(toIndentedString(repaymentFeeChargeDetail)).append("\n");
-    sb.append("    repaymentFeeChargeCap: ").append(toIndentedString(repaymentFeeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get repaymentFeeChargeDetail
+     *
+     * @return repaymentFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "RepaymentFeeChargeDetail", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("RepaymentFeeChargeDetail")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> getRepaymentFeeChargeDetail() {
+        return repaymentFeeChargeDetail;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setRepaymentFeeChargeDetail(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner> repaymentFeeChargeDetail) {
+        this.repaymentFeeChargeDetail = repaymentFeeChargeDetail;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges repaymentFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap) {
+        this.repaymentFeeChargeCap = repaymentFeeChargeCap;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges addRepaymentFeeChargeCapItem(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner repaymentFeeChargeCapItem) {
+        if (this.repaymentFeeChargeCap == null) {
+            this.repaymentFeeChargeCap = new ArrayList<>();
+        }
+        this.repaymentFeeChargeCap.add(repaymentFeeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Get repaymentFeeChargeCap
+     *
+     * @return repaymentFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "RepaymentFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepaymentFeeChargeCap")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> getRepaymentFeeChargeCap() {
+        return repaymentFeeChargeCap;
+    }
+
+    public void setRepaymentFeeChargeCap(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner> repaymentFeeChargeCap) {
+        this.repaymentFeeChargeCap = repaymentFeeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges) o;
+        return Objects.equals(this.repaymentFeeChargeDetail, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.repaymentFeeChargeDetail) &&
+                Objects.equals(this.repaymentFeeChargeCap, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.repaymentFeeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(repaymentFeeChargeDetail, repaymentFeeChargeCap);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges {\n");
+        sb.append("    repaymentFeeChargeDetail: ").append(toIndentedString(repaymentFeeChargeDetail)).append("\n");
+        sb.append("    repaymentFeeChargeCap: ").append(toIndentedString(repaymentFeeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
@@ -15,26 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBMinMaxType1Code;
-import uk.org.openbanking.datamodel.account.OBPeriod1Code;
-import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged
@@ -45,295 +38,256 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner {
 
-  /**
-   * Fee/charge type which is being capped
-   */
-  public enum FeeTypeEnum {
-    FEPF("FEPF"),
-    
-    FTOT("FTOT"),
-    
-    FYAF("FYAF"),
-    
-    FYAM("FYAM"),
-    
-    FYAQ("FYAQ"),
-    
-    FYCP("FYCP"),
-    
-    FYDB("FYDB"),
-    
-    FYMI("FYMI"),
-    
-    FYXX("FYXX");
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType = new ArrayList<>();
 
-    private String value;
+    private OBMinMaxType1Code minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Integer feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private OBPeriod1Code cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType, OBMinMaxType1Code minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public OBMinMaxType1Code getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(OBMinMaxType1Code minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Integer getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Integer feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public OBPeriod1Code getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private OBMinMaxType1Code minMaxType;
-
-  private Integer feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  private OBPeriod1Code cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner(List<FeeTypeEnum> feeType, OBMinMaxType1Code minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner minMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Get minMaxType
-   * @return minMaxType
-  */
-  @NotNull @Valid 
-  @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public OBMinMaxType1Code getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(OBMinMaxType1Code minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Integer getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Integer feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner cappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Get cappingPeriod
-   * @return cappingPeriod
-  */
-  @Valid 
-  @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public OBPeriod1Code getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(OBPeriod1Code cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner otherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner addOtherFeeTypeItem(OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
@@ -15,31 +15,19 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.net.URI;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code2;
-import uk.org.openbanking.datamodel.account.OBFeeFrequency1Code3;
-import uk.org.openbanking.datamodel.account.OBFeeType1Code;
-import uk.org.openbanking.datamodel.account.OBInterestRateType1Code1;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType16;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType17;
-import uk.org.openbanking.datamodel.account.OBOtherCodeType18;
-import uk.org.openbanking.datamodel.account.OBOtherFeeChargeDetailType;
-import java.time.OffsetDateTime;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-
-
-import java.util.*;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 /**
  * Details about specific fees/charges that are applied for repayment
@@ -50,349 +38,364 @@ import jakarta.annotation.Generated;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner {
 
-  private OBFeeType1Code feeType;
+    private OBFeeType1Code feeType;
 
-  private Boolean negotiableIndicator;
+    private Boolean negotiableIndicator;
 
-  private String feeAmount;
+    private String feeAmount;
 
-  private String feeRate;
+    private String feeRate;
 
-  private OBInterestRateType1Code1 feeRateType;
+    private OBInterestRateType1Code1 feeRateType;
 
-  private OBFeeFrequency1Code2 applicationFrequency;
+    private OBFeeFrequency1Code2 applicationFrequency;
 
-  private OBFeeFrequency1Code3 calculationFrequency;
+    private OBFeeFrequency1Code3 calculationFrequency;
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  private OBOtherFeeChargeDetailType otherFeeType;
+    private OBOtherFeeChargeDetailType otherFeeType;
 
-  private OBOtherCodeType18 otherFeeRateType;
+    private OBOtherCodeType18 otherFeeRateType;
 
-  private OBOtherCodeType16 otherApplicationFrequency;
+    private OBOtherCodeType16 otherApplicationFrequency;
 
-  private OBOtherCodeType17 otherCalculationFrequency;
+    private OBOtherCodeType17 otherCalculationFrequency;
 
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner(OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency, OBFeeFrequency1Code3 calculationFrequency) {
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Get feeType
-   * @return feeType
-  */
-  @NotNull @Valid 
-  @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public OBFeeType1Code getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(OBFeeType1Code feeType) {
-    this.feeType = feeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Fee/charge which is usually negotiable rather than a fixed amount
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Get feeRateType
-   * @return feeRateType
-  */
-  @Valid 
-  @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public OBInterestRateType1Code1 getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get applicationFrequency
-   * @return applicationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public OBFeeFrequency1Code2 getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get calculationFrequency
-   * @return calculationFrequency
-  */
-  @NotNull @Valid 
-  @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public OBFeeFrequency1Code3 getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OBOtherFeeChargeDetailType getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OBOtherCodeType18 getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OBOtherCodeType16 getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OBOtherCodeType17 getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner(OBFeeType1Code feeType, OBFeeFrequency1Code2 applicationFrequency, OBFeeFrequency1Code3 calculationFrequency) {
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+        this.calculationFrequency = calculationFrequency;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+        return this;
     }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner) o;
-    return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.notes) &&
-        Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherCalculationFrequency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public OBFeeType1Code getFeeType() {
+        return feeType;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setFeeType(OBFeeType1Code feeType) {
+        this.feeType = feeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Fee/charge which is usually negotiable rather than a fixed amount
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Fee/charge which is usually negotiable rather than a fixed amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner feeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public OBInterestRateType1Code1 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(OBInterestRateType1Code1 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner applicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public OBFeeFrequency1Code2 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(OBFeeFrequency1Code2 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner calculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public OBFeeFrequency1Code3 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(OBFeeFrequency1Code3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OBOtherFeeChargeDetailType getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OBOtherFeeChargeDetailType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OBOtherCodeType18 getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OBOtherCodeType18 otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OBOtherCodeType16 getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OBOtherCodeType16 otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner otherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OBOtherCodeType17 getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OBOtherCodeType17 otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner) o;
+        return Objects.equals(this.feeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.feeAmount, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.notes) &&
+                Objects.equals(this.otherFeeType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, negotiableIndicator, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Repayment frequency
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency {
+
+    SMDA("SMDA"),
+
+    SMFL("SMFL"),
+
+    SMFO("SMFO"),
+
+    SMHY("SMHY"),
+
+    SMMO("SMMO"),
+
+    SMOT("SMOT"),
+
+    SMQU("SMQU"),
+
+    SMWE("SMWE"),
+
+    SMYE("SMYE");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency b : OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
@@ -15,19 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details of capital repayment holiday if any
@@ -38,165 +49,123 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner {
 
-  private Integer maxHolidayLength;
+    private Integer maxHolidayLength;
 
-  /**
-   * The unit of period (days, weeks, months etc.) of the repayment holiday
-   */
-  public enum MaxHolidayPeriodEnum {
-    PACT("PACT"),
-    
-    PDAY("PDAY"),
-    
-    PHYR("PHYR"),
-    
-    PMTH("PMTH"),
-    
-    PQTR("PQTR"),
-    
-    PWEK("PWEK"),
-    
-    PYER("PYER");
+    private OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod maxHolidayPeriod;
 
-    private String value;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-    MaxHolidayPeriodEnum(String value) {
-      this.value = value;
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner maxHolidayLength(Integer maxHolidayLength) {
+        this.maxHolidayLength = maxHolidayLength;
+        return this;
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * The maximum length/duration of a Repayment Holiday
+     *
+     * @return maxHolidayLength
+     */
+
+    @Schema(name = "MaxHolidayLength", description = "The maximum length/duration of a Repayment Holiday", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaxHolidayLength")
+    public Integer getMaxHolidayLength() {
+        return maxHolidayLength;
+    }
+
+    public void setMaxHolidayLength(Integer maxHolidayLength) {
+        this.maxHolidayLength = maxHolidayLength;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner maxHolidayPeriod(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod maxHolidayPeriod) {
+        this.maxHolidayPeriod = maxHolidayPeriod;
+        return this;
+    }
+
+    /**
+     * Get maxHolidayPeriod
+     *
+     * @return maxHolidayPeriod
+     */
+    @Valid
+    @Schema(name = "MaxHolidayPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MaxHolidayPeriod")
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod getMaxHolidayPeriod() {
+        return maxHolidayPeriod;
+    }
+
+    public void setMaxHolidayPeriod(OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod maxHolidayPeriod) {
+        this.maxHolidayPeriod = maxHolidayPeriod;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Get notes
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner) o;
+        return Objects.equals(this.maxHolidayLength, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.maxHolidayLength) &&
+                Objects.equals(this.maxHolidayPeriod, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.maxHolidayPeriod) &&
+                Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.notes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxHolidayLength, maxHolidayPeriod, notes);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner {\n");
+        sb.append("    maxHolidayLength: ").append(toIndentedString(maxHolidayLength)).append("\n");
+        sb.append("    maxHolidayPeriod: ").append(toIndentedString(maxHolidayPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static MaxHolidayPeriodEnum fromValue(String value) {
-      for (MaxHolidayPeriodEnum b : MaxHolidayPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private MaxHolidayPeriodEnum maxHolidayPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner maxHolidayLength(Integer maxHolidayLength) {
-    this.maxHolidayLength = maxHolidayLength;
-    return this;
-  }
-
-  /**
-   * The maximum length/duration of a Repayment Holiday
-   * @return maxHolidayLength
-  */
-  
-  @Schema(name = "MaxHolidayLength", description = "The maximum length/duration of a Repayment Holiday", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaxHolidayLength")
-  public Integer getMaxHolidayLength() {
-    return maxHolidayLength;
-  }
-
-  public void setMaxHolidayLength(Integer maxHolidayLength) {
-    this.maxHolidayLength = maxHolidayLength;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner maxHolidayPeriod(MaxHolidayPeriodEnum maxHolidayPeriod) {
-    this.maxHolidayPeriod = maxHolidayPeriod;
-    return this;
-  }
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the repayment holiday
-   * @return maxHolidayPeriod
-  */
-  
-  @Schema(name = "MaxHolidayPeriod", description = "The unit of period (days, weeks, months etc.) of the repayment holiday", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MaxHolidayPeriod")
-  public MaxHolidayPeriodEnum getMaxHolidayPeriod() {
-    return maxHolidayPeriod;
-  }
-
-  public void setMaxHolidayPeriod(MaxHolidayPeriodEnum maxHolidayPeriod) {
-    this.maxHolidayPeriod = maxHolidayPeriod;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Get notes
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner = (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner) o;
-    return Objects.equals(this.maxHolidayLength, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.maxHolidayLength) &&
-        Objects.equals(this.maxHolidayPeriod, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.maxHolidayPeriod) &&
-        Objects.equals(this.notes, obReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.notes);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(maxHolidayLength, maxHolidayPeriod, notes);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner {\n");
-    sb.append("    maxHolidayLength: ").append(toIndentedString(maxHolidayLength)).append("\n");
-    sb.append("    maxHolidayPeriod: ").append(toIndentedString(maxHolidayPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The unit of period (days, weeks, months etc.) of the repayment holiday
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod {
+
+    PACT("PACT"),
+
+    PDAY("PDAY"),
+
+    PHYR("PHYR"),
+
+    PMTH("PMTH"),
+
+    PQTR("PQTR"),
+
+    PWEK("PWEK"),
+
+    PYER("PYER");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod b : OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Repayment type
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType {
+
+    USBA("USBA"),
+
+    USBU("USBU"),
+
+    USCI("USCI"),
+
+    USCS("USCS"),
+
+    USER("USER"),
+
+    USFA("USFA"),
+
+    USFB("USFB"),
+
+    USFI("USFI"),
+
+    USIO("USIO"),
+
+    USOT("USOT"),
+
+    USPF("USPF"),
+
+    USRW("USRW"),
+
+    USSL("USSL");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType b : OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProductInnerProductType.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Product type : Personal Current Account, Business Current Account
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadProduct2DataProductInnerProductType {
+
+    BUSINESSCURRENTACCOUNT("BusinessCurrentAccount"),
+
+    COMMERCIALCREDITCARD("CommercialCreditCard"),
+
+    OTHER("Other"),
+
+    PERSONALCURRENTACCOUNT("PersonalCurrentAccount"),
+
+    SMELOAN("SMELoan");
+
+    private String value;
+
+    OBReadProduct2DataProductInnerProductType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadProduct2DataProductInnerProductType fromValue(String value) {
+        for (OBReadProduct2DataProductInnerProductType b : OBReadProduct2DataProductInnerProductType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.account.OBReadScheduledPayment3Data;
 import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadScheduledPayment3
@@ -33,122 +43,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadScheduledPayment3 {
 
-  private OBReadScheduledPayment3Data data;
+    private OBReadScheduledPayment3Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadScheduledPayment3() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadScheduledPayment3(OBReadScheduledPayment3Data data) {
-    this.data = data;
-  }
-
-  public OBReadScheduledPayment3 data(OBReadScheduledPayment3Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadScheduledPayment3Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadScheduledPayment3Data data) {
-    this.data = data;
-  }
-
-  public OBReadScheduledPayment3 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadScheduledPayment3 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadScheduledPayment3() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadScheduledPayment3(OBReadScheduledPayment3Data data) {
+        this.data = data;
     }
-    OBReadScheduledPayment3 obReadScheduledPayment3 = (OBReadScheduledPayment3) o;
-    return Objects.equals(this.data, obReadScheduledPayment3.data) &&
-        Objects.equals(this.links, obReadScheduledPayment3.links) &&
-        Objects.equals(this.meta, obReadScheduledPayment3.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadScheduledPayment3 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadScheduledPayment3 data(OBReadScheduledPayment3Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadScheduledPayment3Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadScheduledPayment3Data data) {
+        this.data = data;
+    }
+
+    public OBReadScheduledPayment3 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadScheduledPayment3 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadScheduledPayment3 obReadScheduledPayment3 = (OBReadScheduledPayment3) o;
+        return Objects.equals(this.data, obReadScheduledPayment3.data) &&
+                Objects.equals(this.links, obReadScheduledPayment3.links) &&
+                Objects.equals(this.meta, obReadScheduledPayment3.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadScheduledPayment3 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
@@ -15,16 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBScheduledPayment3;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadScheduledPayment3Data
@@ -34,72 +47,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadScheduledPayment3Data {
 
-  @Valid
-  private List<@Valid OBScheduledPayment3> scheduledPayment;
+    @Valid
+    private List<@Valid OBScheduledPayment3> scheduledPayment;
 
-  public OBReadScheduledPayment3Data scheduledPayment(List<@Valid OBScheduledPayment3> scheduledPayment) {
-    this.scheduledPayment = scheduledPayment;
-    return this;
-  }
-
-  public OBReadScheduledPayment3Data addScheduledPaymentItem(OBScheduledPayment3 scheduledPaymentItem) {
-    if (this.scheduledPayment == null) {
-      this.scheduledPayment = new ArrayList<>();
+    public OBReadScheduledPayment3Data scheduledPayment(List<@Valid OBScheduledPayment3> scheduledPayment) {
+        this.scheduledPayment = scheduledPayment;
+        return this;
     }
-    this.scheduledPayment.add(scheduledPaymentItem);
-    return this;
-  }
 
-  /**
-   * Get scheduledPayment
-   * @return scheduledPayment
-  */
-  @Valid 
-  @Schema(name = "ScheduledPayment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ScheduledPayment")
-  public List<@Valid OBScheduledPayment3> getScheduledPayment() {
-    return scheduledPayment;
-  }
-
-  public void setScheduledPayment(List<@Valid OBScheduledPayment3> scheduledPayment) {
-    this.scheduledPayment = scheduledPayment;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadScheduledPayment3Data addScheduledPaymentItem(OBScheduledPayment3 scheduledPaymentItem) {
+        if (this.scheduledPayment == null) {
+            this.scheduledPayment = new ArrayList<>();
+        }
+        this.scheduledPayment.add(scheduledPaymentItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get scheduledPayment
+     *
+     * @return scheduledPayment
+     */
+    @Valid
+    @Schema(name = "ScheduledPayment", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ScheduledPayment")
+    public List<@Valid OBScheduledPayment3> getScheduledPayment() {
+        return scheduledPayment;
     }
-    OBReadScheduledPayment3Data obReadScheduledPayment3Data = (OBReadScheduledPayment3Data) o;
-    return Objects.equals(this.scheduledPayment, obReadScheduledPayment3Data.scheduledPayment);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(scheduledPayment);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadScheduledPayment3Data {\n");
-    sb.append("    scheduledPayment: ").append(toIndentedString(scheduledPayment)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setScheduledPayment(List<@Valid OBScheduledPayment3> scheduledPayment) {
+        this.scheduledPayment = scheduledPayment;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadScheduledPayment3Data obReadScheduledPayment3Data = (OBReadScheduledPayment3Data) o;
+        return Objects.equals(this.scheduledPayment, obReadScheduledPayment3Data.scheduledPayment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scheduledPayment);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadScheduledPayment3Data {\n");
+        sb.append("    scheduledPayment: ").append(toIndentedString(scheduledPayment)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.account.OBReadStandingOrder6Data;
 import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadStandingOrder6
@@ -33,122 +43,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadStandingOrder6 {
 
-  private OBReadStandingOrder6Data data;
+    private OBReadStandingOrder6Data data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadStandingOrder6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadStandingOrder6(OBReadStandingOrder6Data data) {
-    this.data = data;
-  }
-
-  public OBReadStandingOrder6 data(OBReadStandingOrder6Data data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadStandingOrder6Data getData() {
-    return data;
-  }
-
-  public void setData(OBReadStandingOrder6Data data) {
-    this.data = data;
-  }
-
-  public OBReadStandingOrder6 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadStandingOrder6 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadStandingOrder6() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadStandingOrder6(OBReadStandingOrder6Data data) {
+        this.data = data;
     }
-    OBReadStandingOrder6 obReadStandingOrder6 = (OBReadStandingOrder6) o;
-    return Objects.equals(this.data, obReadStandingOrder6.data) &&
-        Objects.equals(this.links, obReadStandingOrder6.links) &&
-        Objects.equals(this.meta, obReadStandingOrder6.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadStandingOrder6 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadStandingOrder6 data(OBReadStandingOrder6Data data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadStandingOrder6Data getData() {
+        return data;
+    }
+
+    public void setData(OBReadStandingOrder6Data data) {
+        this.data = data;
+    }
+
+    public OBReadStandingOrder6 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadStandingOrder6 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadStandingOrder6 obReadStandingOrder6 = (OBReadStandingOrder6) o;
+        return Objects.equals(this.data, obReadStandingOrder6.data) &&
+                Objects.equals(this.links, obReadStandingOrder6.links) &&
+                Objects.equals(this.meta, obReadStandingOrder6.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadStandingOrder6 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
@@ -15,16 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OBStandingOrder6;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadStandingOrder6Data
@@ -34,72 +47,73 @@ import jakarta.validation.Valid;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadStandingOrder6Data {
 
-  @Valid
-  private List<@Valid OBStandingOrder6> standingOrder;
+    @Valid
+    private List<@Valid OBStandingOrder6> standingOrder;
 
-  public OBReadStandingOrder6Data standingOrder(List<@Valid OBStandingOrder6> standingOrder) {
-    this.standingOrder = standingOrder;
-    return this;
-  }
-
-  public OBReadStandingOrder6Data addStandingOrderItem(OBStandingOrder6 standingOrderItem) {
-    if (this.standingOrder == null) {
-      this.standingOrder = new ArrayList<>();
+    public OBReadStandingOrder6Data standingOrder(List<@Valid OBStandingOrder6> standingOrder) {
+        this.standingOrder = standingOrder;
+        return this;
     }
-    this.standingOrder.add(standingOrderItem);
-    return this;
-  }
 
-  /**
-   * Get standingOrder
-   * @return standingOrder
-  */
-  @Valid 
-  @Schema(name = "StandingOrder", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrder")
-  public List<@Valid OBStandingOrder6> getStandingOrder() {
-    return standingOrder;
-  }
-
-  public void setStandingOrder(List<@Valid OBStandingOrder6> standingOrder) {
-    this.standingOrder = standingOrder;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadStandingOrder6Data addStandingOrderItem(OBStandingOrder6 standingOrderItem) {
+        if (this.standingOrder == null) {
+            this.standingOrder = new ArrayList<>();
+        }
+        this.standingOrder.add(standingOrderItem);
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Get standingOrder
+     *
+     * @return standingOrder
+     */
+    @Valid
+    @Schema(name = "StandingOrder", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrder")
+    public List<@Valid OBStandingOrder6> getStandingOrder() {
+        return standingOrder;
     }
-    OBReadStandingOrder6Data obReadStandingOrder6Data = (OBReadStandingOrder6Data) o;
-    return Objects.equals(this.standingOrder, obReadStandingOrder6Data.standingOrder);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(standingOrder);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadStandingOrder6Data {\n");
-    sb.append("    standingOrder: ").append(toIndentedString(standingOrder)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setStandingOrder(List<@Valid OBStandingOrder6> standingOrder) {
+        this.standingOrder = standingOrder;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadStandingOrder6Data obReadStandingOrder6Data = (OBReadStandingOrder6Data) o;
+        return Objects.equals(this.standingOrder, obReadStandingOrder6Data.standingOrder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(standingOrder);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadStandingOrder6Data {\n");
+        sb.append("    standingOrder: ").append(toIndentedString(standingOrder)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
@@ -33,122 +33,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadStatement2 {
 
-  private OBReadDataStatement2 data;
+    private OBReadDataStatement2 data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadStatement2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadStatement2(OBReadDataStatement2 data) {
-    this.data = data;
-  }
-
-  public OBReadStatement2 data(OBReadDataStatement2 data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadDataStatement2 getData() {
-    return data;
-  }
-
-  public void setData(OBReadDataStatement2 data) {
-    this.data = data;
-  }
-
-  public OBReadStatement2 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadStatement2 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadStatement2() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadStatement2(OBReadDataStatement2 data) {
+        this.data = data;
     }
-    OBReadStatement2 obReadStatement2 = (OBReadStatement2) o;
-    return Objects.equals(this.data, obReadStatement2.data) &&
-        Objects.equals(this.links, obReadStatement2.links) &&
-        Objects.equals(this.meta, obReadStatement2.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadStatement2 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadStatement2 data(OBReadDataStatement2 data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadDataStatement2 getData() {
+        return data;
+    }
+
+    public void setData(OBReadDataStatement2 data) {
+        this.data = data;
+    }
+
+    public OBReadStatement2 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadStatement2 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadStatement2 obReadStatement2 = (OBReadStatement2) o;
+        return Objects.equals(this.data, obReadStatement2.data) &&
+                Objects.equals(this.links, obReadStatement2.links) &&
+                Objects.equals(this.meta, obReadStatement2.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadStatement2 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.account.OBReadDataTransaction6;
 import uk.org.openbanking.datamodel.common.Links;
 import uk.org.openbanking.datamodel.common.Meta;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBReadTransaction6
@@ -33,122 +43,126 @@ import uk.org.openbanking.datamodel.common.Meta;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBReadTransaction6 {
 
-  private OBReadDataTransaction6 data;
+    private OBReadDataTransaction6 data;
 
-  private Links links;
+    private Links links;
 
-  private Meta meta;
+    private Meta meta;
 
-  public OBReadTransaction6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBReadTransaction6(OBReadDataTransaction6 data) {
-    this.data = data;
-  }
-
-  public OBReadTransaction6 data(OBReadDataTransaction6 data) {
-    this.data = data;
-    return this;
-  }
-
-  /**
-   * Get data
-   * @return data
-  */
-  @NotNull @Valid 
-  @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Data")
-  public OBReadDataTransaction6 getData() {
-    return data;
-  }
-
-  public void setData(OBReadDataTransaction6 data) {
-    this.data = data;
-  }
-
-  public OBReadTransaction6 links(Links links) {
-    this.links = links;
-    return this;
-  }
-
-  /**
-   * Get links
-   * @return links
-  */
-  @Valid 
-  @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Links")
-  public Links getLinks() {
-    return links;
-  }
-
-  public void setLinks(Links links) {
-    this.links = links;
-  }
-
-  public OBReadTransaction6 meta(Meta meta) {
-    this.meta = meta;
-    return this;
-  }
-
-  /**
-   * Get meta
-   * @return meta
-  */
-  @Valid 
-  @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Meta")
-  public Meta getMeta() {
-    return meta;
-  }
-
-  public void setMeta(Meta meta) {
-    this.meta = meta;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBReadTransaction6() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBReadTransaction6(OBReadDataTransaction6 data) {
+        this.data = data;
     }
-    OBReadTransaction6 obReadTransaction6 = (OBReadTransaction6) o;
-    return Objects.equals(this.data, obReadTransaction6.data) &&
-        Objects.equals(this.links, obReadTransaction6.links) &&
-        Objects.equals(this.meta, obReadTransaction6.meta);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(data, links, meta);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBReadTransaction6 {\n");
-    sb.append("    data: ").append(toIndentedString(data)).append("\n");
-    sb.append("    links: ").append(toIndentedString(links)).append("\n");
-    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBReadTransaction6 data(OBReadDataTransaction6 data) {
+        this.data = data;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBReadDataTransaction6 getData() {
+        return data;
+    }
+
+    public void setData(OBReadDataTransaction6 data) {
+        this.data = data;
+    }
+
+    public OBReadTransaction6 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBReadTransaction6 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBReadTransaction6 obReadTransaction6 = (OBReadTransaction6) o;
+        return Objects.equals(this.data, obReadTransaction6.data) &&
+                Objects.equals(this.links, obReadTransaction6.links) &&
+                Objects.equals(this.meta, obReadTransaction6.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBReadTransaction6 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
@@ -15,18 +15,31 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount1;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification51;
+import uk.org.openbanking.datamodel.account.OBCashAccount51;
+import uk.org.openbanking.datamodel.account.OBExternalScheduleType1Code;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBScheduledPayment3
@@ -35,270 +48,283 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBScheduledPayment3 {
 
-  private String accountId;
+    private String accountId;
 
-  private String scheduledPaymentId;
+    private String scheduledPaymentId;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime scheduledPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime scheduledPaymentDateTime;
 
-  private OBExternalScheduleType1Code scheduledType;
+    private OBExternalScheduleType1Code scheduledType;
 
-  private String reference;
+    private String reference;
 
-  private String debtorReference;
+    private String debtorReference;
 
-  private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
+    private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
 
-  private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
 
-  private OBCashAccount51 creditorAccount;
+    private OBCashAccount51 creditorAccount;
 
-  public OBScheduledPayment3() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBScheduledPayment3(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.accountId = accountId;
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    this.scheduledType = scheduledType;
-    this.instructedAmount = instructedAmount;
-  }
-
-  public OBScheduledPayment3 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBScheduledPayment3 scheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
-   * @return scheduledPaymentId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ScheduledPaymentId")
-  public String getScheduledPaymentId() {
-    return scheduledPaymentId;
-  }
-
-  public void setScheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-  }
-
-  public OBScheduledPayment3 scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return scheduledPaymentDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledPaymentDateTime")
-  public DateTime getScheduledPaymentDateTime() {
-    return scheduledPaymentDateTime;
-  }
-
-  public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-  }
-
-  public OBScheduledPayment3 scheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-    return this;
-  }
-
-  /**
-   * Get scheduledType
-   * @return scheduledType
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledType")
-  public OBExternalScheduleType1Code getScheduledType() {
-    return scheduledType;
-  }
-
-  public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-  }
-
-  public OBScheduledPayment3 reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBScheduledPayment3 debtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-    return this;
-  }
-
-  /**
-   * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
-   * @return debtorReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorReference")
-  public String getDebtorReference() {
-    return debtorReference;
-  }
-
-  public void setDebtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-  }
-
-  public OBScheduledPayment3 instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-    return this;
-  }
-
-  /**
-   * Get instructedAmount
-   * @return instructedAmount
-  */
-  @NotNull @Valid 
-  @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("InstructedAmount")
-  public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
-    return instructedAmount;
-  }
-
-  public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-  }
-
-  public OBScheduledPayment3 creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBScheduledPayment3 creditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount51 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBScheduledPayment3() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBScheduledPayment3(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.accountId = accountId;
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        this.scheduledType = scheduledType;
+        this.instructedAmount = instructedAmount;
     }
-    OBScheduledPayment3 obScheduledPayment3 = (OBScheduledPayment3) o;
-    return Objects.equals(this.accountId, obScheduledPayment3.accountId) &&
-        Objects.equals(this.scheduledPaymentId, obScheduledPayment3.scheduledPaymentId) &&
-        Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3.scheduledPaymentDateTime) &&
-        Objects.equals(this.scheduledType, obScheduledPayment3.scheduledType) &&
-        Objects.equals(this.reference, obScheduledPayment3.reference) &&
-        Objects.equals(this.debtorReference, obScheduledPayment3.debtorReference) &&
-        Objects.equals(this.instructedAmount, obScheduledPayment3.instructedAmount) &&
-        Objects.equals(this.creditorAgent, obScheduledPayment3.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obScheduledPayment3.creditorAccount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount, creditorAgent, creditorAccount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBScheduledPayment3 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
-    sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
-    sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
-    sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBScheduledPayment3 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBScheduledPayment3 scheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
+     *
+     * @return scheduledPaymentId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ScheduledPaymentId")
+    public String getScheduledPaymentId() {
+        return scheduledPaymentId;
+    }
+
+    public void setScheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+    }
+
+    public OBScheduledPayment3 scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return scheduledPaymentDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledPaymentDateTime")
+    public DateTime getScheduledPaymentDateTime() {
+        return scheduledPaymentDateTime;
+    }
+
+    public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+    }
+
+    public OBScheduledPayment3 scheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+        return this;
+    }
+
+    /**
+     * Get scheduledType
+     *
+     * @return scheduledType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledType")
+    public OBExternalScheduleType1Code getScheduledType() {
+        return scheduledType;
+    }
+
+    public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+    }
+
+    public OBScheduledPayment3 reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBScheduledPayment3 debtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+        return this;
+    }
+
+    /**
+     * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
+     *
+     * @return debtorReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorReference")
+    public String getDebtorReference() {
+        return debtorReference;
+    }
+
+    public void setDebtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+    }
+
+    public OBScheduledPayment3 instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    public OBScheduledPayment3 creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBScheduledPayment3 creditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount51 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBScheduledPayment3 obScheduledPayment3 = (OBScheduledPayment3) o;
+        return Objects.equals(this.accountId, obScheduledPayment3.accountId) &&
+                Objects.equals(this.scheduledPaymentId, obScheduledPayment3.scheduledPaymentId) &&
+                Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3.scheduledPaymentDateTime) &&
+                Objects.equals(this.scheduledType, obScheduledPayment3.scheduledType) &&
+                Objects.equals(this.reference, obScheduledPayment3.reference) &&
+                Objects.equals(this.debtorReference, obScheduledPayment3.debtorReference) &&
+                Objects.equals(this.instructedAmount, obScheduledPayment3.instructedAmount) &&
+                Objects.equals(this.creditorAgent, obScheduledPayment3.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obScheduledPayment3.creditorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount, creditorAgent, creditorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBScheduledPayment3 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
+        sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
+        sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
@@ -15,18 +15,29 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount1;
+import uk.org.openbanking.datamodel.account.OBExternalScheduleType1Code;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBScheduledPayment3Basic
@@ -35,222 +46,233 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBScheduledPayment3Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private String scheduledPaymentId;
+    private String scheduledPaymentId;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime scheduledPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime scheduledPaymentDateTime;
 
-  private OBExternalScheduleType1Code scheduledType;
+    private OBExternalScheduleType1Code scheduledType;
 
-  private String reference;
+    private String reference;
 
-  private String debtorReference;
+    private String debtorReference;
 
-  private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
+    private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
 
-  public OBScheduledPayment3Basic() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBScheduledPayment3Basic(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.accountId = accountId;
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    this.scheduledType = scheduledType;
-    this.instructedAmount = instructedAmount;
-  }
-
-  public OBScheduledPayment3Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBScheduledPayment3Basic scheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
-   * @return scheduledPaymentId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ScheduledPaymentId")
-  public String getScheduledPaymentId() {
-    return scheduledPaymentId;
-  }
-
-  public void setScheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-  }
-
-  public OBScheduledPayment3Basic scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return scheduledPaymentDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledPaymentDateTime")
-  public DateTime getScheduledPaymentDateTime() {
-    return scheduledPaymentDateTime;
-  }
-
-  public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-  }
-
-  public OBScheduledPayment3Basic scheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-    return this;
-  }
-
-  /**
-   * Get scheduledType
-   * @return scheduledType
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledType")
-  public OBExternalScheduleType1Code getScheduledType() {
-    return scheduledType;
-  }
-
-  public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-  }
-
-  public OBScheduledPayment3Basic reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBScheduledPayment3Basic debtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-    return this;
-  }
-
-  /**
-   * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
-   * @return debtorReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorReference")
-  public String getDebtorReference() {
-    return debtorReference;
-  }
-
-  public void setDebtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-  }
-
-  public OBScheduledPayment3Basic instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-    return this;
-  }
-
-  /**
-   * Get instructedAmount
-   * @return instructedAmount
-  */
-  @NotNull @Valid 
-  @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("InstructedAmount")
-  public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
-    return instructedAmount;
-  }
-
-  public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBScheduledPayment3Basic() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBScheduledPayment3Basic(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.accountId = accountId;
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        this.scheduledType = scheduledType;
+        this.instructedAmount = instructedAmount;
     }
-    OBScheduledPayment3Basic obScheduledPayment3Basic = (OBScheduledPayment3Basic) o;
-    return Objects.equals(this.accountId, obScheduledPayment3Basic.accountId) &&
-        Objects.equals(this.scheduledPaymentId, obScheduledPayment3Basic.scheduledPaymentId) &&
-        Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3Basic.scheduledPaymentDateTime) &&
-        Objects.equals(this.scheduledType, obScheduledPayment3Basic.scheduledType) &&
-        Objects.equals(this.reference, obScheduledPayment3Basic.reference) &&
-        Objects.equals(this.debtorReference, obScheduledPayment3Basic.debtorReference) &&
-        Objects.equals(this.instructedAmount, obScheduledPayment3Basic.instructedAmount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBScheduledPayment3Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
-    sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
-    sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
-    sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBScheduledPayment3Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBScheduledPayment3Basic scheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
+     *
+     * @return scheduledPaymentId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ScheduledPaymentId")
+    public String getScheduledPaymentId() {
+        return scheduledPaymentId;
+    }
+
+    public void setScheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+    }
+
+    public OBScheduledPayment3Basic scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return scheduledPaymentDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledPaymentDateTime")
+    public DateTime getScheduledPaymentDateTime() {
+        return scheduledPaymentDateTime;
+    }
+
+    public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+    }
+
+    public OBScheduledPayment3Basic scheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+        return this;
+    }
+
+    /**
+     * Get scheduledType
+     *
+     * @return scheduledType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledType")
+    public OBExternalScheduleType1Code getScheduledType() {
+        return scheduledType;
+    }
+
+    public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+    }
+
+    public OBScheduledPayment3Basic reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBScheduledPayment3Basic debtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+        return this;
+    }
+
+    /**
+     * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
+     *
+     * @return debtorReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorReference")
+    public String getDebtorReference() {
+        return debtorReference;
+    }
+
+    public void setDebtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+    }
+
+    public OBScheduledPayment3Basic instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBScheduledPayment3Basic obScheduledPayment3Basic = (OBScheduledPayment3Basic) o;
+        return Objects.equals(this.accountId, obScheduledPayment3Basic.accountId) &&
+                Objects.equals(this.scheduledPaymentId, obScheduledPayment3Basic.scheduledPaymentId) &&
+                Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3Basic.scheduledPaymentDateTime) &&
+                Objects.equals(this.scheduledType, obScheduledPayment3Basic.scheduledType) &&
+                Objects.equals(this.reference, obScheduledPayment3Basic.reference) &&
+                Objects.equals(this.debtorReference, obScheduledPayment3Basic.debtorReference) &&
+                Objects.equals(this.instructedAmount, obScheduledPayment3Basic.instructedAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBScheduledPayment3Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
+        sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
+        sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
@@ -15,18 +15,31 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount1;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification51;
+import uk.org.openbanking.datamodel.account.OBCashAccount51;
+import uk.org.openbanking.datamodel.account.OBExternalScheduleType1Code;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBScheduledPayment3Detail
@@ -35,271 +48,285 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBScheduledPayment3Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private String scheduledPaymentId;
+    private String scheduledPaymentId;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime scheduledPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime scheduledPaymentDateTime;
 
-  private OBExternalScheduleType1Code scheduledType;
+    private OBExternalScheduleType1Code scheduledType;
 
-  private String reference;
+    private String reference;
 
-  private String debtorReference;
+    private String debtorReference;
 
-  private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
+    private OBActiveOrHistoricCurrencyAndAmount1 instructedAmount;
 
-  private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
 
-  private OBCashAccount51 creditorAccount;
+    private OBCashAccount51 creditorAccount;
 
-  public OBScheduledPayment3Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBScheduledPayment3Detail(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount, OBCashAccount51 creditorAccount) {
-    this.accountId = accountId;
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    this.scheduledType = scheduledType;
-    this.instructedAmount = instructedAmount;
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBScheduledPayment3Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBScheduledPayment3Detail scheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
-   * @return scheduledPaymentId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ScheduledPaymentId")
-  public String getScheduledPaymentId() {
-    return scheduledPaymentId;
-  }
-
-  public void setScheduledPaymentId(String scheduledPaymentId) {
-    this.scheduledPaymentId = scheduledPaymentId;
-  }
-
-  public OBScheduledPayment3Detail scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return scheduledPaymentDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledPaymentDateTime")
-  public DateTime getScheduledPaymentDateTime() {
-    return scheduledPaymentDateTime;
-  }
-
-  public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
-    this.scheduledPaymentDateTime = scheduledPaymentDateTime;
-  }
-
-  public OBScheduledPayment3Detail scheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-    return this;
-  }
-
-  /**
-   * Get scheduledType
-   * @return scheduledType
-  */
-  @NotNull @Valid 
-  @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ScheduledType")
-  public OBExternalScheduleType1Code getScheduledType() {
-    return scheduledType;
-  }
-
-  public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
-    this.scheduledType = scheduledType;
-  }
-
-  public OBScheduledPayment3Detail reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBScheduledPayment3Detail debtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-    return this;
-  }
-
-  /**
-   * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
-   * @return debtorReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorReference")
-  public String getDebtorReference() {
-    return debtorReference;
-  }
-
-  public void setDebtorReference(String debtorReference) {
-    this.debtorReference = debtorReference;
-  }
-
-  public OBScheduledPayment3Detail instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-    return this;
-  }
-
-  /**
-   * Get instructedAmount
-   * @return instructedAmount
-  */
-  @NotNull @Valid 
-  @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("InstructedAmount")
-  public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
-    return instructedAmount;
-  }
-
-  public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
-    this.instructedAmount = instructedAmount;
-  }
-
-  public OBScheduledPayment3Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBScheduledPayment3Detail creditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount51 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBScheduledPayment3Detail() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBScheduledPayment3Detail(String accountId, DateTime scheduledPaymentDateTime, OBExternalScheduleType1Code scheduledType, OBActiveOrHistoricCurrencyAndAmount1 instructedAmount, OBCashAccount51 creditorAccount) {
+        this.accountId = accountId;
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        this.scheduledType = scheduledType;
+        this.instructedAmount = instructedAmount;
+        this.creditorAccount = creditorAccount;
     }
-    OBScheduledPayment3Detail obScheduledPayment3Detail = (OBScheduledPayment3Detail) o;
-    return Objects.equals(this.accountId, obScheduledPayment3Detail.accountId) &&
-        Objects.equals(this.scheduledPaymentId, obScheduledPayment3Detail.scheduledPaymentId) &&
-        Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3Detail.scheduledPaymentDateTime) &&
-        Objects.equals(this.scheduledType, obScheduledPayment3Detail.scheduledType) &&
-        Objects.equals(this.reference, obScheduledPayment3Detail.reference) &&
-        Objects.equals(this.debtorReference, obScheduledPayment3Detail.debtorReference) &&
-        Objects.equals(this.instructedAmount, obScheduledPayment3Detail.instructedAmount) &&
-        Objects.equals(this.creditorAgent, obScheduledPayment3Detail.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obScheduledPayment3Detail.creditorAccount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount, creditorAgent, creditorAccount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBScheduledPayment3Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
-    sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
-    sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
-    sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBScheduledPayment3Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBScheduledPayment3Detail scheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.
+     *
+     * @return scheduledPaymentId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "ScheduledPaymentId", description = "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ScheduledPaymentId")
+    public String getScheduledPaymentId() {
+        return scheduledPaymentId;
+    }
+
+    public void setScheduledPaymentId(String scheduledPaymentId) {
+        this.scheduledPaymentId = scheduledPaymentId;
+    }
+
+    public OBScheduledPayment3Detail scheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return scheduledPaymentDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledPaymentDateTime", description = "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledPaymentDateTime")
+    public DateTime getScheduledPaymentDateTime() {
+        return scheduledPaymentDateTime;
+    }
+
+    public void setScheduledPaymentDateTime(DateTime scheduledPaymentDateTime) {
+        this.scheduledPaymentDateTime = scheduledPaymentDateTime;
+    }
+
+    public OBScheduledPayment3Detail scheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+        return this;
+    }
+
+    /**
+     * Get scheduledType
+     *
+     * @return scheduledType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ScheduledType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ScheduledType")
+    public OBExternalScheduleType1Code getScheduledType() {
+        return scheduledType;
+    }
+
+    public void setScheduledType(OBExternalScheduleType1Code scheduledType) {
+        this.scheduledType = scheduledType;
+    }
+
+    public OBScheduledPayment3Detail reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBScheduledPayment3Detail debtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+        return this;
+    }
+
+    /**
+     * A reference value provided by the PSU to the PISP while setting up the scheduled payment.
+     *
+     * @return debtorReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "DebtorReference", description = "A reference value provided by the PSU to the PISP while setting up the scheduled payment.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorReference")
+    public String getDebtorReference() {
+        return debtorReference;
+    }
+
+    public void setDebtorReference(String debtorReference) {
+        this.debtorReference = debtorReference;
+    }
+
+    public OBScheduledPayment3Detail instructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBActiveOrHistoricCurrencyAndAmount1 getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBActiveOrHistoricCurrencyAndAmount1 instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    public OBScheduledPayment3Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBScheduledPayment3Detail creditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount51 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBScheduledPayment3Detail obScheduledPayment3Detail = (OBScheduledPayment3Detail) o;
+        return Objects.equals(this.accountId, obScheduledPayment3Detail.accountId) &&
+                Objects.equals(this.scheduledPaymentId, obScheduledPayment3Detail.scheduledPaymentId) &&
+                Objects.equals(this.scheduledPaymentDateTime, obScheduledPayment3Detail.scheduledPaymentDateTime) &&
+                Objects.equals(this.scheduledType, obScheduledPayment3Detail.scheduledType) &&
+                Objects.equals(this.reference, obScheduledPayment3Detail.reference) &&
+                Objects.equals(this.debtorReference, obScheduledPayment3Detail.debtorReference) &&
+                Objects.equals(this.instructedAmount, obScheduledPayment3Detail.instructedAmount) &&
+                Objects.equals(this.creditorAgent, obScheduledPayment3Detail.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obScheduledPayment3Detail.creditorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, scheduledPaymentId, scheduledPaymentDateTime, scheduledType, reference, debtorReference, instructedAmount, creditorAgent, creditorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBScheduledPayment3Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    scheduledPaymentId: ").append(toIndentedString(scheduledPaymentId)).append("\n");
+        sb.append("    scheduledPaymentDateTime: ").append(toIndentedString(scheduledPaymentDateTime)).append("\n");
+        sb.append("    scheduledType: ").append(toIndentedString(scheduledType)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    debtorReference: ").append(toIndentedString(debtorReference)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
@@ -37,464 +37,482 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStandingOrder6 {
 
-  private String accountId;
+    private String accountId;
 
-  private String standingOrderId;
+    private String standingOrderId;
 
-  private String frequency;
-
-  private String reference;
+    private String frequency;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime firstPaymentDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime nextPaymentDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime lastPaymentDateTime;
+    private String reference;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime finalPaymentDateTime;
-
-  private String numberOfPayments;
-
-  private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
-
-  private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
-
-  private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
-
-  private OBCashAccount51 creditorAccount;
-
-  @Valid
-  private OBSupplementaryData1 supplementaryData;
-
-  public OBStandingOrder6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStandingOrder6(String accountId, String frequency) {
-    this.accountId = accountId;
-    this.frequency = frequency;
-  }
-
-  public OBStandingOrder6 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStandingOrder6 standingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
-   * @return standingOrderId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderId")
-  public String getStandingOrderId() {
-    return standingOrderId;
-  }
-
-  public void setStandingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-  }
-
-  public OBStandingOrder6 frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
-   * @return frequency
-  */
-  @NotNull @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$") 
-  @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBStandingOrder6 reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBStandingOrder6 firstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return firstPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentDateTime")
-  public DateTime getFirstPaymentDateTime() {
-    return firstPaymentDateTime;
-  }
-
-  public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-  }
-
-  public OBStandingOrder6 nextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return nextPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentDateTime")
-  public DateTime getNextPaymentDateTime() {
-    return nextPaymentDateTime;
-  }
-
-  public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-  }
-
-  public OBStandingOrder6 lastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return lastPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentDateTime")
-  public DateTime getLastPaymentDateTime() {
-    return lastPaymentDateTime;
-  }
-
-  public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-  }
-
-  public OBStandingOrder6 finalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return finalPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentDateTime")
-  public DateTime getFinalPaymentDateTime() {
-    return finalPaymentDateTime;
-  }
-
-  public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-  }
-
-  public OBStandingOrder6 numberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-    return this;
-  }
-
-  /**
-   * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
-   * @return numberOfPayments
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NumberOfPayments")
-  public String getNumberOfPayments() {
-    return numberOfPayments;
-  }
-
-  public void setNumberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-  }
-
-  public OBStandingOrder6 standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-    return this;
-  }
-
-  /**
-   * Get standingOrderStatusCode
-   * @return standingOrderStatusCode
-  */
-  @Valid 
-  @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderStatusCode")
-  public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
-    return standingOrderStatusCode;
-  }
-
-  public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-  }
-
-  public OBStandingOrder6 firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get firstPaymentAmount
-   * @return firstPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
-    return firstPaymentAmount;
-  }
-
-  public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-  }
-
-  public OBStandingOrder6 nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get nextPaymentAmount
-   * @return nextPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
-    return nextPaymentAmount;
-  }
-
-  public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-  }
-
-  public OBStandingOrder6 lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get lastPaymentAmount
-   * @return lastPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
-    return lastPaymentAmount;
-  }
-
-  public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-  }
-
-  public OBStandingOrder6 finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get finalPaymentAmount
-   * @return finalPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
-    return finalPaymentAmount;
-  }
-
-  public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-  }
-
-  public OBStandingOrder6 creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBStandingOrder6 creditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount51 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBStandingOrder6 supplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public OBSupplementaryData1 getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime firstPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime nextPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime lastPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime finalPaymentDateTime;
+
+    private String numberOfPayments;
+
+    private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
+
+    private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
+
+    private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
+
+    private OBCashAccount51 creditorAccount;
+
+    private OBSupplementaryData1 supplementaryData;
+
+    public OBStandingOrder6() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStandingOrder6(String accountId, String frequency) {
+        this.accountId = accountId;
+        this.frequency = frequency;
     }
-    OBStandingOrder6 obStandingOrder6 = (OBStandingOrder6) o;
-    return Objects.equals(this.accountId, obStandingOrder6.accountId) &&
-        Objects.equals(this.standingOrderId, obStandingOrder6.standingOrderId) &&
-        Objects.equals(this.frequency, obStandingOrder6.frequency) &&
-        Objects.equals(this.reference, obStandingOrder6.reference) &&
-        Objects.equals(this.firstPaymentDateTime, obStandingOrder6.firstPaymentDateTime) &&
-        Objects.equals(this.nextPaymentDateTime, obStandingOrder6.nextPaymentDateTime) &&
-        Objects.equals(this.lastPaymentDateTime, obStandingOrder6.lastPaymentDateTime) &&
-        Objects.equals(this.finalPaymentDateTime, obStandingOrder6.finalPaymentDateTime) &&
-        Objects.equals(this.numberOfPayments, obStandingOrder6.numberOfPayments) &&
-        Objects.equals(this.standingOrderStatusCode, obStandingOrder6.standingOrderStatusCode) &&
-        Objects.equals(this.firstPaymentAmount, obStandingOrder6.firstPaymentAmount) &&
-        Objects.equals(this.nextPaymentAmount, obStandingOrder6.nextPaymentAmount) &&
-        Objects.equals(this.lastPaymentAmount, obStandingOrder6.lastPaymentAmount) &&
-        Objects.equals(this.finalPaymentAmount, obStandingOrder6.finalPaymentAmount) &&
-        Objects.equals(this.creditorAgent, obStandingOrder6.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obStandingOrder6.creditorAccount) &&
-        Objects.equals(this.supplementaryData, obStandingOrder6.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, creditorAgent, creditorAccount, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStandingOrder6 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
-    sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
-    sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
-    sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
-    sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
-    sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
-    sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
-    sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
-    sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
-    sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStandingOrder6 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBStandingOrder6 standingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
+     *
+     * @return standingOrderId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderId")
+    public String getStandingOrderId() {
+        return standingOrderId;
+    }
+
+    public void setStandingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+    }
+
+    public OBStandingOrder6 frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
+     *
+     * @return frequency
+     */
+    @NotNull
+    @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$")
+    @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBStandingOrder6 reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBStandingOrder6 firstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return firstPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentDateTime")
+    public DateTime getFirstPaymentDateTime() {
+        return firstPaymentDateTime;
+    }
+
+    public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+    }
+
+    public OBStandingOrder6 nextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return nextPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentDateTime")
+    public DateTime getNextPaymentDateTime() {
+        return nextPaymentDateTime;
+    }
+
+    public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+    }
+
+    public OBStandingOrder6 lastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return lastPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentDateTime")
+    public DateTime getLastPaymentDateTime() {
+        return lastPaymentDateTime;
+    }
+
+    public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+    }
+
+    public OBStandingOrder6 finalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return finalPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentDateTime")
+    public DateTime getFinalPaymentDateTime() {
+        return finalPaymentDateTime;
+    }
+
+    public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+    }
+
+    public OBStandingOrder6 numberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+        return this;
+    }
+
+    /**
+     * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
+     *
+     * @return numberOfPayments
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NumberOfPayments")
+    public String getNumberOfPayments() {
+        return numberOfPayments;
+    }
+
+    public void setNumberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+    }
+
+    public OBStandingOrder6 standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+        return this;
+    }
+
+    /**
+     * Get standingOrderStatusCode
+     *
+     * @return standingOrderStatusCode
+     */
+    @Valid
+    @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderStatusCode")
+    public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
+        return standingOrderStatusCode;
+    }
+
+    public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+    }
+
+    public OBStandingOrder6 firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get firstPaymentAmount
+     *
+     * @return firstPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
+        return firstPaymentAmount;
+    }
+
+    public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+    }
+
+    public OBStandingOrder6 nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get nextPaymentAmount
+     *
+     * @return nextPaymentAmount
+     */
+    @Valid
+    @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
+        return nextPaymentAmount;
+    }
+
+    public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+    }
+
+    public OBStandingOrder6 lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get lastPaymentAmount
+     *
+     * @return lastPaymentAmount
+     */
+    @Valid
+    @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
+        return lastPaymentAmount;
+    }
+
+    public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+    }
+
+    public OBStandingOrder6 finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get finalPaymentAmount
+     *
+     * @return finalPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
+        return finalPaymentAmount;
+    }
+
+    public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+    }
+
+    public OBStandingOrder6 creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBStandingOrder6 creditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount51 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    public OBStandingOrder6 supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStandingOrder6 obStandingOrder6 = (OBStandingOrder6) o;
+        return Objects.equals(this.accountId, obStandingOrder6.accountId) &&
+                Objects.equals(this.standingOrderId, obStandingOrder6.standingOrderId) &&
+                Objects.equals(this.frequency, obStandingOrder6.frequency) &&
+                Objects.equals(this.reference, obStandingOrder6.reference) &&
+                Objects.equals(this.firstPaymentDateTime, obStandingOrder6.firstPaymentDateTime) &&
+                Objects.equals(this.nextPaymentDateTime, obStandingOrder6.nextPaymentDateTime) &&
+                Objects.equals(this.lastPaymentDateTime, obStandingOrder6.lastPaymentDateTime) &&
+                Objects.equals(this.finalPaymentDateTime, obStandingOrder6.finalPaymentDateTime) &&
+                Objects.equals(this.numberOfPayments, obStandingOrder6.numberOfPayments) &&
+                Objects.equals(this.standingOrderStatusCode, obStandingOrder6.standingOrderStatusCode) &&
+                Objects.equals(this.firstPaymentAmount, obStandingOrder6.firstPaymentAmount) &&
+                Objects.equals(this.nextPaymentAmount, obStandingOrder6.nextPaymentAmount) &&
+                Objects.equals(this.lastPaymentAmount, obStandingOrder6.lastPaymentAmount) &&
+                Objects.equals(this.finalPaymentAmount, obStandingOrder6.finalPaymentAmount) &&
+                Objects.equals(this.creditorAgent, obStandingOrder6.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obStandingOrder6.creditorAccount) &&
+                Objects.equals(this.supplementaryData, obStandingOrder6.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, creditorAgent, creditorAccount, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStandingOrder6 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
+        sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
+        sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
+        sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
+        sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
+        sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
+        sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
+        sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
+        sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
+        sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
@@ -15,21 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount11;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount2;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount3;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount4;
+import uk.org.openbanking.datamodel.account.OBExternalStandingOrderStatus1Code;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBStandingOrder6Basic
@@ -38,424 +50,432 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStandingOrder6Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private String standingOrderId;
+    private String standingOrderId;
 
-  private String frequency;
+    private String frequency;
 
-  private String reference;
+    private String reference;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime firstPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime firstPaymentDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime nextPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime nextPaymentDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime lastPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime lastPaymentDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime finalPaymentDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime finalPaymentDateTime;
 
-  private String numberOfPayments;
+    private String numberOfPayments;
 
-  private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
+    private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
 
-  private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
+    private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
 
-  private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
+    private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
 
-  private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
+    private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
 
-  private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
+    private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBStandingOrder6Basic() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStandingOrder6Basic(String accountId, String frequency) {
-    this.accountId = accountId;
-    this.frequency = frequency;
-  }
-
-  public OBStandingOrder6Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStandingOrder6Basic standingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
-   * @return standingOrderId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderId")
-  public String getStandingOrderId() {
-    return standingOrderId;
-  }
-
-  public void setStandingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-  }
-
-  public OBStandingOrder6Basic frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
-   * @return frequency
-  */
-  @NotNull @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$") 
-  @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBStandingOrder6Basic reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBStandingOrder6Basic firstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return firstPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentDateTime")
-  public DateTime getFirstPaymentDateTime() {
-    return firstPaymentDateTime;
-  }
-
-  public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-  }
-
-  public OBStandingOrder6Basic nextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return nextPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentDateTime")
-  public DateTime getNextPaymentDateTime() {
-    return nextPaymentDateTime;
-  }
-
-  public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-  }
-
-  public OBStandingOrder6Basic lastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return lastPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentDateTime")
-  public DateTime getLastPaymentDateTime() {
-    return lastPaymentDateTime;
-  }
-
-  public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-  }
-
-  public OBStandingOrder6Basic finalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return finalPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentDateTime")
-  public DateTime getFinalPaymentDateTime() {
-    return finalPaymentDateTime;
-  }
-
-  public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-  }
-
-  public OBStandingOrder6Basic numberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-    return this;
-  }
-
-  /**
-   * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
-   * @return numberOfPayments
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NumberOfPayments")
-  public String getNumberOfPayments() {
-    return numberOfPayments;
-  }
-
-  public void setNumberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-  }
-
-  public OBStandingOrder6Basic standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-    return this;
-  }
-
-  /**
-   * Get standingOrderStatusCode
-   * @return standingOrderStatusCode
-  */
-  @Valid 
-  @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderStatusCode")
-  public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
-    return standingOrderStatusCode;
-  }
-
-  public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-  }
-
-  public OBStandingOrder6Basic firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get firstPaymentAmount
-   * @return firstPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
-    return firstPaymentAmount;
-  }
-
-  public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-  }
-
-  public OBStandingOrder6Basic nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get nextPaymentAmount
-   * @return nextPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
-    return nextPaymentAmount;
-  }
-
-  public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-  }
-
-  public OBStandingOrder6Basic lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get lastPaymentAmount
-   * @return lastPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
-    return lastPaymentAmount;
-  }
-
-  public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-  }
-
-  public OBStandingOrder6Basic finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get finalPaymentAmount
-   * @return finalPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
-    return finalPaymentAmount;
-  }
-
-  public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-  }
-
-  public OBStandingOrder6Basic supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBStandingOrder6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    public OBStandingOrder6Basic() {
+        super();
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStandingOrder6Basic(String accountId, String frequency) {
+        this.accountId = accountId;
+        this.frequency = frequency;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBStandingOrder6Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBStandingOrder6Basic obStandingOrder6Basic = (OBStandingOrder6Basic) o;
-    return Objects.equals(this.accountId, obStandingOrder6Basic.accountId) &&
-        Objects.equals(this.standingOrderId, obStandingOrder6Basic.standingOrderId) &&
-        Objects.equals(this.frequency, obStandingOrder6Basic.frequency) &&
-        Objects.equals(this.reference, obStandingOrder6Basic.reference) &&
-        Objects.equals(this.firstPaymentDateTime, obStandingOrder6Basic.firstPaymentDateTime) &&
-        Objects.equals(this.nextPaymentDateTime, obStandingOrder6Basic.nextPaymentDateTime) &&
-        Objects.equals(this.lastPaymentDateTime, obStandingOrder6Basic.lastPaymentDateTime) &&
-        Objects.equals(this.finalPaymentDateTime, obStandingOrder6Basic.finalPaymentDateTime) &&
-        Objects.equals(this.numberOfPayments, obStandingOrder6Basic.numberOfPayments) &&
-        Objects.equals(this.standingOrderStatusCode, obStandingOrder6Basic.standingOrderStatusCode) &&
-        Objects.equals(this.firstPaymentAmount, obStandingOrder6Basic.firstPaymentAmount) &&
-        Objects.equals(this.nextPaymentAmount, obStandingOrder6Basic.nextPaymentAmount) &&
-        Objects.equals(this.lastPaymentAmount, obStandingOrder6Basic.lastPaymentAmount) &&
-        Objects.equals(this.finalPaymentAmount, obStandingOrder6Basic.finalPaymentAmount) &&
-        Objects.equals(this.supplementaryData, obStandingOrder6Basic.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStandingOrder6Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
-    sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
-    sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
-    sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
-    sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
-    sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
-    sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
-    sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
-    sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
-    sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBStandingOrder6Basic standingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
+     *
+     * @return standingOrderId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderId")
+    public String getStandingOrderId() {
+        return standingOrderId;
+    }
+
+    public void setStandingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+    }
+
+    public OBStandingOrder6Basic frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
+     *
+     * @return frequency
+     */
+    @NotNull
+    @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$")
+    @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBStandingOrder6Basic reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBStandingOrder6Basic firstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return firstPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentDateTime")
+    public DateTime getFirstPaymentDateTime() {
+        return firstPaymentDateTime;
+    }
+
+    public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+    }
+
+    public OBStandingOrder6Basic nextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return nextPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentDateTime")
+    public DateTime getNextPaymentDateTime() {
+        return nextPaymentDateTime;
+    }
+
+    public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+    }
+
+    public OBStandingOrder6Basic lastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return lastPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentDateTime")
+    public DateTime getLastPaymentDateTime() {
+        return lastPaymentDateTime;
+    }
+
+    public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+    }
+
+    public OBStandingOrder6Basic finalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return finalPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentDateTime")
+    public DateTime getFinalPaymentDateTime() {
+        return finalPaymentDateTime;
+    }
+
+    public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+    }
+
+    public OBStandingOrder6Basic numberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+        return this;
+    }
+
+    /**
+     * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
+     *
+     * @return numberOfPayments
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NumberOfPayments")
+    public String getNumberOfPayments() {
+        return numberOfPayments;
+    }
+
+    public void setNumberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+    }
+
+    public OBStandingOrder6Basic standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+        return this;
+    }
+
+    /**
+     * Get standingOrderStatusCode
+     *
+     * @return standingOrderStatusCode
+     */
+    @Valid
+    @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderStatusCode")
+    public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
+        return standingOrderStatusCode;
+    }
+
+    public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+    }
+
+    public OBStandingOrder6Basic firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get firstPaymentAmount
+     *
+     * @return firstPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
+        return firstPaymentAmount;
+    }
+
+    public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+    }
+
+    public OBStandingOrder6Basic nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get nextPaymentAmount
+     *
+     * @return nextPaymentAmount
+     */
+    @Valid
+    @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
+        return nextPaymentAmount;
+    }
+
+    public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+    }
+
+    public OBStandingOrder6Basic lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get lastPaymentAmount
+     *
+     * @return lastPaymentAmount
+     */
+    @Valid
+    @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
+        return lastPaymentAmount;
+    }
+
+    public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+    }
+
+    public OBStandingOrder6Basic finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get finalPaymentAmount
+     *
+     * @return finalPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
+        return finalPaymentAmount;
+    }
+
+    public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+    }
+
+    public OBStandingOrder6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStandingOrder6Basic obStandingOrder6Basic = (OBStandingOrder6Basic) o;
+        return Objects.equals(this.accountId, obStandingOrder6Basic.accountId) &&
+                Objects.equals(this.standingOrderId, obStandingOrder6Basic.standingOrderId) &&
+                Objects.equals(this.frequency, obStandingOrder6Basic.frequency) &&
+                Objects.equals(this.reference, obStandingOrder6Basic.reference) &&
+                Objects.equals(this.firstPaymentDateTime, obStandingOrder6Basic.firstPaymentDateTime) &&
+                Objects.equals(this.nextPaymentDateTime, obStandingOrder6Basic.nextPaymentDateTime) &&
+                Objects.equals(this.lastPaymentDateTime, obStandingOrder6Basic.lastPaymentDateTime) &&
+                Objects.equals(this.finalPaymentDateTime, obStandingOrder6Basic.finalPaymentDateTime) &&
+                Objects.equals(this.numberOfPayments, obStandingOrder6Basic.numberOfPayments) &&
+                Objects.equals(this.standingOrderStatusCode, obStandingOrder6Basic.standingOrderStatusCode) &&
+                Objects.equals(this.firstPaymentAmount, obStandingOrder6Basic.firstPaymentAmount) &&
+                Objects.equals(this.nextPaymentAmount, obStandingOrder6Basic.nextPaymentAmount) &&
+                Objects.equals(this.lastPaymentAmount, obStandingOrder6Basic.lastPaymentAmount) &&
+                Objects.equals(this.finalPaymentAmount, obStandingOrder6Basic.finalPaymentAmount) &&
+                Objects.equals(this.supplementaryData, obStandingOrder6Basic.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStandingOrder6Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
+        sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
+        sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
+        sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
+        sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
+        sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
+        sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
+        sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
+        sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
+        sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
@@ -15,21 +15,35 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount11;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount2;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount3;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount4;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification51;
+import uk.org.openbanking.datamodel.account.OBCashAccount51;
+import uk.org.openbanking.datamodel.account.OBExternalStandingOrderStatus1Code;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * OBStandingOrder6Detail
@@ -38,473 +52,484 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStandingOrder6Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private String standingOrderId;
+    private String standingOrderId;
 
-  private String frequency;
-
-  private String reference;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime firstPaymentDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime nextPaymentDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime lastPaymentDateTime;
-
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime finalPaymentDateTime;
-
-  private String numberOfPayments;
-
-  private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
-
-  private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
-
-  private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
-
-  private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
-
-  private OBCashAccount51 creditorAccount;
-
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
-
-  public OBStandingOrder6Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStandingOrder6Detail(String accountId, String frequency, OBCashAccount51 creditorAccount) {
-    this.accountId = accountId;
-    this.frequency = frequency;
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBStandingOrder6Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStandingOrder6Detail standingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
-   * @return standingOrderId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderId")
-  public String getStandingOrderId() {
-    return standingOrderId;
-  }
-
-  public void setStandingOrderId(String standingOrderId) {
-    this.standingOrderId = standingOrderId;
-  }
-
-  public OBStandingOrder6Detail frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
-   * @return frequency
-  */
-  @NotNull @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$") 
-  @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBStandingOrder6Detail reference(String reference) {
-    this.reference = reference;
-    return this;
-  }
-
-  /**
-   * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
-   * @return reference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Reference")
-  public String getReference() {
-    return reference;
-  }
-
-  public void setReference(String reference) {
-    this.reference = reference;
-  }
-
-  public OBStandingOrder6Detail firstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return firstPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentDateTime")
-  public DateTime getFirstPaymentDateTime() {
-    return firstPaymentDateTime;
-  }
-
-  public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
-    this.firstPaymentDateTime = firstPaymentDateTime;
-  }
-
-  public OBStandingOrder6Detail nextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return nextPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentDateTime")
-  public DateTime getNextPaymentDateTime() {
-    return nextPaymentDateTime;
-  }
-
-  public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
-    this.nextPaymentDateTime = nextPaymentDateTime;
-  }
-
-  public OBStandingOrder6Detail lastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return lastPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentDateTime")
-  public DateTime getLastPaymentDateTime() {
-    return lastPaymentDateTime;
-  }
-
-  public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
-    this.lastPaymentDateTime = lastPaymentDateTime;
-  }
-
-  public OBStandingOrder6Detail finalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-    return this;
-  }
-
-  /**
-   * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return finalPaymentDateTime
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentDateTime")
-  public DateTime getFinalPaymentDateTime() {
-    return finalPaymentDateTime;
-  }
-
-  public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
-    this.finalPaymentDateTime = finalPaymentDateTime;
-  }
-
-  public OBStandingOrder6Detail numberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-    return this;
-  }
-
-  /**
-   * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
-   * @return numberOfPayments
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NumberOfPayments")
-  public String getNumberOfPayments() {
-    return numberOfPayments;
-  }
-
-  public void setNumberOfPayments(String numberOfPayments) {
-    this.numberOfPayments = numberOfPayments;
-  }
-
-  public OBStandingOrder6Detail standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-    return this;
-  }
-
-  /**
-   * Get standingOrderStatusCode
-   * @return standingOrderStatusCode
-  */
-  @Valid 
-  @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StandingOrderStatusCode")
-  public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
-    return standingOrderStatusCode;
-  }
-
-  public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
-    this.standingOrderStatusCode = standingOrderStatusCode;
-  }
-
-  public OBStandingOrder6Detail firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get firstPaymentAmount
-   * @return firstPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FirstPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
-    return firstPaymentAmount;
-  }
-
-  public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
-    this.firstPaymentAmount = firstPaymentAmount;
-  }
-
-  public OBStandingOrder6Detail nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get nextPaymentAmount
-   * @return nextPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NextPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
-    return nextPaymentAmount;
-  }
-
-  public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
-    this.nextPaymentAmount = nextPaymentAmount;
-  }
-
-  public OBStandingOrder6Detail lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get lastPaymentAmount
-   * @return lastPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("LastPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
-    return lastPaymentAmount;
-  }
-
-  public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
-    this.lastPaymentAmount = lastPaymentAmount;
-  }
-
-  public OBStandingOrder6Detail finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-    return this;
-  }
-
-  /**
-   * Get finalPaymentAmount
-   * @return finalPaymentAmount
-  */
-  @Valid 
-  @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FinalPaymentAmount")
-  public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
-    return finalPaymentAmount;
-  }
-
-  public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
-    this.finalPaymentAmount = finalPaymentAmount;
-  }
-
-  public OBStandingOrder6Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBStandingOrder6Detail creditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount51 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount51 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBStandingOrder6Detail supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBStandingOrder6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    private String frequency;
+
+    private String reference;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime firstPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime nextPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime lastPaymentDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime finalPaymentDateTime;
+
+    private String numberOfPayments;
+
+    private OBExternalStandingOrderStatus1Code standingOrderStatusCode;
+
+    private OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount;
+
+    private OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount;
+
+    private OBBranchAndFinancialInstitutionIdentification51 creditorAgent;
+
+    private OBCashAccount51 creditorAccount;
+
+    private OBSupplementaryData1 supplementaryData;
+
+    public OBStandingOrder6Detail() {
+        super();
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStandingOrder6Detail(String accountId, String frequency, OBCashAccount51 creditorAccount) {
+        this.accountId = accountId;
+        this.frequency = frequency;
+        this.creditorAccount = creditorAccount;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBStandingOrder6Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBStandingOrder6Detail obStandingOrder6Detail = (OBStandingOrder6Detail) o;
-    return Objects.equals(this.accountId, obStandingOrder6Detail.accountId) &&
-        Objects.equals(this.standingOrderId, obStandingOrder6Detail.standingOrderId) &&
-        Objects.equals(this.frequency, obStandingOrder6Detail.frequency) &&
-        Objects.equals(this.reference, obStandingOrder6Detail.reference) &&
-        Objects.equals(this.firstPaymentDateTime, obStandingOrder6Detail.firstPaymentDateTime) &&
-        Objects.equals(this.nextPaymentDateTime, obStandingOrder6Detail.nextPaymentDateTime) &&
-        Objects.equals(this.lastPaymentDateTime, obStandingOrder6Detail.lastPaymentDateTime) &&
-        Objects.equals(this.finalPaymentDateTime, obStandingOrder6Detail.finalPaymentDateTime) &&
-        Objects.equals(this.numberOfPayments, obStandingOrder6Detail.numberOfPayments) &&
-        Objects.equals(this.standingOrderStatusCode, obStandingOrder6Detail.standingOrderStatusCode) &&
-        Objects.equals(this.firstPaymentAmount, obStandingOrder6Detail.firstPaymentAmount) &&
-        Objects.equals(this.nextPaymentAmount, obStandingOrder6Detail.nextPaymentAmount) &&
-        Objects.equals(this.lastPaymentAmount, obStandingOrder6Detail.lastPaymentAmount) &&
-        Objects.equals(this.finalPaymentAmount, obStandingOrder6Detail.finalPaymentAmount) &&
-        Objects.equals(this.creditorAgent, obStandingOrder6Detail.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obStandingOrder6Detail.creditorAccount) &&
-        Objects.equals(this.supplementaryData, obStandingOrder6Detail.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, creditorAgent, creditorAccount, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStandingOrder6Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
-    sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
-    sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
-    sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
-    sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
-    sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
-    sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
-    sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
-    sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
-    sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
-    sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBStandingOrder6Detail standingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+        return this;
+    }
+
+    /**
+     * A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.
+     *
+     * @return standingOrderId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StandingOrderId", description = "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderId")
+    public String getStandingOrderId() {
+        return standingOrderId;
+    }
+
+    public void setStandingOrderId(String standingOrderId) {
+        this.standingOrderId = standingOrderId;
+    }
+
+    public OBStandingOrder6Detail frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
+     *
+     * @return frequency
+     */
+    @NotNull
+    @Pattern(regexp = "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$")
+    @Schema(name = "Frequency", description = "Individual Definitions: NotKnown - Not Known EvryDay - Every day EvryWorkgDay - Every working day IntrvlDay - An interval specified in number of calendar days (02 to 31) IntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07) WkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07) IntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31) QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED) ENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. SCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November. RECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. Individual Patterns: NotKnown (ScheduleCode) EvryDay (ScheduleCode) EvryWorkgDay (ScheduleCode) IntrvlDay:NoOfDay (ScheduleCode + NoOfDay) IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek) WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek) IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth) QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay The regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here: NotKnown EvryDay EvryWorkgDay IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]) IntrvlWkDay:0[1-9]:0[1-7] WkInMnthDay:0[1-5]:0[1-7] IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]) QtrDay:(ENGLISH|SCOTTISH|RECEIVED) Full Regular Expression: ^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBStandingOrder6Detail reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+     *
+     * @return reference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. Usage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBStandingOrder6Detail firstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return firstPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FirstPaymentDateTime", description = "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentDateTime")
+    public DateTime getFirstPaymentDateTime() {
+        return firstPaymentDateTime;
+    }
+
+    public void setFirstPaymentDateTime(DateTime firstPaymentDateTime) {
+        this.firstPaymentDateTime = firstPaymentDateTime;
+    }
+
+    public OBStandingOrder6Detail nextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return nextPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "NextPaymentDateTime", description = "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentDateTime")
+    public DateTime getNextPaymentDateTime() {
+        return nextPaymentDateTime;
+    }
+
+    public void setNextPaymentDateTime(DateTime nextPaymentDateTime) {
+        this.nextPaymentDateTime = nextPaymentDateTime;
+    }
+
+    public OBStandingOrder6Detail lastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return lastPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "LastPaymentDateTime", description = "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentDateTime")
+    public DateTime getLastPaymentDateTime() {
+        return lastPaymentDateTime;
+    }
+
+    public void setLastPaymentDateTime(DateTime lastPaymentDateTime) {
+        this.lastPaymentDateTime = lastPaymentDateTime;
+    }
+
+    public OBStandingOrder6Detail finalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+        return this;
+    }
+
+    /**
+     * The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return finalPaymentDateTime
+     */
+    @Valid
+    @Schema(name = "FinalPaymentDateTime", description = "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentDateTime")
+    public DateTime getFinalPaymentDateTime() {
+        return finalPaymentDateTime;
+    }
+
+    public void setFinalPaymentDateTime(DateTime finalPaymentDateTime) {
+        this.finalPaymentDateTime = finalPaymentDateTime;
+    }
+
+    public OBStandingOrder6Detail numberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+        return this;
+    }
+
+    /**
+     * Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.
+     *
+     * @return numberOfPayments
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "NumberOfPayments", description = "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NumberOfPayments")
+    public String getNumberOfPayments() {
+        return numberOfPayments;
+    }
+
+    public void setNumberOfPayments(String numberOfPayments) {
+        this.numberOfPayments = numberOfPayments;
+    }
+
+    public OBStandingOrder6Detail standingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+        return this;
+    }
+
+    /**
+     * Get standingOrderStatusCode
+     *
+     * @return standingOrderStatusCode
+     */
+    @Valid
+    @Schema(name = "StandingOrderStatusCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StandingOrderStatusCode")
+    public OBExternalStandingOrderStatus1Code getStandingOrderStatusCode() {
+        return standingOrderStatusCode;
+    }
+
+    public void setStandingOrderStatusCode(OBExternalStandingOrderStatus1Code standingOrderStatusCode) {
+        this.standingOrderStatusCode = standingOrderStatusCode;
+    }
+
+    public OBStandingOrder6Detail firstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get firstPaymentAmount
+     *
+     * @return firstPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FirstPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount2 getFirstPaymentAmount() {
+        return firstPaymentAmount;
+    }
+
+    public void setFirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount2 firstPaymentAmount) {
+        this.firstPaymentAmount = firstPaymentAmount;
+    }
+
+    public OBStandingOrder6Detail nextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get nextPaymentAmount
+     *
+     * @return nextPaymentAmount
+     */
+    @Valid
+    @Schema(name = "NextPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NextPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount3 getNextPaymentAmount() {
+        return nextPaymentAmount;
+    }
+
+    public void setNextPaymentAmount(OBActiveOrHistoricCurrencyAndAmount3 nextPaymentAmount) {
+        this.nextPaymentAmount = nextPaymentAmount;
+    }
+
+    public OBStandingOrder6Detail lastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get lastPaymentAmount
+     *
+     * @return lastPaymentAmount
+     */
+    @Valid
+    @Schema(name = "LastPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount11 getLastPaymentAmount() {
+        return lastPaymentAmount;
+    }
+
+    public void setLastPaymentAmount(OBActiveOrHistoricCurrencyAndAmount11 lastPaymentAmount) {
+        this.lastPaymentAmount = lastPaymentAmount;
+    }
+
+    public OBStandingOrder6Detail finalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+        return this;
+    }
+
+    /**
+     * Get finalPaymentAmount
+     *
+     * @return finalPaymentAmount
+     */
+    @Valid
+    @Schema(name = "FinalPaymentAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FinalPaymentAmount")
+    public OBActiveOrHistoricCurrencyAndAmount4 getFinalPaymentAmount() {
+        return finalPaymentAmount;
+    }
+
+    public void setFinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount4 finalPaymentAmount) {
+        this.finalPaymentAmount = finalPaymentAmount;
+    }
+
+    public OBStandingOrder6Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification51 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification51 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBStandingOrder6Detail creditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount51 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount51 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    public OBStandingOrder6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStandingOrder6Detail obStandingOrder6Detail = (OBStandingOrder6Detail) o;
+        return Objects.equals(this.accountId, obStandingOrder6Detail.accountId) &&
+                Objects.equals(this.standingOrderId, obStandingOrder6Detail.standingOrderId) &&
+                Objects.equals(this.frequency, obStandingOrder6Detail.frequency) &&
+                Objects.equals(this.reference, obStandingOrder6Detail.reference) &&
+                Objects.equals(this.firstPaymentDateTime, obStandingOrder6Detail.firstPaymentDateTime) &&
+                Objects.equals(this.nextPaymentDateTime, obStandingOrder6Detail.nextPaymentDateTime) &&
+                Objects.equals(this.lastPaymentDateTime, obStandingOrder6Detail.lastPaymentDateTime) &&
+                Objects.equals(this.finalPaymentDateTime, obStandingOrder6Detail.finalPaymentDateTime) &&
+                Objects.equals(this.numberOfPayments, obStandingOrder6Detail.numberOfPayments) &&
+                Objects.equals(this.standingOrderStatusCode, obStandingOrder6Detail.standingOrderStatusCode) &&
+                Objects.equals(this.firstPaymentAmount, obStandingOrder6Detail.firstPaymentAmount) &&
+                Objects.equals(this.nextPaymentAmount, obStandingOrder6Detail.nextPaymentAmount) &&
+                Objects.equals(this.lastPaymentAmount, obStandingOrder6Detail.lastPaymentAmount) &&
+                Objects.equals(this.finalPaymentAmount, obStandingOrder6Detail.finalPaymentAmount) &&
+                Objects.equals(this.creditorAgent, obStandingOrder6Detail.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obStandingOrder6Detail.creditorAccount) &&
+                Objects.equals(this.supplementaryData, obStandingOrder6Detail.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, standingOrderId, frequency, reference, firstPaymentDateTime, nextPaymentDateTime, lastPaymentDateTime, finalPaymentDateTime, numberOfPayments, standingOrderStatusCode, firstPaymentAmount, nextPaymentAmount, lastPaymentAmount, finalPaymentAmount, creditorAgent, creditorAccount, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStandingOrder6Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    standingOrderId: ").append(toIndentedString(standingOrderId)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    firstPaymentDateTime: ").append(toIndentedString(firstPaymentDateTime)).append("\n");
+        sb.append("    nextPaymentDateTime: ").append(toIndentedString(nextPaymentDateTime)).append("\n");
+        sb.append("    lastPaymentDateTime: ").append(toIndentedString(lastPaymentDateTime)).append("\n");
+        sb.append("    finalPaymentDateTime: ").append(toIndentedString(finalPaymentDateTime)).append("\n");
+        sb.append("    numberOfPayments: ").append(toIndentedString(numberOfPayments)).append("\n");
+        sb.append("    standingOrderStatusCode: ").append(toIndentedString(standingOrderStatusCode)).append("\n");
+        sb.append("    firstPaymentAmount: ").append(toIndentedString(firstPaymentAmount)).append("\n");
+        sb.append("    nextPaymentAmount: ").append(toIndentedString(nextPaymentAmount)).append("\n");
+        sb.append("    lastPaymentAmount: ").append(toIndentedString(lastPaymentAmount)).append("\n");
+        sb.append("    finalPaymentAmount: ").append(toIndentedString(finalPaymentAmount)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
@@ -38,489 +38,509 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2 {
 
-  private String accountId;
+    private String accountId;
 
-  private String statementId;
+    private String statementId;
 
-  private String statementReference;
+    private String statementReference;
 
-  private OBExternalStatementType1Code type;
+    private OBExternalStatementType1Code type;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime startDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime startDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime endDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime endDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime creationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
 
-  @Valid
-  private List<@Size(min = 1, max = 500)String> statementDescription;
+    @Valid
+    private List<@Size(min = 1, max = 500) String> statementDescription;
 
-  @Valid
-  private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
+    @Valid
+    private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
 
-  @Valid
-  private List<@Valid OBStatement2StatementFeeInner> statementFee;
+    @Valid
+    private List<@Valid OBStatement2StatementFeeInner> statementFee;
 
-  @Valid
-  private List<@Valid OBStatement2StatementInterestInner> statementInterest;
+    @Valid
+    private List<@Valid OBStatement2StatementInterestInner> statementInterest;
 
-  @Valid
-  private List<@Valid OBStatement2StatementAmountInner> statementAmount;
+    @Valid
+    private List<@Valid OBStatement2StatementAmountInner> statementAmount;
 
-  @Valid
-  private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
+    @Valid
+    private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
 
-  @Valid
-  private List<@Valid OBStatement2StatementRateInner> statementRate;
+    @Valid
+    private List<@Valid OBStatement2StatementRateInner> statementRate;
 
-  @Valid
-  private List<@Valid OBStatement2StatementValueInner> statementValue;
+    @Valid
+    private List<@Valid OBStatement2StatementValueInner> statementValue;
 
-  public OBStatement2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
-    this.accountId = accountId;
-    this.type = type;
-    this.startDateTime = startDateTime;
-    this.endDateTime = endDateTime;
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStatement2 statementId(String statementId) {
-    this.statementId = statementId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
-   * @return statementId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementId")
-  public String getStatementId() {
-    return statementId;
-  }
-
-  public void setStatementId(String statementId) {
-    this.statementId = statementId;
-  }
-
-  public OBStatement2 statementReference(String statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the statement. This reference may be optionally populated if available.
-   * @return statementReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public String getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(String statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBStatement2 type(OBExternalStatementType1Code type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Get type
-   * @return type
-  */
-  @NotNull @Valid 
-  @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public OBExternalStatementType1Code getType() {
-    return type;
-  }
-
-  public void setType(OBExternalStatementType1Code type) {
-    this.type = type;
-  }
-
-  public OBStatement2 startDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return startDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("StartDateTime")
-  public DateTime getStartDateTime() {
-    return startDateTime;
-  }
-
-  public void setStartDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-  }
-
-  public OBStatement2 endDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return endDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("EndDateTime")
-  public DateTime getEndDateTime() {
-    return endDateTime;
-  }
-
-  public void setEndDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-  }
-
-  public OBStatement2 creationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return creationDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreationDateTime")
-  public DateTime getCreationDateTime() {
-    return creationDateTime;
-  }
-
-  public void setCreationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2 statementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-    return this;
-  }
-
-  public OBStatement2 addStatementDescriptionItem(String statementDescriptionItem) {
-    if (this.statementDescription == null) {
-      this.statementDescription = new ArrayList<>();
+    public OBStatement2() {
+        super();
     }
-    this.statementDescription.add(statementDescriptionItem);
-    return this;
-  }
 
-  /**
-   * Get statementDescription
-   * @return statementDescription
-  */
-  
-  @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDescription")
-  public List<@Size(min = 1, max = 500)String> getStatementDescription() {
-    return statementDescription;
-  }
-
-  public void setStatementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-  }
-
-  public OBStatement2 statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-    return this;
-  }
-
-  public OBStatement2 addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
-    if (this.statementBenefit == null) {
-      this.statementBenefit = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
+        this.accountId = accountId;
+        this.type = type;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.creationDateTime = creationDateTime;
     }
-    this.statementBenefit.add(statementBenefitItem);
-    return this;
-  }
 
-  /**
-   * Get statementBenefit
-   * @return statementBenefit
-  */
-  @Valid 
-  @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementBenefit")
-  public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
-    return statementBenefit;
-  }
-
-  public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-  }
-
-  public OBStatement2 statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-    return this;
-  }
-
-  public OBStatement2 addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
-    if (this.statementFee == null) {
-      this.statementFee = new ArrayList<>();
+    public OBStatement2 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    this.statementFee.add(statementFeeItem);
-    return this;
-  }
 
-  /**
-   * Get statementFee
-   * @return statementFee
-  */
-  @Valid 
-  @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementFee")
-  public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
-    return statementFee;
-  }
-
-  public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-  }
-
-  public OBStatement2 statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-    return this;
-  }
-
-  public OBStatement2 addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
-    if (this.statementInterest == null) {
-      this.statementInterest = new ArrayList<>();
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    this.statementInterest.add(statementInterestItem);
-    return this;
-  }
 
-  /**
-   * Get statementInterest
-   * @return statementInterest
-  */
-  @Valid 
-  @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementInterest")
-  public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
-    return statementInterest;
-  }
-
-  public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-  }
-
-  public OBStatement2 statementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
-    this.statementAmount = statementAmount;
-    return this;
-  }
-
-  public OBStatement2 addStatementAmountItem(OBStatement2StatementAmountInner statementAmountItem) {
-    if (this.statementAmount == null) {
-      this.statementAmount = new ArrayList<>();
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    this.statementAmount.add(statementAmountItem);
-    return this;
-  }
 
-  /**
-   * Get statementAmount
-   * @return statementAmount
-  */
-  @Valid 
-  @Schema(name = "StatementAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementAmount")
-  public List<@Valid OBStatement2StatementAmountInner> getStatementAmount() {
-    return statementAmount;
-  }
-
-  public void setStatementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
-    this.statementAmount = statementAmount;
-  }
-
-  public OBStatement2 statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-    return this;
-  }
-
-  public OBStatement2 addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
-    if (this.statementDateTime == null) {
-      this.statementDateTime = new ArrayList<>();
+    public OBStatement2 statementId(String statementId) {
+        this.statementId = statementId;
+        return this;
     }
-    this.statementDateTime.add(statementDateTimeItem);
-    return this;
-  }
 
-  /**
-   * Get statementDateTime
-   * @return statementDateTime
-  */
-  @Valid 
-  @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDateTime")
-  public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
-    return statementDateTime;
-  }
-
-  public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-  }
-
-  public OBStatement2 statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-    return this;
-  }
-
-  public OBStatement2 addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
-    if (this.statementRate == null) {
-      this.statementRate = new ArrayList<>();
+    /**
+     * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return statementId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementId")
+    public String getStatementId() {
+        return statementId;
     }
-    this.statementRate.add(statementRateItem);
-    return this;
-  }
 
-  /**
-   * Get statementRate
-   * @return statementRate
-  */
-  @Valid 
-  @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementRate")
-  public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
-    return statementRate;
-  }
-
-  public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-  }
-
-  public OBStatement2 statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-    return this;
-  }
-
-  public OBStatement2 addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
-    if (this.statementValue == null) {
-      this.statementValue = new ArrayList<>();
+    public void setStatementId(String statementId) {
+        this.statementId = statementId;
     }
-    this.statementValue.add(statementValueItem);
-    return this;
-  }
 
-  /**
-   * Get statementValue
-   * @return statementValue
-  */
-  @Valid 
-  @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementValue")
-  public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
-    return statementValue;
-  }
-
-  public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2 statementReference(String statementReference) {
+        this.statementReference = statementReference;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Unique reference for the statement. This reference may be optionally populated if available.
+     *
+     * @return statementReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public String getStatementReference() {
+        return statementReference;
     }
-    OBStatement2 obStatement2 = (OBStatement2) o;
-    return Objects.equals(this.accountId, obStatement2.accountId) &&
-        Objects.equals(this.statementId, obStatement2.statementId) &&
-        Objects.equals(this.statementReference, obStatement2.statementReference) &&
-        Objects.equals(this.type, obStatement2.type) &&
-        Objects.equals(this.startDateTime, obStatement2.startDateTime) &&
-        Objects.equals(this.endDateTime, obStatement2.endDateTime) &&
-        Objects.equals(this.creationDateTime, obStatement2.creationDateTime) &&
-        Objects.equals(this.statementDescription, obStatement2.statementDescription) &&
-        Objects.equals(this.statementBenefit, obStatement2.statementBenefit) &&
-        Objects.equals(this.statementFee, obStatement2.statementFee) &&
-        Objects.equals(this.statementInterest, obStatement2.statementInterest) &&
-        Objects.equals(this.statementAmount, obStatement2.statementAmount) &&
-        Objects.equals(this.statementDateTime, obStatement2.statementDateTime) &&
-        Objects.equals(this.statementRate, obStatement2.statementRate) &&
-        Objects.equals(this.statementValue, obStatement2.statementValue);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementAmount, statementDateTime, statementRate, statementValue);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
-    sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
-    sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
-    sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
-    sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
-    sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
-    sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
-    sb.append("    statementAmount: ").append(toIndentedString(statementAmount)).append("\n");
-    sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
-    sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
-    sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setStatementReference(String statementReference) {
+        this.statementReference = statementReference;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBStatement2 type(OBExternalStatementType1Code type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public OBExternalStatementType1Code getType() {
+        return type;
+    }
+
+    public void setType(OBExternalStatementType1Code type) {
+        this.type = type;
+    }
+
+    public OBStatement2 startDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return startDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("StartDateTime")
+    public DateTime getStartDateTime() {
+        return startDateTime;
+    }
+
+    public void setStartDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+    }
+
+    public OBStatement2 endDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return endDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("EndDateTime")
+    public DateTime getEndDateTime() {
+        return endDateTime;
+    }
+
+    public void setEndDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+    }
+
+    public OBStatement2 creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBStatement2 statementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+        return this;
+    }
+
+    public OBStatement2 addStatementDescriptionItem(String statementDescriptionItem) {
+        if (this.statementDescription == null) {
+            this.statementDescription = new ArrayList<>();
+        }
+        this.statementDescription.add(statementDescriptionItem);
+        return this;
+    }
+
+    /**
+     * Get statementDescription
+     *
+     * @return statementDescription
+     */
+
+    @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDescription")
+    public List<@Size(min = 1, max = 500) String> getStatementDescription() {
+        return statementDescription;
+    }
+
+    public void setStatementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+    }
+
+    public OBStatement2 statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+        return this;
+    }
+
+    public OBStatement2 addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
+        if (this.statementBenefit == null) {
+            this.statementBenefit = new ArrayList<>();
+        }
+        this.statementBenefit.add(statementBenefitItem);
+        return this;
+    }
+
+    /**
+     * Get statementBenefit
+     *
+     * @return statementBenefit
+     */
+    @Valid
+    @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementBenefit")
+    public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
+        return statementBenefit;
+    }
+
+    public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+    }
+
+    public OBStatement2 statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+        return this;
+    }
+
+    public OBStatement2 addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
+        if (this.statementFee == null) {
+            this.statementFee = new ArrayList<>();
+        }
+        this.statementFee.add(statementFeeItem);
+        return this;
+    }
+
+    /**
+     * Get statementFee
+     *
+     * @return statementFee
+     */
+    @Valid
+    @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementFee")
+    public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
+        return statementFee;
+    }
+
+    public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+    }
+
+    public OBStatement2 statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+        return this;
+    }
+
+    public OBStatement2 addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
+        if (this.statementInterest == null) {
+            this.statementInterest = new ArrayList<>();
+        }
+        this.statementInterest.add(statementInterestItem);
+        return this;
+    }
+
+    /**
+     * Get statementInterest
+     *
+     * @return statementInterest
+     */
+    @Valid
+    @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementInterest")
+    public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
+        return statementInterest;
+    }
+
+    public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+    }
+
+    public OBStatement2 statementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
+        this.statementAmount = statementAmount;
+        return this;
+    }
+
+    public OBStatement2 addStatementAmountItem(OBStatement2StatementAmountInner statementAmountItem) {
+        if (this.statementAmount == null) {
+            this.statementAmount = new ArrayList<>();
+        }
+        this.statementAmount.add(statementAmountItem);
+        return this;
+    }
+
+    /**
+     * Get statementAmount
+     *
+     * @return statementAmount
+     */
+    @Valid
+    @Schema(name = "StatementAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementAmount")
+    public List<@Valid OBStatement2StatementAmountInner> getStatementAmount() {
+        return statementAmount;
+    }
+
+    public void setStatementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
+        this.statementAmount = statementAmount;
+    }
+
+    public OBStatement2 statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+        return this;
+    }
+
+    public OBStatement2 addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
+        if (this.statementDateTime == null) {
+            this.statementDateTime = new ArrayList<>();
+        }
+        this.statementDateTime.add(statementDateTimeItem);
+        return this;
+    }
+
+    /**
+     * Get statementDateTime
+     *
+     * @return statementDateTime
+     */
+    @Valid
+    @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDateTime")
+    public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
+        return statementDateTime;
+    }
+
+    public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+    }
+
+    public OBStatement2 statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+        return this;
+    }
+
+    public OBStatement2 addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
+        if (this.statementRate == null) {
+            this.statementRate = new ArrayList<>();
+        }
+        this.statementRate.add(statementRateItem);
+        return this;
+    }
+
+    /**
+     * Get statementRate
+     *
+     * @return statementRate
+     */
+    @Valid
+    @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementRate")
+    public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
+        return statementRate;
+    }
+
+    public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+    }
+
+    public OBStatement2 statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+        return this;
+    }
+
+    public OBStatement2 addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
+        if (this.statementValue == null) {
+            this.statementValue = new ArrayList<>();
+        }
+        this.statementValue.add(statementValueItem);
+        return this;
+    }
+
+    /**
+     * Get statementValue
+     *
+     * @return statementValue
+     */
+    @Valid
+    @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementValue")
+    public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
+        return statementValue;
+    }
+
+    public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2 obStatement2 = (OBStatement2) o;
+        return Objects.equals(this.accountId, obStatement2.accountId) &&
+                Objects.equals(this.statementId, obStatement2.statementId) &&
+                Objects.equals(this.statementReference, obStatement2.statementReference) &&
+                Objects.equals(this.type, obStatement2.type) &&
+                Objects.equals(this.startDateTime, obStatement2.startDateTime) &&
+                Objects.equals(this.endDateTime, obStatement2.endDateTime) &&
+                Objects.equals(this.creationDateTime, obStatement2.creationDateTime) &&
+                Objects.equals(this.statementDescription, obStatement2.statementDescription) &&
+                Objects.equals(this.statementBenefit, obStatement2.statementBenefit) &&
+                Objects.equals(this.statementFee, obStatement2.statementFee) &&
+                Objects.equals(this.statementInterest, obStatement2.statementInterest) &&
+                Objects.equals(this.statementAmount, obStatement2.statementAmount) &&
+                Objects.equals(this.statementDateTime, obStatement2.statementDateTime) &&
+                Objects.equals(this.statementRate, obStatement2.statementRate) &&
+                Objects.equals(this.statementValue, obStatement2.statementValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementAmount, statementDateTime, statementRate, statementValue);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
+        sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
+        sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
+        sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
+        sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
+        sb.append("    statementAmount: ").append(toIndentedString(statementAmount)).append("\n");
+        sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
+        sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
+        sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
@@ -38,456 +38,475 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private String statementId;
+    private String statementId;
 
-  private String statementReference;
+    private String statementReference;
 
-  private OBExternalStatementType1Code type;
+    private OBExternalStatementType1Code type;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime startDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime startDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime endDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime endDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime creationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
 
-  @Valid
-  private List<@Size(min = 1, max = 500)String> statementDescription;
+    @Valid
+    private List<@Size(min = 1, max = 500) String> statementDescription;
 
-  @Valid
-  private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
+    @Valid
+    private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
 
-  @Valid
-  private List<@Valid OBStatement2StatementFeeInner> statementFee;
+    @Valid
+    private List<@Valid OBStatement2StatementFeeInner> statementFee;
 
-  @Valid
-  private List<@Valid OBStatement2StatementInterestInner> statementInterest;
+    @Valid
+    private List<@Valid OBStatement2StatementInterestInner> statementInterest;
 
-  @Valid
-  private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
+    @Valid
+    private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
 
-  @Valid
-  private List<@Valid OBStatement2StatementRateInner> statementRate;
+    @Valid
+    private List<@Valid OBStatement2StatementRateInner> statementRate;
 
-  @Valid
-  private List<@Valid OBStatement2StatementValueInner> statementValue;
+    @Valid
+    private List<@Valid OBStatement2StatementValueInner> statementValue;
 
-  public OBStatement2Basic() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2Basic(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
-    this.accountId = accountId;
-    this.type = type;
-    this.startDateTime = startDateTime;
-    this.endDateTime = endDateTime;
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStatement2Basic statementId(String statementId) {
-    this.statementId = statementId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
-   * @return statementId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementId")
-  public String getStatementId() {
-    return statementId;
-  }
-
-  public void setStatementId(String statementId) {
-    this.statementId = statementId;
-  }
-
-  public OBStatement2Basic statementReference(String statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the statement. This reference may be optionally populated if available.
-   * @return statementReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public String getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(String statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBStatement2Basic type(OBExternalStatementType1Code type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Get type
-   * @return type
-  */
-  @NotNull @Valid 
-  @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public OBExternalStatementType1Code getType() {
-    return type;
-  }
-
-  public void setType(OBExternalStatementType1Code type) {
-    this.type = type;
-  }
-
-  public OBStatement2Basic startDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return startDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("StartDateTime")
-  public DateTime getStartDateTime() {
-    return startDateTime;
-  }
-
-  public void setStartDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-  }
-
-  public OBStatement2Basic endDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return endDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("EndDateTime")
-  public DateTime getEndDateTime() {
-    return endDateTime;
-  }
-
-  public void setEndDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-  }
-
-  public OBStatement2Basic creationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return creationDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreationDateTime")
-  public DateTime getCreationDateTime() {
-    return creationDateTime;
-  }
-
-  public void setCreationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2Basic statementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementDescriptionItem(String statementDescriptionItem) {
-    if (this.statementDescription == null) {
-      this.statementDescription = new ArrayList<>();
+    public OBStatement2Basic() {
+        super();
     }
-    this.statementDescription.add(statementDescriptionItem);
-    return this;
-  }
 
-  /**
-   * Get statementDescription
-   * @return statementDescription
-  */
-  
-  @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDescription")
-  public List<@Size(min = 1, max = 500)String> getStatementDescription() {
-    return statementDescription;
-  }
-
-  public void setStatementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-  }
-
-  public OBStatement2Basic statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
-    if (this.statementBenefit == null) {
-      this.statementBenefit = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2Basic(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
+        this.accountId = accountId;
+        this.type = type;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.creationDateTime = creationDateTime;
     }
-    this.statementBenefit.add(statementBenefitItem);
-    return this;
-  }
 
-  /**
-   * Get statementBenefit
-   * @return statementBenefit
-  */
-  @Valid 
-  @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementBenefit")
-  public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
-    return statementBenefit;
-  }
-
-  public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-  }
-
-  public OBStatement2Basic statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
-    if (this.statementFee == null) {
-      this.statementFee = new ArrayList<>();
+    public OBStatement2Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    this.statementFee.add(statementFeeItem);
-    return this;
-  }
 
-  /**
-   * Get statementFee
-   * @return statementFee
-  */
-  @Valid 
-  @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementFee")
-  public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
-    return statementFee;
-  }
-
-  public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-  }
-
-  public OBStatement2Basic statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
-    if (this.statementInterest == null) {
-      this.statementInterest = new ArrayList<>();
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    this.statementInterest.add(statementInterestItem);
-    return this;
-  }
 
-  /**
-   * Get statementInterest
-   * @return statementInterest
-  */
-  @Valid 
-  @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementInterest")
-  public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
-    return statementInterest;
-  }
-
-  public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-  }
-
-  public OBStatement2Basic statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
-    if (this.statementDateTime == null) {
-      this.statementDateTime = new ArrayList<>();
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    this.statementDateTime.add(statementDateTimeItem);
-    return this;
-  }
 
-  /**
-   * Get statementDateTime
-   * @return statementDateTime
-  */
-  @Valid 
-  @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDateTime")
-  public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
-    return statementDateTime;
-  }
-
-  public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-  }
-
-  public OBStatement2Basic statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
-    if (this.statementRate == null) {
-      this.statementRate = new ArrayList<>();
+    public OBStatement2Basic statementId(String statementId) {
+        this.statementId = statementId;
+        return this;
     }
-    this.statementRate.add(statementRateItem);
-    return this;
-  }
 
-  /**
-   * Get statementRate
-   * @return statementRate
-  */
-  @Valid 
-  @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementRate")
-  public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
-    return statementRate;
-  }
-
-  public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-  }
-
-  public OBStatement2Basic statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-    return this;
-  }
-
-  public OBStatement2Basic addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
-    if (this.statementValue == null) {
-      this.statementValue = new ArrayList<>();
+    /**
+     * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return statementId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementId")
+    public String getStatementId() {
+        return statementId;
     }
-    this.statementValue.add(statementValueItem);
-    return this;
-  }
 
-  /**
-   * Get statementValue
-   * @return statementValue
-  */
-  @Valid 
-  @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementValue")
-  public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
-    return statementValue;
-  }
-
-  public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public void setStatementId(String statementId) {
+        this.statementId = statementId;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBStatement2Basic statementReference(String statementReference) {
+        this.statementReference = statementReference;
+        return this;
     }
-    OBStatement2Basic obStatement2Basic = (OBStatement2Basic) o;
-    return Objects.equals(this.accountId, obStatement2Basic.accountId) &&
-        Objects.equals(this.statementId, obStatement2Basic.statementId) &&
-        Objects.equals(this.statementReference, obStatement2Basic.statementReference) &&
-        Objects.equals(this.type, obStatement2Basic.type) &&
-        Objects.equals(this.startDateTime, obStatement2Basic.startDateTime) &&
-        Objects.equals(this.endDateTime, obStatement2Basic.endDateTime) &&
-        Objects.equals(this.creationDateTime, obStatement2Basic.creationDateTime) &&
-        Objects.equals(this.statementDescription, obStatement2Basic.statementDescription) &&
-        Objects.equals(this.statementBenefit, obStatement2Basic.statementBenefit) &&
-        Objects.equals(this.statementFee, obStatement2Basic.statementFee) &&
-        Objects.equals(this.statementInterest, obStatement2Basic.statementInterest) &&
-        Objects.equals(this.statementDateTime, obStatement2Basic.statementDateTime) &&
-        Objects.equals(this.statementRate, obStatement2Basic.statementRate) &&
-        Objects.equals(this.statementValue, obStatement2Basic.statementValue);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementDateTime, statementRate, statementValue);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
-    sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
-    sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
-    sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
-    sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
-    sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
-    sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
-    sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
-    sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
-    sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Unique reference for the statement. This reference may be optionally populated if available.
+     *
+     * @return statementReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public String getStatementReference() {
+        return statementReference;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setStatementReference(String statementReference) {
+        this.statementReference = statementReference;
+    }
+
+    public OBStatement2Basic type(OBExternalStatementType1Code type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public OBExternalStatementType1Code getType() {
+        return type;
+    }
+
+    public void setType(OBExternalStatementType1Code type) {
+        this.type = type;
+    }
+
+    public OBStatement2Basic startDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return startDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("StartDateTime")
+    public DateTime getStartDateTime() {
+        return startDateTime;
+    }
+
+    public void setStartDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+    }
+
+    public OBStatement2Basic endDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return endDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("EndDateTime")
+    public DateTime getEndDateTime() {
+        return endDateTime;
+    }
+
+    public void setEndDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+    }
+
+    public OBStatement2Basic creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBStatement2Basic statementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementDescriptionItem(String statementDescriptionItem) {
+        if (this.statementDescription == null) {
+            this.statementDescription = new ArrayList<>();
+        }
+        this.statementDescription.add(statementDescriptionItem);
+        return this;
+    }
+
+    /**
+     * Get statementDescription
+     *
+     * @return statementDescription
+     */
+
+    @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDescription")
+    public List<@Size(min = 1, max = 500) String> getStatementDescription() {
+        return statementDescription;
+    }
+
+    public void setStatementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+    }
+
+    public OBStatement2Basic statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
+        if (this.statementBenefit == null) {
+            this.statementBenefit = new ArrayList<>();
+        }
+        this.statementBenefit.add(statementBenefitItem);
+        return this;
+    }
+
+    /**
+     * Get statementBenefit
+     *
+     * @return statementBenefit
+     */
+    @Valid
+    @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementBenefit")
+    public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
+        return statementBenefit;
+    }
+
+    public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+    }
+
+    public OBStatement2Basic statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
+        if (this.statementFee == null) {
+            this.statementFee = new ArrayList<>();
+        }
+        this.statementFee.add(statementFeeItem);
+        return this;
+    }
+
+    /**
+     * Get statementFee
+     *
+     * @return statementFee
+     */
+    @Valid
+    @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementFee")
+    public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
+        return statementFee;
+    }
+
+    public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+    }
+
+    public OBStatement2Basic statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
+        if (this.statementInterest == null) {
+            this.statementInterest = new ArrayList<>();
+        }
+        this.statementInterest.add(statementInterestItem);
+        return this;
+    }
+
+    /**
+     * Get statementInterest
+     *
+     * @return statementInterest
+     */
+    @Valid
+    @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementInterest")
+    public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
+        return statementInterest;
+    }
+
+    public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+    }
+
+    public OBStatement2Basic statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
+        if (this.statementDateTime == null) {
+            this.statementDateTime = new ArrayList<>();
+        }
+        this.statementDateTime.add(statementDateTimeItem);
+        return this;
+    }
+
+    /**
+     * Get statementDateTime
+     *
+     * @return statementDateTime
+     */
+    @Valid
+    @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDateTime")
+    public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
+        return statementDateTime;
+    }
+
+    public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+    }
+
+    public OBStatement2Basic statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
+        if (this.statementRate == null) {
+            this.statementRate = new ArrayList<>();
+        }
+        this.statementRate.add(statementRateItem);
+        return this;
+    }
+
+    /**
+     * Get statementRate
+     *
+     * @return statementRate
+     */
+    @Valid
+    @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementRate")
+    public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
+        return statementRate;
+    }
+
+    public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+    }
+
+    public OBStatement2Basic statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+        return this;
+    }
+
+    public OBStatement2Basic addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
+        if (this.statementValue == null) {
+            this.statementValue = new ArrayList<>();
+        }
+        this.statementValue.add(statementValueItem);
+        return this;
+    }
+
+    /**
+     * Get statementValue
+     *
+     * @return statementValue
+     */
+    @Valid
+    @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementValue")
+    public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
+        return statementValue;
+    }
+
+    public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2Basic obStatement2Basic = (OBStatement2Basic) o;
+        return Objects.equals(this.accountId, obStatement2Basic.accountId) &&
+                Objects.equals(this.statementId, obStatement2Basic.statementId) &&
+                Objects.equals(this.statementReference, obStatement2Basic.statementReference) &&
+                Objects.equals(this.type, obStatement2Basic.type) &&
+                Objects.equals(this.startDateTime, obStatement2Basic.startDateTime) &&
+                Objects.equals(this.endDateTime, obStatement2Basic.endDateTime) &&
+                Objects.equals(this.creationDateTime, obStatement2Basic.creationDateTime) &&
+                Objects.equals(this.statementDescription, obStatement2Basic.statementDescription) &&
+                Objects.equals(this.statementBenefit, obStatement2Basic.statementBenefit) &&
+                Objects.equals(this.statementFee, obStatement2Basic.statementFee) &&
+                Objects.equals(this.statementInterest, obStatement2Basic.statementInterest) &&
+                Objects.equals(this.statementDateTime, obStatement2Basic.statementDateTime) &&
+                Objects.equals(this.statementRate, obStatement2Basic.statementRate) &&
+                Objects.equals(this.statementValue, obStatement2Basic.statementValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementDateTime, statementRate, statementValue);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
+        sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
+        sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
+        sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
+        sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
+        sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
+        sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
+        sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
@@ -15,20 +15,39 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBExternalStatementType1Code;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementAmountInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementBenefitInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementDateTimeInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementFeeInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementInterestInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementRateInner;
+import uk.org.openbanking.datamodel.account.OBStatement2StatementValueInner;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Provides further details on a statement resource.
@@ -38,489 +57,509 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private String statementId;
+    private String statementId;
 
-  private String statementReference;
+    private String statementReference;
 
-  private OBExternalStatementType1Code type;
+    private OBExternalStatementType1Code type;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime startDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime startDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime endDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime endDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime creationDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
 
-  @Valid
-  private List<@Size(min = 1, max = 500)String> statementDescription;
+    @Valid
+    private List<@Size(min = 1, max = 500) String> statementDescription;
 
-  @Valid
-  private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
+    @Valid
+    private List<@Valid OBStatement2StatementBenefitInner> statementBenefit;
 
-  @Valid
-  private List<@Valid OBStatement2StatementFeeInner> statementFee;
+    @Valid
+    private List<@Valid OBStatement2StatementFeeInner> statementFee;
 
-  @Valid
-  private List<@Valid OBStatement2StatementInterestInner> statementInterest;
+    @Valid
+    private List<@Valid OBStatement2StatementInterestInner> statementInterest;
 
-  @Valid
-  private List<@Valid OBStatement2StatementAmountInner> statementAmount;
+    @Valid
+    private List<@Valid OBStatement2StatementAmountInner> statementAmount;
 
-  @Valid
-  private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
+    @Valid
+    private List<@Valid OBStatement2StatementDateTimeInner> statementDateTime;
 
-  @Valid
-  private List<@Valid OBStatement2StatementRateInner> statementRate;
+    @Valid
+    private List<@Valid OBStatement2StatementRateInner> statementRate;
 
-  @Valid
-  private List<@Valid OBStatement2StatementValueInner> statementValue;
+    @Valid
+    private List<@Valid OBStatement2StatementValueInner> statementValue;
 
-  public OBStatement2Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2Detail(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
-    this.accountId = accountId;
-    this.type = type;
-    this.startDateTime = startDateTime;
-    this.endDateTime = endDateTime;
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBStatement2Detail statementId(String statementId) {
-    this.statementId = statementId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
-   * @return statementId
-  */
-  @Size(min = 1, max = 40) 
-  @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementId")
-  public String getStatementId() {
-    return statementId;
-  }
-
-  public void setStatementId(String statementId) {
-    this.statementId = statementId;
-  }
-
-  public OBStatement2Detail statementReference(String statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the statement. This reference may be optionally populated if available.
-   * @return statementReference
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public String getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(String statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBStatement2Detail type(OBExternalStatementType1Code type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Get type
-   * @return type
-  */
-  @NotNull @Valid 
-  @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public OBExternalStatementType1Code getType() {
-    return type;
-  }
-
-  public void setType(OBExternalStatementType1Code type) {
-    this.type = type;
-  }
-
-  public OBStatement2Detail startDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return startDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("StartDateTime")
-  public DateTime getStartDateTime() {
-    return startDateTime;
-  }
-
-  public void setStartDateTime(DateTime startDateTime) {
-    this.startDateTime = startDateTime;
-  }
-
-  public OBStatement2Detail endDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return endDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("EndDateTime")
-  public DateTime getEndDateTime() {
-    return endDateTime;
-  }
-
-  public void setEndDateTime(DateTime endDateTime) {
-    this.endDateTime = endDateTime;
-  }
-
-  public OBStatement2Detail creationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return creationDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreationDateTime")
-  public DateTime getCreationDateTime() {
-    return creationDateTime;
-  }
-
-  public void setCreationDateTime(DateTime creationDateTime) {
-    this.creationDateTime = creationDateTime;
-  }
-
-  public OBStatement2Detail statementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementDescriptionItem(String statementDescriptionItem) {
-    if (this.statementDescription == null) {
-      this.statementDescription = new ArrayList<>();
+    public OBStatement2Detail() {
+        super();
     }
-    this.statementDescription.add(statementDescriptionItem);
-    return this;
-  }
 
-  /**
-   * Get statementDescription
-   * @return statementDescription
-  */
-  
-  @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDescription")
-  public List<@Size(min = 1, max = 500)String> getStatementDescription() {
-    return statementDescription;
-  }
-
-  public void setStatementDescription(List<@Size(min = 1, max = 500)String> statementDescription) {
-    this.statementDescription = statementDescription;
-  }
-
-  public OBStatement2Detail statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
-    if (this.statementBenefit == null) {
-      this.statementBenefit = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2Detail(String accountId, OBExternalStatementType1Code type, DateTime startDateTime, DateTime endDateTime, DateTime creationDateTime) {
+        this.accountId = accountId;
+        this.type = type;
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.creationDateTime = creationDateTime;
     }
-    this.statementBenefit.add(statementBenefitItem);
-    return this;
-  }
 
-  /**
-   * Get statementBenefit
-   * @return statementBenefit
-  */
-  @Valid 
-  @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementBenefit")
-  public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
-    return statementBenefit;
-  }
-
-  public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
-    this.statementBenefit = statementBenefit;
-  }
-
-  public OBStatement2Detail statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
-    if (this.statementFee == null) {
-      this.statementFee = new ArrayList<>();
+    public OBStatement2Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    this.statementFee.add(statementFeeItem);
-    return this;
-  }
 
-  /**
-   * Get statementFee
-   * @return statementFee
-  */
-  @Valid 
-  @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementFee")
-  public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
-    return statementFee;
-  }
-
-  public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
-    this.statementFee = statementFee;
-  }
-
-  public OBStatement2Detail statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
-    if (this.statementInterest == null) {
-      this.statementInterest = new ArrayList<>();
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    this.statementInterest.add(statementInterestItem);
-    return this;
-  }
 
-  /**
-   * Get statementInterest
-   * @return statementInterest
-  */
-  @Valid 
-  @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementInterest")
-  public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
-    return statementInterest;
-  }
-
-  public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
-    this.statementInterest = statementInterest;
-  }
-
-  public OBStatement2Detail statementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
-    this.statementAmount = statementAmount;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementAmountItem(OBStatement2StatementAmountInner statementAmountItem) {
-    if (this.statementAmount == null) {
-      this.statementAmount = new ArrayList<>();
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    this.statementAmount.add(statementAmountItem);
-    return this;
-  }
 
-  /**
-   * Get statementAmount
-   * @return statementAmount
-  */
-  @Valid 
-  @Schema(name = "StatementAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementAmount")
-  public List<@Valid OBStatement2StatementAmountInner> getStatementAmount() {
-    return statementAmount;
-  }
-
-  public void setStatementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
-    this.statementAmount = statementAmount;
-  }
-
-  public OBStatement2Detail statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
-    if (this.statementDateTime == null) {
-      this.statementDateTime = new ArrayList<>();
+    public OBStatement2Detail statementId(String statementId) {
+        this.statementId = statementId;
+        return this;
     }
-    this.statementDateTime.add(statementDateTimeItem);
-    return this;
-  }
 
-  /**
-   * Get statementDateTime
-   * @return statementDateTime
-  */
-  @Valid 
-  @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementDateTime")
-  public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
-    return statementDateTime;
-  }
-
-  public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
-    this.statementDateTime = statementDateTime;
-  }
-
-  public OBStatement2Detail statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
-    if (this.statementRate == null) {
-      this.statementRate = new ArrayList<>();
+    /**
+     * Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return statementId
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "StatementId", description = "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementId")
+    public String getStatementId() {
+        return statementId;
     }
-    this.statementRate.add(statementRateItem);
-    return this;
-  }
 
-  /**
-   * Get statementRate
-   * @return statementRate
-  */
-  @Valid 
-  @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementRate")
-  public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
-    return statementRate;
-  }
-
-  public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
-    this.statementRate = statementRate;
-  }
-
-  public OBStatement2Detail statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-    return this;
-  }
-
-  public OBStatement2Detail addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
-    if (this.statementValue == null) {
-      this.statementValue = new ArrayList<>();
+    public void setStatementId(String statementId) {
+        this.statementId = statementId;
     }
-    this.statementValue.add(statementValueItem);
-    return this;
-  }
 
-  /**
-   * Get statementValue
-   * @return statementValue
-  */
-  @Valid 
-  @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementValue")
-  public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
-    return statementValue;
-  }
-
-  public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
-    this.statementValue = statementValue;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2Detail statementReference(String statementReference) {
+        this.statementReference = statementReference;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Unique reference for the statement. This reference may be optionally populated if available.
+     *
+     * @return statementReference
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "StatementReference", description = "Unique reference for the statement. This reference may be optionally populated if available.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public String getStatementReference() {
+        return statementReference;
     }
-    OBStatement2Detail obStatement2Detail = (OBStatement2Detail) o;
-    return Objects.equals(this.accountId, obStatement2Detail.accountId) &&
-        Objects.equals(this.statementId, obStatement2Detail.statementId) &&
-        Objects.equals(this.statementReference, obStatement2Detail.statementReference) &&
-        Objects.equals(this.type, obStatement2Detail.type) &&
-        Objects.equals(this.startDateTime, obStatement2Detail.startDateTime) &&
-        Objects.equals(this.endDateTime, obStatement2Detail.endDateTime) &&
-        Objects.equals(this.creationDateTime, obStatement2Detail.creationDateTime) &&
-        Objects.equals(this.statementDescription, obStatement2Detail.statementDescription) &&
-        Objects.equals(this.statementBenefit, obStatement2Detail.statementBenefit) &&
-        Objects.equals(this.statementFee, obStatement2Detail.statementFee) &&
-        Objects.equals(this.statementInterest, obStatement2Detail.statementInterest) &&
-        Objects.equals(this.statementAmount, obStatement2Detail.statementAmount) &&
-        Objects.equals(this.statementDateTime, obStatement2Detail.statementDateTime) &&
-        Objects.equals(this.statementRate, obStatement2Detail.statementRate) &&
-        Objects.equals(this.statementValue, obStatement2Detail.statementValue);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementAmount, statementDateTime, statementRate, statementValue);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
-    sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
-    sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
-    sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
-    sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
-    sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
-    sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
-    sb.append("    statementAmount: ").append(toIndentedString(statementAmount)).append("\n");
-    sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
-    sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
-    sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setStatementReference(String statementReference) {
+        this.statementReference = statementReference;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBStatement2Detail type(OBExternalStatementType1Code type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public OBExternalStatementType1Code getType() {
+        return type;
+    }
+
+    public void setType(OBExternalStatementType1Code type) {
+        this.type = type;
+    }
+
+    public OBStatement2Detail startDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return startDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "StartDateTime", description = "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("StartDateTime")
+    public DateTime getStartDateTime() {
+        return startDateTime;
+    }
+
+    public void setStartDateTime(DateTime startDateTime) {
+        this.startDateTime = startDateTime;
+    }
+
+    public OBStatement2Detail endDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return endDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "EndDateTime", description = "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("EndDateTime")
+    public DateTime getEndDateTime() {
+        return endDateTime;
+    }
+
+    public void setEndDateTime(DateTime endDateTime) {
+        this.endDateTime = endDateTime;
+    }
+
+    public OBStatement2Detail creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBStatement2Detail statementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementDescriptionItem(String statementDescriptionItem) {
+        if (this.statementDescription == null) {
+            this.statementDescription = new ArrayList<>();
+        }
+        this.statementDescription.add(statementDescriptionItem);
+        return this;
+    }
+
+    /**
+     * Get statementDescription
+     *
+     * @return statementDescription
+     */
+
+    @Schema(name = "StatementDescription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDescription")
+    public List<@Size(min = 1, max = 500) String> getStatementDescription() {
+        return statementDescription;
+    }
+
+    public void setStatementDescription(List<@Size(min = 1, max = 500) String> statementDescription) {
+        this.statementDescription = statementDescription;
+    }
+
+    public OBStatement2Detail statementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementBenefitItem(OBStatement2StatementBenefitInner statementBenefitItem) {
+        if (this.statementBenefit == null) {
+            this.statementBenefit = new ArrayList<>();
+        }
+        this.statementBenefit.add(statementBenefitItem);
+        return this;
+    }
+
+    /**
+     * Get statementBenefit
+     *
+     * @return statementBenefit
+     */
+    @Valid
+    @Schema(name = "StatementBenefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementBenefit")
+    public List<@Valid OBStatement2StatementBenefitInner> getStatementBenefit() {
+        return statementBenefit;
+    }
+
+    public void setStatementBenefit(List<@Valid OBStatement2StatementBenefitInner> statementBenefit) {
+        this.statementBenefit = statementBenefit;
+    }
+
+    public OBStatement2Detail statementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementFeeItem(OBStatement2StatementFeeInner statementFeeItem) {
+        if (this.statementFee == null) {
+            this.statementFee = new ArrayList<>();
+        }
+        this.statementFee.add(statementFeeItem);
+        return this;
+    }
+
+    /**
+     * Get statementFee
+     *
+     * @return statementFee
+     */
+    @Valid
+    @Schema(name = "StatementFee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementFee")
+    public List<@Valid OBStatement2StatementFeeInner> getStatementFee() {
+        return statementFee;
+    }
+
+    public void setStatementFee(List<@Valid OBStatement2StatementFeeInner> statementFee) {
+        this.statementFee = statementFee;
+    }
+
+    public OBStatement2Detail statementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementInterestItem(OBStatement2StatementInterestInner statementInterestItem) {
+        if (this.statementInterest == null) {
+            this.statementInterest = new ArrayList<>();
+        }
+        this.statementInterest.add(statementInterestItem);
+        return this;
+    }
+
+    /**
+     * Get statementInterest
+     *
+     * @return statementInterest
+     */
+    @Valid
+    @Schema(name = "StatementInterest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementInterest")
+    public List<@Valid OBStatement2StatementInterestInner> getStatementInterest() {
+        return statementInterest;
+    }
+
+    public void setStatementInterest(List<@Valid OBStatement2StatementInterestInner> statementInterest) {
+        this.statementInterest = statementInterest;
+    }
+
+    public OBStatement2Detail statementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
+        this.statementAmount = statementAmount;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementAmountItem(OBStatement2StatementAmountInner statementAmountItem) {
+        if (this.statementAmount == null) {
+            this.statementAmount = new ArrayList<>();
+        }
+        this.statementAmount.add(statementAmountItem);
+        return this;
+    }
+
+    /**
+     * Get statementAmount
+     *
+     * @return statementAmount
+     */
+    @Valid
+    @Schema(name = "StatementAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementAmount")
+    public List<@Valid OBStatement2StatementAmountInner> getStatementAmount() {
+        return statementAmount;
+    }
+
+    public void setStatementAmount(List<@Valid OBStatement2StatementAmountInner> statementAmount) {
+        this.statementAmount = statementAmount;
+    }
+
+    public OBStatement2Detail statementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementDateTimeItem(OBStatement2StatementDateTimeInner statementDateTimeItem) {
+        if (this.statementDateTime == null) {
+            this.statementDateTime = new ArrayList<>();
+        }
+        this.statementDateTime.add(statementDateTimeItem);
+        return this;
+    }
+
+    /**
+     * Get statementDateTime
+     *
+     * @return statementDateTime
+     */
+    @Valid
+    @Schema(name = "StatementDateTime", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementDateTime")
+    public List<@Valid OBStatement2StatementDateTimeInner> getStatementDateTime() {
+        return statementDateTime;
+    }
+
+    public void setStatementDateTime(List<@Valid OBStatement2StatementDateTimeInner> statementDateTime) {
+        this.statementDateTime = statementDateTime;
+    }
+
+    public OBStatement2Detail statementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementRateItem(OBStatement2StatementRateInner statementRateItem) {
+        if (this.statementRate == null) {
+            this.statementRate = new ArrayList<>();
+        }
+        this.statementRate.add(statementRateItem);
+        return this;
+    }
+
+    /**
+     * Get statementRate
+     *
+     * @return statementRate
+     */
+    @Valid
+    @Schema(name = "StatementRate", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementRate")
+    public List<@Valid OBStatement2StatementRateInner> getStatementRate() {
+        return statementRate;
+    }
+
+    public void setStatementRate(List<@Valid OBStatement2StatementRateInner> statementRate) {
+        this.statementRate = statementRate;
+    }
+
+    public OBStatement2Detail statementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+        return this;
+    }
+
+    public OBStatement2Detail addStatementValueItem(OBStatement2StatementValueInner statementValueItem) {
+        if (this.statementValue == null) {
+            this.statementValue = new ArrayList<>();
+        }
+        this.statementValue.add(statementValueItem);
+        return this;
+    }
+
+    /**
+     * Get statementValue
+     *
+     * @return statementValue
+     */
+    @Valid
+    @Schema(name = "StatementValue", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementValue")
+    public List<@Valid OBStatement2StatementValueInner> getStatementValue() {
+        return statementValue;
+    }
+
+    public void setStatementValue(List<@Valid OBStatement2StatementValueInner> statementValue) {
+        this.statementValue = statementValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2Detail obStatement2Detail = (OBStatement2Detail) o;
+        return Objects.equals(this.accountId, obStatement2Detail.accountId) &&
+                Objects.equals(this.statementId, obStatement2Detail.statementId) &&
+                Objects.equals(this.statementReference, obStatement2Detail.statementReference) &&
+                Objects.equals(this.type, obStatement2Detail.type) &&
+                Objects.equals(this.startDateTime, obStatement2Detail.startDateTime) &&
+                Objects.equals(this.endDateTime, obStatement2Detail.endDateTime) &&
+                Objects.equals(this.creationDateTime, obStatement2Detail.creationDateTime) &&
+                Objects.equals(this.statementDescription, obStatement2Detail.statementDescription) &&
+                Objects.equals(this.statementBenefit, obStatement2Detail.statementBenefit) &&
+                Objects.equals(this.statementFee, obStatement2Detail.statementFee) &&
+                Objects.equals(this.statementInterest, obStatement2Detail.statementInterest) &&
+                Objects.equals(this.statementAmount, obStatement2Detail.statementAmount) &&
+                Objects.equals(this.statementDateTime, obStatement2Detail.statementDateTime) &&
+                Objects.equals(this.statementRate, obStatement2Detail.statementRate) &&
+                Objects.equals(this.statementValue, obStatement2Detail.statementValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, statementId, statementReference, type, startDateTime, endDateTime, creationDateTime, statementDescription, statementBenefit, statementFee, statementInterest, statementAmount, statementDateTime, statementRate, statementValue);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    statementId: ").append(toIndentedString(statementId)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    startDateTime: ").append(toIndentedString(startDateTime)).append("\n");
+        sb.append("    endDateTime: ").append(toIndentedString(endDateTime)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    statementDescription: ").append(toIndentedString(statementDescription)).append("\n");
+        sb.append("    statementBenefit: ").append(toIndentedString(statementBenefit)).append("\n");
+        sb.append("    statementFee: ").append(toIndentedString(statementFee)).append("\n");
+        sb.append("    statementInterest: ").append(toIndentedString(statementInterest)).append("\n");
+        sb.append("    statementAmount: ").append(toIndentedString(statementAmount)).append("\n");
+        sb.append("    statementDateTime: ").append(toIndentedString(statementDateTime)).append("\n");
+        sb.append("    statementRate: ").append(toIndentedString(statementRate)).append("\n");
+        sb.append("    statementValue: ").append(toIndentedString(statementValue)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmountInner.java
@@ -34,124 +34,129 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementAmountInner {
 
-  private OBCreditDebitCode0 creditDebitIndicator;
+    private OBCreditDebitCode0 creditDebitIndicator;
 
-  private String type;
+    private String type;
 
-  private OBActiveOrHistoricCurrencyAndAmount8 amount;
+    private OBActiveOrHistoricCurrencyAndAmount8 amount;
 
-  public OBStatement2StatementAmountInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementAmountInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount8 amount) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.type = type;
-    this.amount = amount;
-  }
-
-  public OBStatement2StatementAmountInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode0 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBStatement2StatementAmountInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Amount type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Amount type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public OBStatement2StatementAmountInner amount(OBActiveOrHistoricCurrencyAndAmount8 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount8 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount8 amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementAmountInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementAmountInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount8 amount) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.type = type;
+        this.amount = amount;
     }
-    OBStatement2StatementAmountInner obStatement2StatementAmountInner = (OBStatement2StatementAmountInner) o;
-    return Objects.equals(this.creditDebitIndicator, obStatement2StatementAmountInner.creditDebitIndicator) &&
-        Objects.equals(this.type, obStatement2StatementAmountInner.type) &&
-        Objects.equals(this.amount, obStatement2StatementAmountInner.amount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(creditDebitIndicator, type, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementAmountInner {\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementAmountInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode0 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBStatement2StatementAmountInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Amount type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Amount type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public OBStatement2StatementAmountInner amount(OBActiveOrHistoricCurrencyAndAmount8 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount8 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount8 amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementAmountInner obStatement2StatementAmountInner = (OBStatement2StatementAmountInner) o;
+        return Objects.equals(this.creditDebitIndicator, obStatement2StatementAmountInner.creditDebitIndicator) &&
+                Objects.equals(this.type, obStatement2StatementAmountInner.type) &&
+                Objects.equals(this.amount, obStatement2StatementAmountInner.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(creditDebitIndicator, type, amount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementAmountInner {\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefitInner.java
@@ -15,15 +15,25 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount5;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details of a benefit or reward amount for the statement resource.
@@ -34,99 +44,102 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementBenefitInner {
 
-  private String type;
+    private String type;
 
-  private OBActiveOrHistoricCurrencyAndAmount5 amount;
+    private OBActiveOrHistoricCurrencyAndAmount5 amount;
 
-  public OBStatement2StatementBenefitInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementBenefitInner(String type, OBActiveOrHistoricCurrencyAndAmount5 amount) {
-    this.type = type;
-    this.amount = amount;
-  }
-
-  public OBStatement2StatementBenefitInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Benefit type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Benefit type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public OBStatement2StatementBenefitInner amount(OBActiveOrHistoricCurrencyAndAmount5 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount5 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount5 amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementBenefitInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementBenefitInner(String type, OBActiveOrHistoricCurrencyAndAmount5 amount) {
+        this.type = type;
+        this.amount = amount;
     }
-    OBStatement2StatementBenefitInner obStatement2StatementBenefitInner = (OBStatement2StatementBenefitInner) o;
-    return Objects.equals(this.type, obStatement2StatementBenefitInner.type) &&
-        Objects.equals(this.amount, obStatement2StatementBenefitInner.amount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(type, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementBenefitInner {\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementBenefitInner type(String type) {
+        this.type = type;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Benefit type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Benefit type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public OBStatement2StatementBenefitInner amount(OBActiveOrHistoricCurrencyAndAmount5 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount5 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount5 amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementBenefitInner obStatement2StatementBenefitInner = (OBStatement2StatementBenefitInner) o;
+        return Objects.equals(this.type, obStatement2StatementBenefitInner.type) &&
+                Objects.equals(this.amount, obStatement2StatementBenefitInner.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, amount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementBenefitInner {\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTimeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTimeInner.java
@@ -15,18 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.time.OffsetDateTime;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details of a generic date time for the statement resource.
@@ -37,100 +45,103 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementDateTimeInner {
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime dateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime dateTime;
 
-  private String type;
+    private String type;
 
-  public OBStatement2StatementDateTimeInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementDateTimeInner(DateTime dateTime, String type) {
-    this.dateTime = dateTime;
-    this.type = type;
-  }
-
-  public OBStatement2StatementDateTimeInner dateTime(DateTime dateTime) {
-    this.dateTime = dateTime;
-    return this;
-  }
-
-  /**
-   * Date and time associated with the date time type.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return dateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "DateTime", description = "Date and time associated with the date time type.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("DateTime")
-  public DateTime getDateTime() {
-    return dateTime;
-  }
-
-  public void setDateTime(DateTime dateTime) {
-    this.dateTime = dateTime;
-  }
-
-  public OBStatement2StatementDateTimeInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Date time type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Date time type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementDateTimeInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementDateTimeInner(DateTime dateTime, String type) {
+        this.dateTime = dateTime;
+        this.type = type;
     }
-    OBStatement2StatementDateTimeInner obStatement2StatementDateTimeInner = (OBStatement2StatementDateTimeInner) o;
-    return Objects.equals(this.dateTime, obStatement2StatementDateTimeInner.dateTime) &&
-        Objects.equals(this.type, obStatement2StatementDateTimeInner.type);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(dateTime, type);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementDateTimeInner {\n");
-    sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementDateTimeInner dateTime(DateTime dateTime) {
+        this.dateTime = dateTime;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Date and time associated with the date time type.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return dateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "DateTime", description = "Date and time associated with the date time type.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("DateTime")
+    public DateTime getDateTime() {
+        return dateTime;
+    }
+
+    public void setDateTime(DateTime dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    public OBStatement2StatementDateTimeInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Date time type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Date time type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementDateTimeInner obStatement2StatementDateTimeInner = (OBStatement2StatementDateTimeInner) o;
+        return Objects.equals(this.dateTime, obStatement2StatementDateTimeInner.dateTime) &&
+                Objects.equals(this.type, obStatement2StatementDateTimeInner.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dateTime, type);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementDateTimeInner {\n");
+        sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFeeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFeeInner.java
@@ -17,17 +17,29 @@ package uk.org.openbanking.datamodel.account;
 
 import static uk.org.openbanking.datamodel.utils.EqualityVerificationUtil.BigDecimalUtil.isEqual;
 
-import java.math.BigDecimal;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.math.BigDecimal;
+
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount6;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode0;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details of a fee for the statement resource.
@@ -38,221 +50,230 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementFeeInner {
 
-  private String description;
+    private String description;
 
-  private OBCreditDebitCode0 creditDebitIndicator;
+    private OBCreditDebitCode0 creditDebitIndicator;
 
-  private String type;
+    private String type;
 
-  private BigDecimal rate;
+    private BigDecimal rate;
 
-  private String rateType;
+    private String rateType;
 
-  private String frequency;
+    private String frequency;
 
-  private OBActiveOrHistoricCurrencyAndAmount6 amount;
+    private OBActiveOrHistoricCurrencyAndAmount6 amount;
 
-  public OBStatement2StatementFeeInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementFeeInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount6 amount) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.type = type;
-    this.amount = amount;
-  }
-
-  public OBStatement2StatementFeeInner description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description that may be available for the statement fee.
-   * @return description
-  */
-  @Size(min = 1, max = 128) 
-  @Schema(name = "Description", description = "Description that may be available for the statement fee.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBStatement2StatementFeeInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode0 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBStatement2StatementFeeInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Fee type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Fee type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public OBStatement2StatementFeeInner rate(BigDecimal rate) {
-    this.rate = rate;
-    return this;
-  }
-
-  /**
-   * Rate charged for Statement Fee (where it is charged in terms of a rate rather than an amount)
-   * @return rate
-  */
-  @Valid 
-  @Schema(name = "Rate", description = "Rate charged for Statement Fee (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Rate")
-  public BigDecimal getRate() {
-    return rate;
-  }
-
-  public void setRate(BigDecimal rate) {
-    this.rate = rate;
-  }
-
-  public OBStatement2StatementFeeInner rateType(String rateType) {
-    this.rateType = rateType;
-    return this;
-  }
-
-  /**
-   * Description that may be available for the statement fee rate type.
-   * @return rateType
-  */
-  
-  @Schema(name = "RateType", description = "Description that may be available for the statement fee rate type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RateType")
-  public String getRateType() {
-    return rateType;
-  }
-
-  public void setRateType(String rateType) {
-    this.rateType = rateType;
-  }
-
-  public OBStatement2StatementFeeInner frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * How frequently the fee is applied to the Account.
-   * @return frequency
-  */
-  
-  @Schema(name = "Frequency", description = "How frequently the fee is applied to the Account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBStatement2StatementFeeInner amount(OBActiveOrHistoricCurrencyAndAmount6 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount6 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount6 amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementFeeInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementFeeInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount6 amount) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.type = type;
+        this.amount = amount;
     }
-    OBStatement2StatementFeeInner obStatement2StatementFeeInner = (OBStatement2StatementFeeInner) o;
-    return Objects.equals(this.description, obStatement2StatementFeeInner.description) &&
-        Objects.equals(this.creditDebitIndicator, obStatement2StatementFeeInner.creditDebitIndicator) &&
-        Objects.equals(this.type, obStatement2StatementFeeInner.type) &&
-        // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
-        isEqual(this.rate, obStatement2StatementFeeInner.rate) &&
-        Objects.equals(this.rateType, obStatement2StatementFeeInner.rateType) &&
-        Objects.equals(this.frequency, obStatement2StatementFeeInner.frequency) &&
-        Objects.equals(this.amount, obStatement2StatementFeeInner.amount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(description, creditDebitIndicator, type, rate, rateType, frequency, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementFeeInner {\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
-    sb.append("    rateType: ").append(toIndentedString(rateType)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementFeeInner description(String description) {
+        this.description = description;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Description that may be available for the statement fee.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 128)
+    @Schema(name = "Description", description = "Description that may be available for the statement fee.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBStatement2StatementFeeInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode0 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBStatement2StatementFeeInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Fee type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Fee type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public OBStatement2StatementFeeInner rate(BigDecimal rate) {
+        this.rate = rate;
+        return this;
+    }
+
+    /**
+     * Rate charged for Statement Fee (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return rate
+     */
+    @Valid
+    @Schema(name = "Rate", description = "Rate charged for Statement Fee (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Rate")
+    public BigDecimal getRate() {
+        return rate;
+    }
+
+    public void setRate(BigDecimal rate) {
+        this.rate = rate;
+    }
+
+    public OBStatement2StatementFeeInner rateType(String rateType) {
+        this.rateType = rateType;
+        return this;
+    }
+
+    /**
+     * Description that may be available for the statement fee rate type.
+     *
+     * @return rateType
+     */
+
+    @Schema(name = "RateType", description = "Description that may be available for the statement fee rate type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RateType")
+    public String getRateType() {
+        return rateType;
+    }
+
+    public void setRateType(String rateType) {
+        this.rateType = rateType;
+    }
+
+    public OBStatement2StatementFeeInner frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * How frequently the fee is applied to the Account.
+     *
+     * @return frequency
+     */
+
+    @Schema(name = "Frequency", description = "How frequently the fee is applied to the Account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBStatement2StatementFeeInner amount(OBActiveOrHistoricCurrencyAndAmount6 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount6 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount6 amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementFeeInner obStatement2StatementFeeInner = (OBStatement2StatementFeeInner) o;
+        return Objects.equals(this.description, obStatement2StatementFeeInner.description) &&
+                Objects.equals(this.creditDebitIndicator, obStatement2StatementFeeInner.creditDebitIndicator) &&
+                Objects.equals(this.type, obStatement2StatementFeeInner.type) &&
+                // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
+                isEqual(this.rate, obStatement2StatementFeeInner.rate) &&
+                Objects.equals(this.rateType, obStatement2StatementFeeInner.rateType) &&
+                Objects.equals(this.frequency, obStatement2StatementFeeInner.frequency) &&
+                Objects.equals(this.amount, obStatement2StatementFeeInner.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, creditDebitIndicator, type, rate, rateType, frequency, amount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementFeeInner {\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
+        sb.append("    rateType: ").append(toIndentedString(rateType)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterestInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterestInner.java
@@ -17,17 +17,29 @@ package uk.org.openbanking.datamodel.account;
 
 import static uk.org.openbanking.datamodel.utils.EqualityVerificationUtil.BigDecimalUtil.isEqual;
 
-import java.math.BigDecimal;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.math.BigDecimal;
+
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount7;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode0;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to provide details of a generic interest amount related to the statement resource.
@@ -38,221 +50,230 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementInterestInner {
 
-  private String description;
+    private String description;
 
-  private OBCreditDebitCode0 creditDebitIndicator;
+    private OBCreditDebitCode0 creditDebitIndicator;
 
-  private String type;
+    private String type;
 
-  private BigDecimal rate;
+    private BigDecimal rate;
 
-  private String rateType;
+    private String rateType;
 
-  private String frequency;
+    private String frequency;
 
-  private OBActiveOrHistoricCurrencyAndAmount7 amount;
+    private OBActiveOrHistoricCurrencyAndAmount7 amount;
 
-  public OBStatement2StatementInterestInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementInterestInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount7 amount) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.type = type;
-    this.amount = amount;
-  }
-
-  public OBStatement2StatementInterestInner description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description that may be available for the statement interest.
-   * @return description
-  */
-  @Size(min = 1, max = 128) 
-  @Schema(name = "Description", description = "Description that may be available for the statement interest.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public OBStatement2StatementInterestInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode0 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBStatement2StatementInterestInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Interest amount type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Interest amount type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public OBStatement2StatementInterestInner rate(BigDecimal rate) {
-    this.rate = rate;
-    return this;
-  }
-
-  /**
-   * field representing a percentage (e.g. 0.05 represents 5% and 0.9525 represents 95.25%). Note the number of decimal places may vary.
-   * @return rate
-  */
-  @Valid 
-  @Schema(name = "Rate", description = "field representing a percentage (e.g. 0.05 represents 5% and 0.9525 represents 95.25%). Note the number of decimal places may vary.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Rate")
-  public BigDecimal getRate() {
-    return rate;
-  }
-
-  public void setRate(BigDecimal rate) {
-    this.rate = rate;
-  }
-
-  public OBStatement2StatementInterestInner rateType(String rateType) {
-    this.rateType = rateType;
-    return this;
-  }
-
-  /**
-   * Description that may be available for the statement Interest rate type.
-   * @return rateType
-  */
-  
-  @Schema(name = "RateType", description = "Description that may be available for the statement Interest rate type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RateType")
-  public String getRateType() {
-    return rateType;
-  }
-
-  public void setRateType(String rateType) {
-    this.rateType = rateType;
-  }
-
-  public OBStatement2StatementInterestInner frequency(String frequency) {
-    this.frequency = frequency;
-    return this;
-  }
-
-  /**
-   * Specifies the statement fee type requested
-   * @return frequency
-  */
-  
-  @Schema(name = "Frequency", description = "Specifies the statement fee type requested", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Frequency")
-  public String getFrequency() {
-    return frequency;
-  }
-
-  public void setFrequency(String frequency) {
-    this.frequency = frequency;
-  }
-
-  public OBStatement2StatementInterestInner amount(OBActiveOrHistoricCurrencyAndAmount7 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount7 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount7 amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementInterestInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementInterestInner(OBCreditDebitCode0 creditDebitIndicator, String type, OBActiveOrHistoricCurrencyAndAmount7 amount) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.type = type;
+        this.amount = amount;
     }
-    OBStatement2StatementInterestInner obStatement2StatementInterestInner = (OBStatement2StatementInterestInner) o;
-    return Objects.equals(this.description, obStatement2StatementInterestInner.description) &&
-        Objects.equals(this.creditDebitIndicator, obStatement2StatementInterestInner.creditDebitIndicator) &&
-        Objects.equals(this.type, obStatement2StatementInterestInner.type) &&
-        // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
-        isEqual(this.rate, obStatement2StatementInterestInner.rate) &&
-        Objects.equals(this.rateType, obStatement2StatementInterestInner.rateType) &&
-        Objects.equals(this.frequency, obStatement2StatementInterestInner.frequency) &&
-        Objects.equals(this.amount, obStatement2StatementInterestInner.amount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(description, creditDebitIndicator, type, rate, rateType, frequency, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementInterestInner {\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
-    sb.append("    rateType: ").append(toIndentedString(rateType)).append("\n");
-    sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementInterestInner description(String description) {
+        this.description = description;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Description that may be available for the statement interest.
+     *
+     * @return description
+     */
+    @Size(min = 1, max = 128)
+    @Schema(name = "Description", description = "Description that may be available for the statement interest.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public OBStatement2StatementInterestInner creditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode0 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode0 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBStatement2StatementInterestInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Interest amount type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Interest amount type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public OBStatement2StatementInterestInner rate(BigDecimal rate) {
+        this.rate = rate;
+        return this;
+    }
+
+    /**
+     * field representing a percentage (e.g. 0.05 represents 5% and 0.9525 represents 95.25%). Note the number of decimal places may vary.
+     *
+     * @return rate
+     */
+    @Valid
+    @Schema(name = "Rate", description = "field representing a percentage (e.g. 0.05 represents 5% and 0.9525 represents 95.25%). Note the number of decimal places may vary.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Rate")
+    public BigDecimal getRate() {
+        return rate;
+    }
+
+    public void setRate(BigDecimal rate) {
+        this.rate = rate;
+    }
+
+    public OBStatement2StatementInterestInner rateType(String rateType) {
+        this.rateType = rateType;
+        return this;
+    }
+
+    /**
+     * Description that may be available for the statement Interest rate type.
+     *
+     * @return rateType
+     */
+
+    @Schema(name = "RateType", description = "Description that may be available for the statement Interest rate type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RateType")
+    public String getRateType() {
+        return rateType;
+    }
+
+    public void setRateType(String rateType) {
+        this.rateType = rateType;
+    }
+
+    public OBStatement2StatementInterestInner frequency(String frequency) {
+        this.frequency = frequency;
+        return this;
+    }
+
+    /**
+     * Specifies the statement fee type requested
+     *
+     * @return frequency
+     */
+
+    @Schema(name = "Frequency", description = "Specifies the statement fee type requested", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Frequency")
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public OBStatement2StatementInterestInner amount(OBActiveOrHistoricCurrencyAndAmount7 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount7 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount7 amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementInterestInner obStatement2StatementInterestInner = (OBStatement2StatementInterestInner) o;
+        return Objects.equals(this.description, obStatement2StatementInterestInner.description) &&
+                Objects.equals(this.creditDebitIndicator, obStatement2StatementInterestInner.creditDebitIndicator) &&
+                Objects.equals(this.type, obStatement2StatementInterestInner.type) &&
+                // TODO: temporary fix for https://github.com/SecureApiGateway/SecureApiGateway/issues/981
+                isEqual(this.rate, obStatement2StatementInterestInner.rate) &&
+                Objects.equals(this.rateType, obStatement2StatementInterestInner.rateType) &&
+                Objects.equals(this.frequency, obStatement2StatementInterestInner.frequency) &&
+                Objects.equals(this.amount, obStatement2StatementInterestInner.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, creditDebitIndicator, type, rate, rateType, frequency, amount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementInterestInner {\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
+        sb.append("    rateType: ").append(toIndentedString(rateType)).append("\n");
+        sb.append("    frequency: ").append(toIndentedString(frequency)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRateInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRateInner.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Set of elements used to provide details of a generic rate related to the statement resource.
@@ -34,99 +42,102 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementRateInner {
 
-  private String rate;
+    private String rate;
 
-  private String type;
+    private String type;
 
-  public OBStatement2StatementRateInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementRateInner(String rate, String type) {
-    this.rate = rate;
-    this.type = type;
-  }
-
-  public OBStatement2StatementRateInner rate(String rate) {
-    this.rate = rate;
-    return this;
-  }
-
-  /**
-   * Rate associated with the statement rate type.
-   * @return rate
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "Rate", description = "Rate associated with the statement rate type.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Rate")
-  public String getRate() {
-    return rate;
-  }
-
-  public void setRate(String rate) {
-    this.rate = rate;
-  }
-
-  public OBStatement2StatementRateInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Statement rate type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Statement rate type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementRateInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementRateInner(String rate, String type) {
+        this.rate = rate;
+        this.type = type;
     }
-    OBStatement2StatementRateInner obStatement2StatementRateInner = (OBStatement2StatementRateInner) o;
-    return Objects.equals(this.rate, obStatement2StatementRateInner.rate) &&
-        Objects.equals(this.type, obStatement2StatementRateInner.type);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(rate, type);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementRateInner {\n");
-    sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementRateInner rate(String rate) {
+        this.rate = rate;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Rate associated with the statement rate type.
+     *
+     * @return rate
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "Rate", description = "Rate associated with the statement rate type.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Rate")
+    public String getRate() {
+        return rate;
+    }
+
+    public void setRate(String rate) {
+        this.rate = rate;
+    }
+
+    public OBStatement2StatementRateInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Statement rate type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Statement rate type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementRateInner obStatement2StatementRateInner = (OBStatement2StatementRateInner) o;
+        return Objects.equals(this.rate, obStatement2StatementRateInner.rate) &&
+                Objects.equals(this.type, obStatement2StatementRateInner.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rate, type);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementRateInner {\n");
+        sb.append("    rate: ").append(toIndentedString(rate)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValueInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValueInner.java
@@ -34,99 +34,102 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBStatement2StatementValueInner {
 
-  private String value;
+    private String value;
 
-  private String type;
+    private String type;
 
-  public OBStatement2StatementValueInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBStatement2StatementValueInner(String value, String type) {
-    this.value = value;
-    this.type = type;
-  }
-
-  public OBStatement2StatementValueInner value(String value) {
-    this.value = value;
-    return this;
-  }
-
-  /**
-   * Value associated with the statement value type.
-   * @return value
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "Value", description = "Value associated with the statement value type.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Value")
-  public String getValue() {
-    return value;
-  }
-
-  public void setValue(String value) {
-    this.value = value;
-  }
-
-  public OBStatement2StatementValueInner type(String type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Statement value type, in a coded form.
-   * @return type
-  */
-  @NotNull 
-  @Schema(name = "Type", description = "Statement value type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBStatement2StatementValueInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBStatement2StatementValueInner(String value, String type) {
+        this.value = value;
+        this.type = type;
     }
-    OBStatement2StatementValueInner obStatement2StatementValueInner = (OBStatement2StatementValueInner) o;
-    return Objects.equals(this.value, obStatement2StatementValueInner.value) &&
-        Objects.equals(this.type, obStatement2StatementValueInner.type);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(value, type);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBStatement2StatementValueInner {\n");
-    sb.append("    value: ").append(toIndentedString(value)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBStatement2StatementValueInner value(String value) {
+        this.value = value;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Value associated with the statement value type.
+     *
+     * @return value
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "Value", description = "Value associated with the statement value type.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Value")
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public OBStatement2StatementValueInner type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Statement value type, in a coded form.
+     *
+     * @return type
+     */
+    @NotNull
+    @Schema(name = "Type", description = "Statement value type, in a coded form.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatement2StatementValueInner obStatement2StatementValueInner = (OBStatement2StatementValueInner) o;
+        return Objects.equals(this.value, obStatement2StatementValueInner.value) &&
+                Objects.equals(this.type, obStatement2StatementValueInner.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, type);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatement2StatementValueInner {\n");
+        sb.append("    value: ").append(toIndentedString(value)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
@@ -39,642 +39,670 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransaction6 {
 
-  private String accountId;
+    private String accountId;
 
-  private String transactionId;
+    private String transactionId;
 
-  private String transactionReference;
+    private String transactionReference;
 
-  @Valid
-  private List<@Valid String> statementReference;
+    @Valid
+    private List<@Valid String> statementReference;
 
-  private OBCreditDebitCode1 creditDebitIndicator;
+    private OBCreditDebitCode1 creditDebitIndicator;
 
-  private OBEntryStatus1Code status;
+    private OBEntryStatus1Code status;
 
-  private OBTransactionMutability1Code transactionMutability;
+    private OBTransactionMutability1Code transactionMutability;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime bookingDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime bookingDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime valueDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime valueDateTime;
 
-  private String transactionInformation;
+    private String transactionInformation;
 
-  private String addressLine;
+    private String addressLine;
 
-  private OBActiveOrHistoricCurrencyAndAmount9 amount;
+    private OBActiveOrHistoricCurrencyAndAmount9 amount;
 
-  private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
+    private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
 
-  private OBCurrencyExchange5 currencyExchange;
+    private OBCurrencyExchange5 currencyExchange;
 
-  private OBBankTransactionCodeStructure1 bankTransactionCode;
+    private OBBankTransactionCodeStructure1 bankTransactionCode;
 
-  private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
+    private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
 
-  private OBTransactionCashBalance balance;
+    private OBTransactionCashBalance balance;
 
-  private OBMerchantDetails1 merchantDetails;
+    private OBMerchantDetails1 merchantDetails;
 
-  private OBBranchAndFinancialInstitutionIdentification61 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification61 creditorAgent;
 
-  private OBCashAccount60 creditorAccount;
+    private OBCashAccount60 creditorAccount;
 
-  private OBBranchAndFinancialInstitutionIdentification62 debtorAgent;
+    private OBBranchAndFinancialInstitutionIdentification62 debtorAgent;
 
-  private OBCashAccount61 debtorAccount;
+    private OBCashAccount61 debtorAccount;
 
-  private OBTransactionCardInstrument1 cardInstrument;
+    private OBTransactionCardInstrument1 cardInstrument;
 
-  @Valid
-  private OBSupplementaryData1 supplementaryData;
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBTransaction6() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransaction6(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.accountId = accountId;
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.status = status;
-    this.bookingDateTime = bookingDateTime;
-    this.amount = amount;
-  }
-
-  public OBTransaction6 accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBTransaction6 transactionId(String transactionId) {
-    this.transactionId = transactionId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
-   * @return transactionId
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionId")
-  public String getTransactionId() {
-    return transactionId;
-  }
-
-  public void setTransactionId(String transactionId) {
-    this.transactionId = transactionId;
-  }
-
-  public OBTransaction6 transactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
-   * @return transactionReference
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionReference")
-  public String getTransactionReference() {
-    return transactionReference;
-  }
-
-  public void setTransactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-  }
-
-  public OBTransaction6 statementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  public OBTransaction6 addStatementReferenceItem(String statementReferenceItem) {
-    if (this.statementReference == null) {
-      this.statementReference = new ArrayList<>();
+    public OBTransaction6() {
+        super();
     }
-    this.statementReference.add(statementReferenceItem);
-    return this;
-  }
 
-  /**
-   * Get statementReference
-   * @return statementReference
-  */
-  
-  @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public List<@Valid String> getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBTransaction6 creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode1 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBTransaction6 status(OBEntryStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @NotNull @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Status")
-  public OBEntryStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBEntryStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBTransaction6 transactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-    return this;
-  }
-
-  /**
-   * Get transactionMutability
-   * @return transactionMutability
-  */
-  @Valid 
-  @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionMutability")
-  public OBTransactionMutability1Code getTransactionMutability() {
-    return transactionMutability;
-  }
-
-  public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-  }
-
-  public OBTransaction6 bookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return bookingDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("BookingDateTime")
-  public DateTime getBookingDateTime() {
-    return bookingDateTime;
-  }
-
-  public void setBookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-  }
-
-  public OBTransaction6 valueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return valueDateTime
-  */
-  @Valid 
-  @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ValueDateTime")
-  public DateTime getValueDateTime() {
-    return valueDateTime;
-  }
-
-  public void setValueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-  }
-
-  public OBTransaction6 transactionInformation(String transactionInformation) {
-    this.transactionInformation = transactionInformation;
-    return this;
-  }
-
-  /**
-   * Further details of the transaction.  This is the transaction narrative, which is unstructured text.
-   * @return transactionInformation
-  */
-  @Size(min = 1, max = 500) 
-  @Schema(name = "TransactionInformation", description = "Further details of the transaction.  This is the transaction narrative, which is unstructured text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionInformation")
-  public String getTransactionInformation() {
-    return transactionInformation;
-  }
-
-  public void setTransactionInformation(String transactionInformation) {
-    this.transactionInformation = transactionInformation;
-  }
-
-  public OBTransaction6 addressLine(String addressLine) {
-    this.addressLine = addressLine;
-    return this;
-  }
-
-  /**
-   * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
-   * @return addressLine
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AddressLine")
-  public String getAddressLine() {
-    return addressLine;
-  }
-
-  public void setAddressLine(String addressLine) {
-    this.addressLine = addressLine;
-  }
-
-  public OBTransaction6 amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-  }
-
-  public OBTransaction6 chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-    return this;
-  }
-
-  /**
-   * Get chargeAmount
-   * @return chargeAmount
-  */
-  @Valid 
-  @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ChargeAmount")
-  public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
-    return chargeAmount;
-  }
-
-  public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-  }
-
-  public OBTransaction6 currencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-    return this;
-  }
-
-  /**
-   * Get currencyExchange
-   * @return currencyExchange
-  */
-  @Valid 
-  @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CurrencyExchange")
-  public OBCurrencyExchange5 getCurrencyExchange() {
-    return currencyExchange;
-  }
-
-  public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-  }
-
-  public OBTransaction6 bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get bankTransactionCode
-   * @return bankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankTransactionCode")
-  public OBBankTransactionCodeStructure1 getBankTransactionCode() {
-    return bankTransactionCode;
-  }
-
-  public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-  }
-
-  public OBTransaction6 proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get proprietaryBankTransactionCode
-   * @return proprietaryBankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProprietaryBankTransactionCode")
-  public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
-    return proprietaryBankTransactionCode;
-  }
-
-  public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-  }
-
-  public OBTransaction6 balance(OBTransactionCashBalance balance) {
-    this.balance = balance;
-    return this;
-  }
-
-  /**
-   * Get balance
-   * @return balance
-  */
-  @Valid 
-  @Schema(name = "Balance", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Balance")
-  public OBTransactionCashBalance getBalance() {
-    return balance;
-  }
-
-  public void setBalance(OBTransactionCashBalance balance) {
-    this.balance = balance;
-  }
-
-  public OBTransaction6 merchantDetails(OBMerchantDetails1 merchantDetails) {
-    this.merchantDetails = merchantDetails;
-    return this;
-  }
-
-  /**
-   * Get merchantDetails
-   * @return merchantDetails
-  */
-  @Valid 
-  @Schema(name = "MerchantDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MerchantDetails")
-  public OBMerchantDetails1 getMerchantDetails() {
-    return merchantDetails;
-  }
-
-  public void setMerchantDetails(OBMerchantDetails1 merchantDetails) {
-    this.merchantDetails = merchantDetails;
-  }
-
-  public OBTransaction6 creditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification61 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBTransaction6 creditorAccount(OBCashAccount60 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount60 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount60 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBTransaction6 debtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
-    this.debtorAgent = debtorAgent;
-    return this;
-  }
-
-  /**
-   * Get debtorAgent
-   * @return debtorAgent
-  */
-  @Valid 
-  @Schema(name = "DebtorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorAgent")
-  public OBBranchAndFinancialInstitutionIdentification62 getDebtorAgent() {
-    return debtorAgent;
-  }
-
-  public void setDebtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
-    this.debtorAgent = debtorAgent;
-  }
-
-  public OBTransaction6 debtorAccount(OBCashAccount61 debtorAccount) {
-    this.debtorAccount = debtorAccount;
-    return this;
-  }
-
-  /**
-   * Get debtorAccount
-   * @return debtorAccount
-  */
-  @Valid 
-  @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorAccount")
-  public OBCashAccount61 getDebtorAccount() {
-    return debtorAccount;
-  }
-
-  public void setDebtorAccount(OBCashAccount61 debtorAccount) {
-    this.debtorAccount = debtorAccount;
-  }
-
-  public OBTransaction6 cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-    return this;
-  }
-
-  /**
-   * Get cardInstrument
-   * @return cardInstrument
-  */
-  @Valid 
-  @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CardInstrument")
-  public OBTransactionCardInstrument1 getCardInstrument() {
-    return cardInstrument;
-  }
-
-  public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-  }
-
-  public OBTransaction6 supplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public OBSupplementaryData1 getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransaction6(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.accountId = accountId;
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.status = status;
+        this.bookingDateTime = bookingDateTime;
+        this.amount = amount;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OBTransaction6 accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    OBTransaction6 obTransaction6 = (OBTransaction6) o;
-    return Objects.equals(this.accountId, obTransaction6.accountId) &&
-        Objects.equals(this.transactionId, obTransaction6.transactionId) &&
-        Objects.equals(this.transactionReference, obTransaction6.transactionReference) &&
-        Objects.equals(this.statementReference, obTransaction6.statementReference) &&
-        Objects.equals(this.creditDebitIndicator, obTransaction6.creditDebitIndicator) &&
-        Objects.equals(this.status, obTransaction6.status) &&
-        Objects.equals(this.transactionMutability, obTransaction6.transactionMutability) &&
-        Objects.equals(this.bookingDateTime, obTransaction6.bookingDateTime) &&
-        Objects.equals(this.valueDateTime, obTransaction6.valueDateTime) &&
-        Objects.equals(this.transactionInformation, obTransaction6.transactionInformation) &&
-        Objects.equals(this.addressLine, obTransaction6.addressLine) &&
-        Objects.equals(this.amount, obTransaction6.amount) &&
-        Objects.equals(this.chargeAmount, obTransaction6.chargeAmount) &&
-        Objects.equals(this.currencyExchange, obTransaction6.currencyExchange) &&
-        Objects.equals(this.bankTransactionCode, obTransaction6.bankTransactionCode) &&
-        Objects.equals(this.proprietaryBankTransactionCode, obTransaction6.proprietaryBankTransactionCode) &&
-        Objects.equals(this.balance, obTransaction6.balance) &&
-        Objects.equals(this.merchantDetails, obTransaction6.merchantDetails) &&
-        Objects.equals(this.creditorAgent, obTransaction6.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obTransaction6.creditorAccount) &&
-        Objects.equals(this.debtorAgent, obTransaction6.debtorAgent) &&
-        Objects.equals(this.debtorAccount, obTransaction6.debtorAccount) &&
-        Objects.equals(this.cardInstrument, obTransaction6.cardInstrument) &&
-        Objects.equals(this.supplementaryData, obTransaction6.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, transactionInformation, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, balance, merchantDetails, creditorAgent, creditorAccount, debtorAgent, debtorAccount, cardInstrument, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransaction6 {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
-    sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
-    sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
-    sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
-    sb.append("    transactionInformation: ").append(toIndentedString(transactionInformation)).append("\n");
-    sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
-    sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
-    sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
-    sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
-    sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
-    sb.append("    merchantDetails: ").append(toIndentedString(merchantDetails)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("    debtorAgent: ").append(toIndentedString(debtorAgent)).append("\n");
-    sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
-    sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public OBTransaction6 transactionId(String transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    /**
+     * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return transactionId
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionId")
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public OBTransaction6 transactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+        return this;
+    }
+
+    /**
+     * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
+     *
+     * @return transactionReference
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionReference")
+    public String getTransactionReference() {
+        return transactionReference;
+    }
+
+    public void setTransactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+    }
+
+    public OBTransaction6 statementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+        return this;
+    }
+
+    public OBTransaction6 addStatementReferenceItem(String statementReferenceItem) {
+        if (this.statementReference == null) {
+            this.statementReference = new ArrayList<>();
+        }
+        this.statementReference.add(statementReferenceItem);
+        return this;
+    }
+
+    /**
+     * Get statementReference
+     *
+     * @return statementReference
+     */
+
+    @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public List<@Valid String> getStatementReference() {
+        return statementReference;
+    }
+
+    public void setStatementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+    }
+
+    public OBTransaction6 creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode1 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBTransaction6 status(OBEntryStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Status")
+    public OBEntryStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBEntryStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBTransaction6 transactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+        return this;
+    }
+
+    /**
+     * Get transactionMutability
+     *
+     * @return transactionMutability
+     */
+    @Valid
+    @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionMutability")
+    public OBTransactionMutability1Code getTransactionMutability() {
+        return transactionMutability;
+    }
+
+    public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+    }
+
+    public OBTransaction6 bookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return bookingDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("BookingDateTime")
+    public DateTime getBookingDateTime() {
+        return bookingDateTime;
+    }
+
+    public void setBookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+    }
+
+    public OBTransaction6 valueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return valueDateTime
+     */
+    @Valid
+    @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ValueDateTime")
+    public DateTime getValueDateTime() {
+        return valueDateTime;
+    }
+
+    public void setValueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+    }
+
+    public OBTransaction6 transactionInformation(String transactionInformation) {
+        this.transactionInformation = transactionInformation;
+        return this;
+    }
+
+    /**
+     * Further details of the transaction.  This is the transaction narrative, which is unstructured text.
+     *
+     * @return transactionInformation
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "TransactionInformation", description = "Further details of the transaction.  This is the transaction narrative, which is unstructured text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionInformation")
+    public String getTransactionInformation() {
+        return transactionInformation;
+    }
+
+    public void setTransactionInformation(String transactionInformation) {
+        this.transactionInformation = transactionInformation;
+    }
+
+    public OBTransaction6 addressLine(String addressLine) {
+        this.addressLine = addressLine;
+        return this;
+    }
+
+    /**
+     * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
+     *
+     * @return addressLine
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressLine")
+    public String getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine(String addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public OBTransaction6 amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+    }
+
+    public OBTransaction6 chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+        return this;
+    }
+
+    /**
+     * Get chargeAmount
+     *
+     * @return chargeAmount
+     */
+    @Valid
+    @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ChargeAmount")
+    public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
+        return chargeAmount;
+    }
+
+    public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+    }
+
+    public OBTransaction6 currencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+        return this;
+    }
+
+    /**
+     * Get currencyExchange
+     *
+     * @return currencyExchange
+     */
+    @Valid
+    @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CurrencyExchange")
+    public OBCurrencyExchange5 getCurrencyExchange() {
+        return currencyExchange;
+    }
+
+    public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+    }
+
+    public OBTransaction6 bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get bankTransactionCode
+     *
+     * @return bankTransactionCode
+     */
+    @Valid
+    @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankTransactionCode")
+    public OBBankTransactionCodeStructure1 getBankTransactionCode() {
+        return bankTransactionCode;
+    }
+
+    public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+    }
+
+    public OBTransaction6 proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get proprietaryBankTransactionCode
+     *
+     * @return proprietaryBankTransactionCode
+     */
+    @Valid
+    @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProprietaryBankTransactionCode")
+    public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
+        return proprietaryBankTransactionCode;
+    }
+
+    public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+    }
+
+    public OBTransaction6 balance(OBTransactionCashBalance balance) {
+        this.balance = balance;
+        return this;
+    }
+
+    /**
+     * Get balance
+     *
+     * @return balance
+     */
+    @Valid
+    @Schema(name = "Balance", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Balance")
+    public OBTransactionCashBalance getBalance() {
+        return balance;
+    }
+
+    public void setBalance(OBTransactionCashBalance balance) {
+        this.balance = balance;
+    }
+
+    public OBTransaction6 merchantDetails(OBMerchantDetails1 merchantDetails) {
+        this.merchantDetails = merchantDetails;
+        return this;
+    }
+
+    /**
+     * Get merchantDetails
+     *
+     * @return merchantDetails
+     */
+    @Valid
+    @Schema(name = "MerchantDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantDetails")
+    public OBMerchantDetails1 getMerchantDetails() {
+        return merchantDetails;
+    }
+
+    public void setMerchantDetails(OBMerchantDetails1 merchantDetails) {
+        this.merchantDetails = merchantDetails;
+    }
+
+    public OBTransaction6 creditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification61 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBTransaction6 creditorAccount(OBCashAccount60 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount60 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount60 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    public OBTransaction6 debtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
+        this.debtorAgent = debtorAgent;
+        return this;
+    }
+
+    /**
+     * Get debtorAgent
+     *
+     * @return debtorAgent
+     */
+    @Valid
+    @Schema(name = "DebtorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorAgent")
+    public OBBranchAndFinancialInstitutionIdentification62 getDebtorAgent() {
+        return debtorAgent;
+    }
+
+    public void setDebtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
+        this.debtorAgent = debtorAgent;
+    }
+
+    public OBTransaction6 debtorAccount(OBCashAccount61 debtorAccount) {
+        this.debtorAccount = debtorAccount;
+        return this;
+    }
+
+    /**
+     * Get debtorAccount
+     *
+     * @return debtorAccount
+     */
+    @Valid
+    @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorAccount")
+    public OBCashAccount61 getDebtorAccount() {
+        return debtorAccount;
+    }
+
+    public void setDebtorAccount(OBCashAccount61 debtorAccount) {
+        this.debtorAccount = debtorAccount;
+    }
+
+    public OBTransaction6 cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+        return this;
+    }
+
+    /**
+     * Get cardInstrument
+     *
+     * @return cardInstrument
+     */
+    @Valid
+    @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CardInstrument")
+    public OBTransactionCardInstrument1 getCardInstrument() {
+        return cardInstrument;
+    }
+
+    public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+    }
+
+    public OBTransaction6 supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransaction6 obTransaction6 = (OBTransaction6) o;
+        return Objects.equals(this.accountId, obTransaction6.accountId) &&
+                Objects.equals(this.transactionId, obTransaction6.transactionId) &&
+                Objects.equals(this.transactionReference, obTransaction6.transactionReference) &&
+                Objects.equals(this.statementReference, obTransaction6.statementReference) &&
+                Objects.equals(this.creditDebitIndicator, obTransaction6.creditDebitIndicator) &&
+                Objects.equals(this.status, obTransaction6.status) &&
+                Objects.equals(this.transactionMutability, obTransaction6.transactionMutability) &&
+                Objects.equals(this.bookingDateTime, obTransaction6.bookingDateTime) &&
+                Objects.equals(this.valueDateTime, obTransaction6.valueDateTime) &&
+                Objects.equals(this.transactionInformation, obTransaction6.transactionInformation) &&
+                Objects.equals(this.addressLine, obTransaction6.addressLine) &&
+                Objects.equals(this.amount, obTransaction6.amount) &&
+                Objects.equals(this.chargeAmount, obTransaction6.chargeAmount) &&
+                Objects.equals(this.currencyExchange, obTransaction6.currencyExchange) &&
+                Objects.equals(this.bankTransactionCode, obTransaction6.bankTransactionCode) &&
+                Objects.equals(this.proprietaryBankTransactionCode, obTransaction6.proprietaryBankTransactionCode) &&
+                Objects.equals(this.balance, obTransaction6.balance) &&
+                Objects.equals(this.merchantDetails, obTransaction6.merchantDetails) &&
+                Objects.equals(this.creditorAgent, obTransaction6.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obTransaction6.creditorAccount) &&
+                Objects.equals(this.debtorAgent, obTransaction6.debtorAgent) &&
+                Objects.equals(this.debtorAccount, obTransaction6.debtorAccount) &&
+                Objects.equals(this.cardInstrument, obTransaction6.cardInstrument) &&
+                Objects.equals(this.supplementaryData, obTransaction6.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, transactionInformation, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, balance, merchantDetails, creditorAgent, creditorAccount, debtorAgent, debtorAccount, cardInstrument, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransaction6 {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
+        sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
+        sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
+        sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
+        sb.append("    transactionInformation: ").append(toIndentedString(transactionInformation)).append("\n");
+        sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
+        sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
+        sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
+        sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
+        sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
+        sb.append("    merchantDetails: ").append(toIndentedString(merchantDetails)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("    debtorAgent: ").append(toIndentedString(debtorAgent)).append("\n");
+        sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
+        sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
@@ -15,22 +15,41 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount10;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount9;
+import uk.org.openbanking.datamodel.account.OBBankTransactionCodeStructure1;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode1;
+import uk.org.openbanking.datamodel.account.OBCurrencyExchange5;
+import uk.org.openbanking.datamodel.account.OBEntryStatus1Code;
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1;
+import uk.org.openbanking.datamodel.account.OBTransactionMutability1Code;
+import uk.org.openbanking.datamodel.account.ProprietaryBankTransactionCodeStructure1;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Provides further details on an entry in the report.
@@ -40,482 +59,495 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransaction6Basic {
 
-  private String accountId;
+    private String accountId;
 
-  private String transactionId;
+    private String transactionId;
 
-  private String transactionReference;
+    private String transactionReference;
 
-  @Valid
-  private List<@Valid String> statementReference;
+    @Valid
+    private List<@Valid String> statementReference;
 
-  private OBCreditDebitCode1 creditDebitIndicator;
+    private OBCreditDebitCode1 creditDebitIndicator;
 
-  private OBEntryStatus1Code status;
+    private OBEntryStatus1Code status;
 
-  private OBTransactionMutability1Code transactionMutability;
+    private OBTransactionMutability1Code transactionMutability;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime bookingDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime bookingDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime valueDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime valueDateTime;
 
-  private String addressLine;
+    private String addressLine;
 
-  private OBActiveOrHistoricCurrencyAndAmount9 amount;
+    private OBActiveOrHistoricCurrencyAndAmount9 amount;
 
-  private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
+    private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
 
-  private OBCurrencyExchange5 currencyExchange;
+    private OBCurrencyExchange5 currencyExchange;
 
-  private OBBankTransactionCodeStructure1 bankTransactionCode;
+    private OBBankTransactionCodeStructure1 bankTransactionCode;
 
-  private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
+    private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
 
-  private OBTransactionCardInstrument1 cardInstrument;
+    private OBTransactionCardInstrument1 cardInstrument;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBTransaction6Basic() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransaction6Basic(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.accountId = accountId;
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.status = status;
-    this.bookingDateTime = bookingDateTime;
-    this.amount = amount;
-  }
-
-  public OBTransaction6Basic accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBTransaction6Basic transactionId(String transactionId) {
-    this.transactionId = transactionId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
-   * @return transactionId
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionId")
-  public String getTransactionId() {
-    return transactionId;
-  }
-
-  public void setTransactionId(String transactionId) {
-    this.transactionId = transactionId;
-  }
-
-  public OBTransaction6Basic transactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
-   * @return transactionReference
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionReference")
-  public String getTransactionReference() {
-    return transactionReference;
-  }
-
-  public void setTransactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-  }
-
-  public OBTransaction6Basic statementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  public OBTransaction6Basic addStatementReferenceItem(String statementReferenceItem) {
-    if (this.statementReference == null) {
-      this.statementReference = new ArrayList<>();
+    public OBTransaction6Basic() {
+        super();
     }
-    this.statementReference.add(statementReferenceItem);
-    return this;
-  }
 
-  /**
-   * Get statementReference
-   * @return statementReference
-  */
-  
-  @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public List<@Valid String> getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBTransaction6Basic creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode1 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBTransaction6Basic status(OBEntryStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @NotNull @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Status")
-  public OBEntryStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBEntryStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBTransaction6Basic transactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-    return this;
-  }
-
-  /**
-   * Get transactionMutability
-   * @return transactionMutability
-  */
-  @Valid 
-  @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionMutability")
-  public OBTransactionMutability1Code getTransactionMutability() {
-    return transactionMutability;
-  }
-
-  public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-  }
-
-  public OBTransaction6Basic bookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return bookingDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("BookingDateTime")
-  public DateTime getBookingDateTime() {
-    return bookingDateTime;
-  }
-
-  public void setBookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-  }
-
-  public OBTransaction6Basic valueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return valueDateTime
-  */
-  @Valid 
-  @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ValueDateTime")
-  public DateTime getValueDateTime() {
-    return valueDateTime;
-  }
-
-  public void setValueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-  }
-
-  public OBTransaction6Basic addressLine(String addressLine) {
-    this.addressLine = addressLine;
-    return this;
-  }
-
-  /**
-   * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
-   * @return addressLine
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AddressLine")
-  public String getAddressLine() {
-    return addressLine;
-  }
-
-  public void setAddressLine(String addressLine) {
-    this.addressLine = addressLine;
-  }
-
-  public OBTransaction6Basic amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-  }
-
-  public OBTransaction6Basic chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-    return this;
-  }
-
-  /**
-   * Get chargeAmount
-   * @return chargeAmount
-  */
-  @Valid 
-  @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ChargeAmount")
-  public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
-    return chargeAmount;
-  }
-
-  public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-  }
-
-  public OBTransaction6Basic currencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-    return this;
-  }
-
-  /**
-   * Get currencyExchange
-   * @return currencyExchange
-  */
-  @Valid 
-  @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CurrencyExchange")
-  public OBCurrencyExchange5 getCurrencyExchange() {
-    return currencyExchange;
-  }
-
-  public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-  }
-
-  public OBTransaction6Basic bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get bankTransactionCode
-   * @return bankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankTransactionCode")
-  public OBBankTransactionCodeStructure1 getBankTransactionCode() {
-    return bankTransactionCode;
-  }
-
-  public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-  }
-
-  public OBTransaction6Basic proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get proprietaryBankTransactionCode
-   * @return proprietaryBankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProprietaryBankTransactionCode")
-  public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
-    return proprietaryBankTransactionCode;
-  }
-
-  public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-  }
-
-  public OBTransaction6Basic cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-    return this;
-  }
-
-  /**
-   * Get cardInstrument
-   * @return cardInstrument
-  */
-  @Valid 
-  @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CardInstrument")
-  public OBTransactionCardInstrument1 getCardInstrument() {
-    return cardInstrument;
-  }
-
-  public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-  }
-
-  public OBTransaction6Basic supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransaction6Basic(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.accountId = accountId;
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.status = status;
+        this.bookingDateTime = bookingDateTime;
+        this.amount = amount;
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBTransaction6Basic accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    OBTransaction6Basic obTransaction6Basic = (OBTransaction6Basic) o;
-    return Objects.equals(this.accountId, obTransaction6Basic.accountId) &&
-        Objects.equals(this.transactionId, obTransaction6Basic.transactionId) &&
-        Objects.equals(this.transactionReference, obTransaction6Basic.transactionReference) &&
-        Objects.equals(this.statementReference, obTransaction6Basic.statementReference) &&
-        Objects.equals(this.creditDebitIndicator, obTransaction6Basic.creditDebitIndicator) &&
-        Objects.equals(this.status, obTransaction6Basic.status) &&
-        Objects.equals(this.transactionMutability, obTransaction6Basic.transactionMutability) &&
-        Objects.equals(this.bookingDateTime, obTransaction6Basic.bookingDateTime) &&
-        Objects.equals(this.valueDateTime, obTransaction6Basic.valueDateTime) &&
-        Objects.equals(this.addressLine, obTransaction6Basic.addressLine) &&
-        Objects.equals(this.amount, obTransaction6Basic.amount) &&
-        Objects.equals(this.chargeAmount, obTransaction6Basic.chargeAmount) &&
-        Objects.equals(this.currencyExchange, obTransaction6Basic.currencyExchange) &&
-        Objects.equals(this.bankTransactionCode, obTransaction6Basic.bankTransactionCode) &&
-        Objects.equals(this.proprietaryBankTransactionCode, obTransaction6Basic.proprietaryBankTransactionCode) &&
-        Objects.equals(this.cardInstrument, obTransaction6Basic.cardInstrument) &&
-        Objects.equals(this.supplementaryData, obTransaction6Basic.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, cardInstrument, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransaction6Basic {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
-    sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
-    sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
-    sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
-    sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
-    sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
-    sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
-    sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
-    sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBTransaction6Basic transactionId(String transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    /**
+     * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return transactionId
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionId")
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public OBTransaction6Basic transactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+        return this;
+    }
+
+    /**
+     * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
+     *
+     * @return transactionReference
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionReference")
+    public String getTransactionReference() {
+        return transactionReference;
+    }
+
+    public void setTransactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+    }
+
+    public OBTransaction6Basic statementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+        return this;
+    }
+
+    public OBTransaction6Basic addStatementReferenceItem(String statementReferenceItem) {
+        if (this.statementReference == null) {
+            this.statementReference = new ArrayList<>();
+        }
+        this.statementReference.add(statementReferenceItem);
+        return this;
+    }
+
+    /**
+     * Get statementReference
+     *
+     * @return statementReference
+     */
+
+    @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public List<@Valid String> getStatementReference() {
+        return statementReference;
+    }
+
+    public void setStatementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+    }
+
+    public OBTransaction6Basic creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode1 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBTransaction6Basic status(OBEntryStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Status")
+    public OBEntryStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBEntryStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBTransaction6Basic transactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+        return this;
+    }
+
+    /**
+     * Get transactionMutability
+     *
+     * @return transactionMutability
+     */
+    @Valid
+    @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionMutability")
+    public OBTransactionMutability1Code getTransactionMutability() {
+        return transactionMutability;
+    }
+
+    public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+    }
+
+    public OBTransaction6Basic bookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return bookingDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("BookingDateTime")
+    public DateTime getBookingDateTime() {
+        return bookingDateTime;
+    }
+
+    public void setBookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+    }
+
+    public OBTransaction6Basic valueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return valueDateTime
+     */
+    @Valid
+    @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ValueDateTime")
+    public DateTime getValueDateTime() {
+        return valueDateTime;
+    }
+
+    public void setValueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+    }
+
+    public OBTransaction6Basic addressLine(String addressLine) {
+        this.addressLine = addressLine;
+        return this;
+    }
+
+    /**
+     * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
+     *
+     * @return addressLine
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressLine")
+    public String getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine(String addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public OBTransaction6Basic amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+    }
+
+    public OBTransaction6Basic chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+        return this;
+    }
+
+    /**
+     * Get chargeAmount
+     *
+     * @return chargeAmount
+     */
+    @Valid
+    @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ChargeAmount")
+    public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
+        return chargeAmount;
+    }
+
+    public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+    }
+
+    public OBTransaction6Basic currencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+        return this;
+    }
+
+    /**
+     * Get currencyExchange
+     *
+     * @return currencyExchange
+     */
+    @Valid
+    @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CurrencyExchange")
+    public OBCurrencyExchange5 getCurrencyExchange() {
+        return currencyExchange;
+    }
+
+    public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+    }
+
+    public OBTransaction6Basic bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get bankTransactionCode
+     *
+     * @return bankTransactionCode
+     */
+    @Valid
+    @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankTransactionCode")
+    public OBBankTransactionCodeStructure1 getBankTransactionCode() {
+        return bankTransactionCode;
+    }
+
+    public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+    }
+
+    public OBTransaction6Basic proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get proprietaryBankTransactionCode
+     *
+     * @return proprietaryBankTransactionCode
+     */
+    @Valid
+    @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProprietaryBankTransactionCode")
+    public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
+        return proprietaryBankTransactionCode;
+    }
+
+    public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+    }
+
+    public OBTransaction6Basic cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+        return this;
+    }
+
+    /**
+     * Get cardInstrument
+     *
+     * @return cardInstrument
+     */
+    @Valid
+    @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CardInstrument")
+    public OBTransactionCardInstrument1 getCardInstrument() {
+        return cardInstrument;
+    }
+
+    public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+    }
+
+    public OBTransaction6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransaction6Basic obTransaction6Basic = (OBTransaction6Basic) o;
+        return Objects.equals(this.accountId, obTransaction6Basic.accountId) &&
+                Objects.equals(this.transactionId, obTransaction6Basic.transactionId) &&
+                Objects.equals(this.transactionReference, obTransaction6Basic.transactionReference) &&
+                Objects.equals(this.statementReference, obTransaction6Basic.statementReference) &&
+                Objects.equals(this.creditDebitIndicator, obTransaction6Basic.creditDebitIndicator) &&
+                Objects.equals(this.status, obTransaction6Basic.status) &&
+                Objects.equals(this.transactionMutability, obTransaction6Basic.transactionMutability) &&
+                Objects.equals(this.bookingDateTime, obTransaction6Basic.bookingDateTime) &&
+                Objects.equals(this.valueDateTime, obTransaction6Basic.valueDateTime) &&
+                Objects.equals(this.addressLine, obTransaction6Basic.addressLine) &&
+                Objects.equals(this.amount, obTransaction6Basic.amount) &&
+                Objects.equals(this.chargeAmount, obTransaction6Basic.chargeAmount) &&
+                Objects.equals(this.currencyExchange, obTransaction6Basic.currencyExchange) &&
+                Objects.equals(this.bankTransactionCode, obTransaction6Basic.bankTransactionCode) &&
+                Objects.equals(this.proprietaryBankTransactionCode, obTransaction6Basic.proprietaryBankTransactionCode) &&
+                Objects.equals(this.cardInstrument, obTransaction6Basic.cardInstrument) &&
+                Objects.equals(this.supplementaryData, obTransaction6Basic.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, cardInstrument, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransaction6Basic {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
+        sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
+        sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
+        sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
+        sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
+        sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
+        sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
+        sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
+        sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
@@ -15,22 +15,47 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.net.URI;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.joda.time.DateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount10;
+import uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount9;
+import uk.org.openbanking.datamodel.account.OBBankTransactionCodeStructure1;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification61;
+import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification62;
+import uk.org.openbanking.datamodel.account.OBCashAccount60;
+import uk.org.openbanking.datamodel.account.OBCashAccount61;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode1;
+import uk.org.openbanking.datamodel.account.OBCurrencyExchange5;
+import uk.org.openbanking.datamodel.account.OBEntryStatus1Code;
+import uk.org.openbanking.datamodel.account.OBMerchantDetails1;
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1;
+import uk.org.openbanking.datamodel.account.OBTransactionCashBalance;
+import uk.org.openbanking.datamodel.account.OBTransactionMutability1Code;
+import uk.org.openbanking.datamodel.account.ProprietaryBankTransactionCodeStructure1;
+import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Provides further details on an entry in the report.
@@ -40,650 +65,670 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransaction6Detail {
 
-  private String accountId;
+    private String accountId;
 
-  private String transactionId;
+    private String transactionId;
 
-  private String transactionReference;
+    private String transactionReference;
 
-  @Valid
-  private List<@Valid String> statementReference;
+    @Valid
+    private List<@Valid String> statementReference;
 
-  private OBCreditDebitCode1 creditDebitIndicator;
+    private OBCreditDebitCode1 creditDebitIndicator;
 
-  private OBEntryStatus1Code status;
+    private OBEntryStatus1Code status;
 
-  private OBTransactionMutability1Code transactionMutability;
+    private OBTransactionMutability1Code transactionMutability;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime bookingDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime bookingDateTime;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private DateTime valueDateTime;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime valueDateTime;
 
-  private String transactionInformation;
+    private String transactionInformation;
 
-  private String addressLine;
+    private String addressLine;
 
-  private OBActiveOrHistoricCurrencyAndAmount9 amount;
+    private OBActiveOrHistoricCurrencyAndAmount9 amount;
 
-  private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
+    private OBActiveOrHistoricCurrencyAndAmount10 chargeAmount;
 
-  private OBCurrencyExchange5 currencyExchange;
+    private OBCurrencyExchange5 currencyExchange;
 
-  private OBBankTransactionCodeStructure1 bankTransactionCode;
+    private OBBankTransactionCodeStructure1 bankTransactionCode;
 
-  private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
+    private ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode;
 
-  private OBTransactionCashBalance balance;
+    private OBTransactionCashBalance balance;
 
-  private OBMerchantDetails1 merchantDetails;
+    private OBMerchantDetails1 merchantDetails;
 
-  private OBBranchAndFinancialInstitutionIdentification61 creditorAgent;
+    private OBBranchAndFinancialInstitutionIdentification61 creditorAgent;
 
-  private OBCashAccount60 creditorAccount;
+    private OBCashAccount60 creditorAccount;
 
-  private OBBranchAndFinancialInstitutionIdentification62 debtorAgent;
+    private OBBranchAndFinancialInstitutionIdentification62 debtorAgent;
 
-  private OBCashAccount61 debtorAccount;
+    private OBCashAccount61 debtorAccount;
 
-  private OBTransactionCardInstrument1 cardInstrument;
+    private OBTransactionCardInstrument1 cardInstrument;
 
-  @Valid
-  private Map<String, Object> supplementaryData = new HashMap<>();
+    private OBSupplementaryData1 supplementaryData;
 
-  public OBTransaction6Detail() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransaction6Detail(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.accountId = accountId;
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.status = status;
-    this.bookingDateTime = bookingDateTime;
-    this.amount = amount;
-  }
-
-  public OBTransaction6Detail accountId(String accountId) {
-    this.accountId = accountId;
-    return this;
-  }
-
-  /**
-   * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
-   * @return accountId
-  */
-  @NotNull @Size(min = 1, max = 40) 
-  @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AccountId")
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String accountId) {
-    this.accountId = accountId;
-  }
-
-  public OBTransaction6Detail transactionId(String transactionId) {
-    this.transactionId = transactionId;
-    return this;
-  }
-
-  /**
-   * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
-   * @return transactionId
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionId")
-  public String getTransactionId() {
-    return transactionId;
-  }
-
-  public void setTransactionId(String transactionId) {
-    this.transactionId = transactionId;
-  }
-
-  public OBTransaction6Detail transactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-    return this;
-  }
-
-  /**
-   * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
-   * @return transactionReference
-  */
-  @Size(min = 1, max = 210) 
-  @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionReference")
-  public String getTransactionReference() {
-    return transactionReference;
-  }
-
-  public void setTransactionReference(String transactionReference) {
-    this.transactionReference = transactionReference;
-  }
-
-  public OBTransaction6Detail statementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-    return this;
-  }
-
-  public OBTransaction6Detail addStatementReferenceItem(String statementReferenceItem) {
-    if (this.statementReference == null) {
-      this.statementReference = new ArrayList<>();
+    public OBTransaction6Detail() {
+        super();
     }
-    this.statementReference.add(statementReferenceItem);
-    return this;
-  }
 
-  /**
-   * Get statementReference
-   * @return statementReference
-  */
-  
-  @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("StatementReference")
-  public List<@Valid String> getStatementReference() {
-    return statementReference;
-  }
-
-  public void setStatementReference(List<@Valid String> statementReference) {
-    this.statementReference = statementReference;
-  }
-
-  public OBTransaction6Detail creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode1 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBTransaction6Detail status(OBEntryStatus1Code status) {
-    this.status = status;
-    return this;
-  }
-
-  /**
-   * Get status
-   * @return status
-  */
-  @NotNull @Valid 
-  @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Status")
-  public OBEntryStatus1Code getStatus() {
-    return status;
-  }
-
-  public void setStatus(OBEntryStatus1Code status) {
-    this.status = status;
-  }
-
-  public OBTransaction6Detail transactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-    return this;
-  }
-
-  /**
-   * Get transactionMutability
-   * @return transactionMutability
-  */
-  @Valid 
-  @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionMutability")
-  public OBTransactionMutability1Code getTransactionMutability() {
-    return transactionMutability;
-  }
-
-  public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
-    this.transactionMutability = transactionMutability;
-  }
-
-  public OBTransaction6Detail bookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return bookingDateTime
-  */
-  @NotNull @Valid 
-  @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("BookingDateTime")
-  public DateTime getBookingDateTime() {
-    return bookingDateTime;
-  }
-
-  public void setBookingDateTime(DateTime bookingDateTime) {
-    this.bookingDateTime = bookingDateTime;
-  }
-
-  public OBTransaction6Detail valueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-    return this;
-  }
-
-  /**
-   * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
-   * @return valueDateTime
-  */
-  @Valid 
-  @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ValueDateTime")
-  public DateTime getValueDateTime() {
-    return valueDateTime;
-  }
-
-  public void setValueDateTime(DateTime valueDateTime) {
-    this.valueDateTime = valueDateTime;
-  }
-
-  public OBTransaction6Detail transactionInformation(String transactionInformation) {
-    this.transactionInformation = transactionInformation;
-    return this;
-  }
-
-  /**
-   * Further details of the transaction.  This is the transaction narrative, which is unstructured text.
-   * @return transactionInformation
-  */
-  @Size(min = 1, max = 500) 
-  @Schema(name = "TransactionInformation", description = "Further details of the transaction.  This is the transaction narrative, which is unstructured text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TransactionInformation")
-  public String getTransactionInformation() {
-    return transactionInformation;
-  }
-
-  public void setTransactionInformation(String transactionInformation) {
-    this.transactionInformation = transactionInformation;
-  }
-
-  public OBTransaction6Detail addressLine(String addressLine) {
-    this.addressLine = addressLine;
-    return this;
-  }
-
-  /**
-   * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
-   * @return addressLine
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AddressLine")
-  public String getAddressLine() {
-    return addressLine;
-  }
-
-  public void setAddressLine(String addressLine) {
-    this.addressLine = addressLine;
-  }
-
-  public OBTransaction6Detail amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
-    this.amount = amount;
-  }
-
-  public OBTransaction6Detail chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-    return this;
-  }
-
-  /**
-   * Get chargeAmount
-   * @return chargeAmount
-  */
-  @Valid 
-  @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ChargeAmount")
-  public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
-    return chargeAmount;
-  }
-
-  public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
-    this.chargeAmount = chargeAmount;
-  }
-
-  public OBTransaction6Detail currencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-    return this;
-  }
-
-  /**
-   * Get currencyExchange
-   * @return currencyExchange
-  */
-  @Valid 
-  @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CurrencyExchange")
-  public OBCurrencyExchange5 getCurrencyExchange() {
-    return currencyExchange;
-  }
-
-  public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
-    this.currencyExchange = currencyExchange;
-  }
-
-  public OBTransaction6Detail bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get bankTransactionCode
-   * @return bankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankTransactionCode")
-  public OBBankTransactionCodeStructure1 getBankTransactionCode() {
-    return bankTransactionCode;
-  }
-
-  public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
-    this.bankTransactionCode = bankTransactionCode;
-  }
-
-  public OBTransaction6Detail proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-    return this;
-  }
-
-  /**
-   * Get proprietaryBankTransactionCode
-   * @return proprietaryBankTransactionCode
-  */
-  @Valid 
-  @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("ProprietaryBankTransactionCode")
-  public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
-    return proprietaryBankTransactionCode;
-  }
-
-  public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
-    this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
-  }
-
-  public OBTransaction6Detail balance(OBTransactionCashBalance balance) {
-    this.balance = balance;
-    return this;
-  }
-
-  /**
-   * Get balance
-   * @return balance
-  */
-  @Valid 
-  @Schema(name = "Balance", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Balance")
-  public OBTransactionCashBalance getBalance() {
-    return balance;
-  }
-
-  public void setBalance(OBTransactionCashBalance balance) {
-    this.balance = balance;
-  }
-
-  public OBTransaction6Detail merchantDetails(OBMerchantDetails1 merchantDetails) {
-    this.merchantDetails = merchantDetails;
-    return this;
-  }
-
-  /**
-   * Get merchantDetails
-   * @return merchantDetails
-  */
-  @Valid 
-  @Schema(name = "MerchantDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MerchantDetails")
-  public OBMerchantDetails1 getMerchantDetails() {
-    return merchantDetails;
-  }
-
-  public void setMerchantDetails(OBMerchantDetails1 merchantDetails) {
-    this.merchantDetails = merchantDetails;
-  }
-
-  public OBTransaction6Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-    return this;
-  }
-
-  /**
-   * Get creditorAgent
-   * @return creditorAgent
-  */
-  @Valid 
-  @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAgent")
-  public OBBranchAndFinancialInstitutionIdentification61 getCreditorAgent() {
-    return creditorAgent;
-  }
-
-  public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
-    this.creditorAgent = creditorAgent;
-  }
-
-  public OBTransaction6Detail creditorAccount(OBCashAccount60 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-    return this;
-  }
-
-  /**
-   * Get creditorAccount
-   * @return creditorAccount
-  */
-  @Valid 
-  @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CreditorAccount")
-  public OBCashAccount60 getCreditorAccount() {
-    return creditorAccount;
-  }
-
-  public void setCreditorAccount(OBCashAccount60 creditorAccount) {
-    this.creditorAccount = creditorAccount;
-  }
-
-  public OBTransaction6Detail debtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
-    this.debtorAgent = debtorAgent;
-    return this;
-  }
-
-  /**
-   * Get debtorAgent
-   * @return debtorAgent
-  */
-  @Valid 
-  @Schema(name = "DebtorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorAgent")
-  public OBBranchAndFinancialInstitutionIdentification62 getDebtorAgent() {
-    return debtorAgent;
-  }
-
-  public void setDebtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
-    this.debtorAgent = debtorAgent;
-  }
-
-  public OBTransaction6Detail debtorAccount(OBCashAccount61 debtorAccount) {
-    this.debtorAccount = debtorAccount;
-    return this;
-  }
-
-  /**
-   * Get debtorAccount
-   * @return debtorAccount
-  */
-  @Valid 
-  @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DebtorAccount")
-  public OBCashAccount61 getDebtorAccount() {
-    return debtorAccount;
-  }
-
-  public void setDebtorAccount(OBCashAccount61 debtorAccount) {
-    this.debtorAccount = debtorAccount;
-  }
-
-  public OBTransaction6Detail cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-    return this;
-  }
-
-  /**
-   * Get cardInstrument
-   * @return cardInstrument
-  */
-  @Valid 
-  @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CardInstrument")
-  public OBTransactionCardInstrument1 getCardInstrument() {
-    return cardInstrument;
-  }
-
-  public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
-    this.cardInstrument = cardInstrument;
-  }
-
-  public OBTransaction6Detail supplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransaction6Detail(String accountId, OBCreditDebitCode1 creditDebitIndicator, OBEntryStatus1Code status, DateTime bookingDateTime, OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.accountId = accountId;
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.status = status;
+        this.bookingDateTime = bookingDateTime;
+        this.amount = amount;
     }
-    this.supplementaryData.put(key, supplementaryDataItem);
-    return this;
-  }
 
-  /**
-   * Additional information that can not be captured in the structured fields and/or any other specific block.
-   * @return supplementaryData
-  */
-  
-  @Schema(name = "SupplementaryData", description = "Additional information that can not be captured in the structured fields and/or any other specific block.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("SupplementaryData")
-  public Map<String, Object> getSupplementaryData() {
-    return supplementaryData;
-  }
-
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
-    this.supplementaryData = supplementaryData;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBTransaction6Detail accountId(String accountId) {
+        this.accountId = accountId;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.
+     *
+     * @return accountId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "AccountId", description = "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AccountId")
+    public String getAccountId() {
+        return accountId;
     }
-    OBTransaction6Detail obTransaction6Detail = (OBTransaction6Detail) o;
-    return Objects.equals(this.accountId, obTransaction6Detail.accountId) &&
-        Objects.equals(this.transactionId, obTransaction6Detail.transactionId) &&
-        Objects.equals(this.transactionReference, obTransaction6Detail.transactionReference) &&
-        Objects.equals(this.statementReference, obTransaction6Detail.statementReference) &&
-        Objects.equals(this.creditDebitIndicator, obTransaction6Detail.creditDebitIndicator) &&
-        Objects.equals(this.status, obTransaction6Detail.status) &&
-        Objects.equals(this.transactionMutability, obTransaction6Detail.transactionMutability) &&
-        Objects.equals(this.bookingDateTime, obTransaction6Detail.bookingDateTime) &&
-        Objects.equals(this.valueDateTime, obTransaction6Detail.valueDateTime) &&
-        Objects.equals(this.transactionInformation, obTransaction6Detail.transactionInformation) &&
-        Objects.equals(this.addressLine, obTransaction6Detail.addressLine) &&
-        Objects.equals(this.amount, obTransaction6Detail.amount) &&
-        Objects.equals(this.chargeAmount, obTransaction6Detail.chargeAmount) &&
-        Objects.equals(this.currencyExchange, obTransaction6Detail.currencyExchange) &&
-        Objects.equals(this.bankTransactionCode, obTransaction6Detail.bankTransactionCode) &&
-        Objects.equals(this.proprietaryBankTransactionCode, obTransaction6Detail.proprietaryBankTransactionCode) &&
-        Objects.equals(this.balance, obTransaction6Detail.balance) &&
-        Objects.equals(this.merchantDetails, obTransaction6Detail.merchantDetails) &&
-        Objects.equals(this.creditorAgent, obTransaction6Detail.creditorAgent) &&
-        Objects.equals(this.creditorAccount, obTransaction6Detail.creditorAccount) &&
-        Objects.equals(this.debtorAgent, obTransaction6Detail.debtorAgent) &&
-        Objects.equals(this.debtorAccount, obTransaction6Detail.debtorAccount) &&
-        Objects.equals(this.cardInstrument, obTransaction6Detail.cardInstrument) &&
-        Objects.equals(this.supplementaryData, obTransaction6Detail.supplementaryData);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, transactionInformation, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, balance, merchantDetails, creditorAgent, creditorAccount, debtorAgent, debtorAccount, cardInstrument, supplementaryData);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransaction6Detail {\n");
-    sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
-    sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
-    sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
-    sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    status: ").append(toIndentedString(status)).append("\n");
-    sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
-    sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
-    sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
-    sb.append("    transactionInformation: ").append(toIndentedString(transactionInformation)).append("\n");
-    sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
-    sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
-    sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
-    sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
-    sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
-    sb.append("    merchantDetails: ").append(toIndentedString(merchantDetails)).append("\n");
-    sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
-    sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
-    sb.append("    debtorAgent: ").append(toIndentedString(debtorAgent)).append("\n");
-    sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
-    sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
-    sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public OBTransaction6Detail transactionId(String transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    /**
+     * Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
+     *
+     * @return transactionId
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionId", description = "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionId")
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public OBTransaction6Detail transactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+        return this;
+    }
+
+    /**
+     * Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.
+     *
+     * @return transactionReference
+     */
+    @Size(min = 1, max = 210)
+    @Schema(name = "TransactionReference", description = "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionReference")
+    public String getTransactionReference() {
+        return transactionReference;
+    }
+
+    public void setTransactionReference(String transactionReference) {
+        this.transactionReference = transactionReference;
+    }
+
+    public OBTransaction6Detail statementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+        return this;
+    }
+
+    public OBTransaction6Detail addStatementReferenceItem(String statementReferenceItem) {
+        if (this.statementReference == null) {
+            this.statementReference = new ArrayList<>();
+        }
+        this.statementReference.add(statementReferenceItem);
+        return this;
+    }
+
+    /**
+     * Get statementReference
+     *
+     * @return statementReference
+     */
+
+    @Schema(name = "StatementReference", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatementReference")
+    public List<@Valid String> getStatementReference() {
+        return statementReference;
+    }
+
+    public void setStatementReference(List<@Valid String> statementReference) {
+        this.statementReference = statementReference;
+    }
+
+    public OBTransaction6Detail creditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
+    }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode1 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode1 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBTransaction6Detail status(OBEntryStatus1Code status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Status")
+    public OBEntryStatus1Code getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBEntryStatus1Code status) {
+        this.status = status;
+    }
+
+    public OBTransaction6Detail transactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+        return this;
+    }
+
+    /**
+     * Get transactionMutability
+     *
+     * @return transactionMutability
+     */
+    @Valid
+    @Schema(name = "TransactionMutability", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionMutability")
+    public OBTransactionMutability1Code getTransactionMutability() {
+        return transactionMutability;
+    }
+
+    public void setTransactionMutability(OBTransactionMutability1Code transactionMutability) {
+        this.transactionMutability = transactionMutability;
+    }
+
+    public OBTransaction6Detail bookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return bookingDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "BookingDateTime", description = "Date and time when a transaction entry is posted to an account on the account servicer's books. Usage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("BookingDateTime")
+    public DateTime getBookingDateTime() {
+        return bookingDateTime;
+    }
+
+    public void setBookingDateTime(DateTime bookingDateTime) {
+        this.bookingDateTime = bookingDateTime;
+    }
+
+    public OBTransaction6Detail valueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return valueDateTime
+     */
+    @Valid
+    @Schema(name = "ValueDateTime", description = "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry. Usage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date. For transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ValueDateTime")
+    public DateTime getValueDateTime() {
+        return valueDateTime;
+    }
+
+    public void setValueDateTime(DateTime valueDateTime) {
+        this.valueDateTime = valueDateTime;
+    }
+
+    public OBTransaction6Detail transactionInformation(String transactionInformation) {
+        this.transactionInformation = transactionInformation;
+        return this;
+    }
+
+    /**
+     * Further details of the transaction.  This is the transaction narrative, which is unstructured text.
+     *
+     * @return transactionInformation
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "TransactionInformation", description = "Further details of the transaction.  This is the transaction narrative, which is unstructured text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TransactionInformation")
+    public String getTransactionInformation() {
+        return transactionInformation;
+    }
+
+    public void setTransactionInformation(String transactionInformation) {
+        this.transactionInformation = transactionInformation;
+    }
+
+    public OBTransaction6Detail addressLine(String addressLine) {
+        this.addressLine = addressLine;
+        return this;
+    }
+
+    /**
+     * Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.
+     *
+     * @return addressLine
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "AddressLine", description = "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressLine")
+    public String getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine(String addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public OBTransaction6Detail amount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBActiveOrHistoricCurrencyAndAmount9 getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBActiveOrHistoricCurrencyAndAmount9 amount) {
+        this.amount = amount;
+    }
+
+    public OBTransaction6Detail chargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+        return this;
+    }
+
+    /**
+     * Get chargeAmount
+     *
+     * @return chargeAmount
+     */
+    @Valid
+    @Schema(name = "ChargeAmount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ChargeAmount")
+    public OBActiveOrHistoricCurrencyAndAmount10 getChargeAmount() {
+        return chargeAmount;
+    }
+
+    public void setChargeAmount(OBActiveOrHistoricCurrencyAndAmount10 chargeAmount) {
+        this.chargeAmount = chargeAmount;
+    }
+
+    public OBTransaction6Detail currencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+        return this;
+    }
+
+    /**
+     * Get currencyExchange
+     *
+     * @return currencyExchange
+     */
+    @Valid
+    @Schema(name = "CurrencyExchange", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CurrencyExchange")
+    public OBCurrencyExchange5 getCurrencyExchange() {
+        return currencyExchange;
+    }
+
+    public void setCurrencyExchange(OBCurrencyExchange5 currencyExchange) {
+        this.currencyExchange = currencyExchange;
+    }
+
+    public OBTransaction6Detail bankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get bankTransactionCode
+     *
+     * @return bankTransactionCode
+     */
+    @Valid
+    @Schema(name = "BankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankTransactionCode")
+    public OBBankTransactionCodeStructure1 getBankTransactionCode() {
+        return bankTransactionCode;
+    }
+
+    public void setBankTransactionCode(OBBankTransactionCodeStructure1 bankTransactionCode) {
+        this.bankTransactionCode = bankTransactionCode;
+    }
+
+    public OBTransaction6Detail proprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+        return this;
+    }
+
+    /**
+     * Get proprietaryBankTransactionCode
+     *
+     * @return proprietaryBankTransactionCode
+     */
+    @Valid
+    @Schema(name = "ProprietaryBankTransactionCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ProprietaryBankTransactionCode")
+    public ProprietaryBankTransactionCodeStructure1 getProprietaryBankTransactionCode() {
+        return proprietaryBankTransactionCode;
+    }
+
+    public void setProprietaryBankTransactionCode(ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCode) {
+        this.proprietaryBankTransactionCode = proprietaryBankTransactionCode;
+    }
+
+    public OBTransaction6Detail balance(OBTransactionCashBalance balance) {
+        this.balance = balance;
+        return this;
+    }
+
+    /**
+     * Get balance
+     *
+     * @return balance
+     */
+    @Valid
+    @Schema(name = "Balance", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Balance")
+    public OBTransactionCashBalance getBalance() {
+        return balance;
+    }
+
+    public void setBalance(OBTransactionCashBalance balance) {
+        this.balance = balance;
+    }
+
+    public OBTransaction6Detail merchantDetails(OBMerchantDetails1 merchantDetails) {
+        this.merchantDetails = merchantDetails;
+        return this;
+    }
+
+    /**
+     * Get merchantDetails
+     *
+     * @return merchantDetails
+     */
+    @Valid
+    @Schema(name = "MerchantDetails", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantDetails")
+    public OBMerchantDetails1 getMerchantDetails() {
+        return merchantDetails;
+    }
+
+    public void setMerchantDetails(OBMerchantDetails1 merchantDetails) {
+        this.merchantDetails = merchantDetails;
+    }
+
+    public OBTransaction6Detail creditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+        return this;
+    }
+
+    /**
+     * Get creditorAgent
+     *
+     * @return creditorAgent
+     */
+    @Valid
+    @Schema(name = "CreditorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAgent")
+    public OBBranchAndFinancialInstitutionIdentification61 getCreditorAgent() {
+        return creditorAgent;
+    }
+
+    public void setCreditorAgent(OBBranchAndFinancialInstitutionIdentification61 creditorAgent) {
+        this.creditorAgent = creditorAgent;
+    }
+
+    public OBTransaction6Detail creditorAccount(OBCashAccount60 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+        return this;
+    }
+
+    /**
+     * Get creditorAccount
+     *
+     * @return creditorAccount
+     */
+    @Valid
+    @Schema(name = "CreditorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CreditorAccount")
+    public OBCashAccount60 getCreditorAccount() {
+        return creditorAccount;
+    }
+
+    public void setCreditorAccount(OBCashAccount60 creditorAccount) {
+        this.creditorAccount = creditorAccount;
+    }
+
+    public OBTransaction6Detail debtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
+        this.debtorAgent = debtorAgent;
+        return this;
+    }
+
+    /**
+     * Get debtorAgent
+     *
+     * @return debtorAgent
+     */
+    @Valid
+    @Schema(name = "DebtorAgent", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorAgent")
+    public OBBranchAndFinancialInstitutionIdentification62 getDebtorAgent() {
+        return debtorAgent;
+    }
+
+    public void setDebtorAgent(OBBranchAndFinancialInstitutionIdentification62 debtorAgent) {
+        this.debtorAgent = debtorAgent;
+    }
+
+    public OBTransaction6Detail debtorAccount(OBCashAccount61 debtorAccount) {
+        this.debtorAccount = debtorAccount;
+        return this;
+    }
+
+    /**
+     * Get debtorAccount
+     *
+     * @return debtorAccount
+     */
+    @Valid
+    @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DebtorAccount")
+    public OBCashAccount61 getDebtorAccount() {
+        return debtorAccount;
+    }
+
+    public void setDebtorAccount(OBCashAccount61 debtorAccount) {
+        this.debtorAccount = debtorAccount;
+    }
+
+    public OBTransaction6Detail cardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+        return this;
+    }
+
+    /**
+     * Get cardInstrument
+     *
+     * @return cardInstrument
+     */
+    @Valid
+    @Schema(name = "CardInstrument", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CardInstrument")
+    public OBTransactionCardInstrument1 getCardInstrument() {
+        return cardInstrument;
+    }
+
+    public void setCardInstrument(OBTransactionCardInstrument1 cardInstrument) {
+        this.cardInstrument = cardInstrument;
+    }
+
+    public OBTransaction6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+        return this;
+    }
+
+    /**
+     * Get supplementaryData
+     *
+     * @return supplementaryData
+     */
+    @Valid
+    @Schema(name = "SupplementaryData", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SupplementaryData")
+    public OBSupplementaryData1 getSupplementaryData() {
+        return supplementaryData;
+    }
+
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
+        this.supplementaryData = supplementaryData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransaction6Detail obTransaction6Detail = (OBTransaction6Detail) o;
+        return Objects.equals(this.accountId, obTransaction6Detail.accountId) &&
+                Objects.equals(this.transactionId, obTransaction6Detail.transactionId) &&
+                Objects.equals(this.transactionReference, obTransaction6Detail.transactionReference) &&
+                Objects.equals(this.statementReference, obTransaction6Detail.statementReference) &&
+                Objects.equals(this.creditDebitIndicator, obTransaction6Detail.creditDebitIndicator) &&
+                Objects.equals(this.status, obTransaction6Detail.status) &&
+                Objects.equals(this.transactionMutability, obTransaction6Detail.transactionMutability) &&
+                Objects.equals(this.bookingDateTime, obTransaction6Detail.bookingDateTime) &&
+                Objects.equals(this.valueDateTime, obTransaction6Detail.valueDateTime) &&
+                Objects.equals(this.transactionInformation, obTransaction6Detail.transactionInformation) &&
+                Objects.equals(this.addressLine, obTransaction6Detail.addressLine) &&
+                Objects.equals(this.amount, obTransaction6Detail.amount) &&
+                Objects.equals(this.chargeAmount, obTransaction6Detail.chargeAmount) &&
+                Objects.equals(this.currencyExchange, obTransaction6Detail.currencyExchange) &&
+                Objects.equals(this.bankTransactionCode, obTransaction6Detail.bankTransactionCode) &&
+                Objects.equals(this.proprietaryBankTransactionCode, obTransaction6Detail.proprietaryBankTransactionCode) &&
+                Objects.equals(this.balance, obTransaction6Detail.balance) &&
+                Objects.equals(this.merchantDetails, obTransaction6Detail.merchantDetails) &&
+                Objects.equals(this.creditorAgent, obTransaction6Detail.creditorAgent) &&
+                Objects.equals(this.creditorAccount, obTransaction6Detail.creditorAccount) &&
+                Objects.equals(this.debtorAgent, obTransaction6Detail.debtorAgent) &&
+                Objects.equals(this.debtorAccount, obTransaction6Detail.debtorAccount) &&
+                Objects.equals(this.cardInstrument, obTransaction6Detail.cardInstrument) &&
+                Objects.equals(this.supplementaryData, obTransaction6Detail.supplementaryData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId, transactionId, transactionReference, statementReference, creditDebitIndicator, status, transactionMutability, bookingDateTime, valueDateTime, transactionInformation, addressLine, amount, chargeAmount, currencyExchange, bankTransactionCode, proprietaryBankTransactionCode, balance, merchantDetails, creditorAgent, creditorAccount, debtorAgent, debtorAccount, cardInstrument, supplementaryData);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransaction6Detail {\n");
+        sb.append("    accountId: ").append(toIndentedString(accountId)).append("\n");
+        sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
+        sb.append("    transactionReference: ").append(toIndentedString(transactionReference)).append("\n");
+        sb.append("    statementReference: ").append(toIndentedString(statementReference)).append("\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    transactionMutability: ").append(toIndentedString(transactionMutability)).append("\n");
+        sb.append("    bookingDateTime: ").append(toIndentedString(bookingDateTime)).append("\n");
+        sb.append("    valueDateTime: ").append(toIndentedString(valueDateTime)).append("\n");
+        sb.append("    transactionInformation: ").append(toIndentedString(transactionInformation)).append("\n");
+        sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    chargeAmount: ").append(toIndentedString(chargeAmount)).append("\n");
+        sb.append("    currencyExchange: ").append(toIndentedString(currencyExchange)).append("\n");
+        sb.append("    bankTransactionCode: ").append(toIndentedString(bankTransactionCode)).append("\n");
+        sb.append("    proprietaryBankTransactionCode: ").append(toIndentedString(proprietaryBankTransactionCode)).append("\n");
+        sb.append("    balance: ").append(toIndentedString(balance)).append("\n");
+        sb.append("    merchantDetails: ").append(toIndentedString(merchantDetails)).append("\n");
+        sb.append("    creditorAgent: ").append(toIndentedString(creditorAgent)).append("\n");
+        sb.append("    creditorAccount: ").append(toIndentedString(creditorAccount)).append("\n");
+        sb.append("    debtorAgent: ").append(toIndentedString(debtorAgent)).append("\n");
+        sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
+        sb.append("    cardInstrument: ").append(toIndentedString(cardInstrument)).append("\n");
+        sb.append("    supplementaryData: ").append(toIndentedString(supplementaryData)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
@@ -15,16 +15,26 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1AuthorisationType;
+import uk.org.openbanking.datamodel.account.OBTransactionCardInstrument1CardSchemeName;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 /**
  * Set of elements to describe the card instrument used in the transaction.
@@ -34,226 +44,151 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransactionCardInstrument1 {
 
-  /**
-   * Name of the card scheme.
-   */
-  public enum CardSchemeNameEnum {
-    AMERICANEXPRESS("AmericanExpress"),
-    
-    DINERS("Diners"),
-    
-    DISCOVER("Discover"),
-    
-    MASTERCARD("MasterCard"),
-    
-    VISA("VISA");
+    private OBTransactionCardInstrument1CardSchemeName cardSchemeName;
 
-    private String value;
+    private OBTransactionCardInstrument1AuthorisationType authorisationType;
 
-    CardSchemeNameEnum(String value) {
-      this.value = value;
+    private String name;
+
+    private String identification;
+
+    public OBTransactionCardInstrument1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransactionCardInstrument1(OBTransactionCardInstrument1CardSchemeName cardSchemeName) {
+        this.cardSchemeName = cardSchemeName;
+    }
+
+    public OBTransactionCardInstrument1 cardSchemeName(OBTransactionCardInstrument1CardSchemeName cardSchemeName) {
+        this.cardSchemeName = cardSchemeName;
+        return this;
+    }
+
+    /**
+     * Get cardSchemeName
+     *
+     * @return cardSchemeName
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CardSchemeName", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CardSchemeName")
+    public OBTransactionCardInstrument1CardSchemeName getCardSchemeName() {
+        return cardSchemeName;
+    }
+
+    public void setCardSchemeName(OBTransactionCardInstrument1CardSchemeName cardSchemeName) {
+        this.cardSchemeName = cardSchemeName;
+    }
+
+    public OBTransactionCardInstrument1 authorisationType(OBTransactionCardInstrument1AuthorisationType authorisationType) {
+        this.authorisationType = authorisationType;
+        return this;
+    }
+
+    /**
+     * Get authorisationType
+     *
+     * @return authorisationType
+     */
+    @Valid
+    @Schema(name = "AuthorisationType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AuthorisationType")
+    public OBTransactionCardInstrument1AuthorisationType getAuthorisationType() {
+        return authorisationType;
+    }
+
+    public void setAuthorisationType(OBTransactionCardInstrument1AuthorisationType authorisationType) {
+        this.authorisationType = authorisationType;
+    }
+
+    public OBTransactionCardInstrument1 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name of the cardholder using the card instrument.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Name of the cardholder using the card instrument.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBTransactionCardInstrument1 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransactionCardInstrument1 obTransactionCardInstrument1 = (OBTransactionCardInstrument1) o;
+        return Objects.equals(this.cardSchemeName, obTransactionCardInstrument1.cardSchemeName) &&
+                Objects.equals(this.authorisationType, obTransactionCardInstrument1.authorisationType) &&
+                Objects.equals(this.name, obTransactionCardInstrument1.name) &&
+                Objects.equals(this.identification, obTransactionCardInstrument1.identification);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardSchemeName, authorisationType, name, identification);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransactionCardInstrument1 {\n");
+        sb.append("    cardSchemeName: ").append(toIndentedString(cardSchemeName)).append("\n");
+        sb.append("    authorisationType: ").append(toIndentedString(authorisationType)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static CardSchemeNameEnum fromValue(String value) {
-      for (CardSchemeNameEnum b : CardSchemeNameEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private CardSchemeNameEnum cardSchemeName;
-
-  /**
-   * The card authorisation type.
-   */
-  public enum AuthorisationTypeEnum {
-    CONSUMERDEVICE("ConsumerDevice"),
-    
-    CONTACTLESS("Contactless"),
-    
-    NONE("None"),
-    
-    PIN("PIN");
-
-    private String value;
-
-    AuthorisationTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static AuthorisationTypeEnum fromValue(String value) {
-      for (AuthorisationTypeEnum b : AuthorisationTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private AuthorisationTypeEnum authorisationType;
-
-  private String name;
-
-  private String identification;
-
-  public OBTransactionCardInstrument1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransactionCardInstrument1(CardSchemeNameEnum cardSchemeName) {
-    this.cardSchemeName = cardSchemeName;
-  }
-
-  public OBTransactionCardInstrument1 cardSchemeName(CardSchemeNameEnum cardSchemeName) {
-    this.cardSchemeName = cardSchemeName;
-    return this;
-  }
-
-  /**
-   * Name of the card scheme.
-   * @return cardSchemeName
-  */
-  @NotNull 
-  @Schema(name = "CardSchemeName", description = "Name of the card scheme.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CardSchemeName")
-  public CardSchemeNameEnum getCardSchemeName() {
-    return cardSchemeName;
-  }
-
-  public void setCardSchemeName(CardSchemeNameEnum cardSchemeName) {
-    this.cardSchemeName = cardSchemeName;
-  }
-
-  public OBTransactionCardInstrument1 authorisationType(AuthorisationTypeEnum authorisationType) {
-    this.authorisationType = authorisationType;
-    return this;
-  }
-
-  /**
-   * The card authorisation type.
-   * @return authorisationType
-  */
-  
-  @Schema(name = "AuthorisationType", description = "The card authorisation type.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AuthorisationType")
-  public AuthorisationTypeEnum getAuthorisationType() {
-    return authorisationType;
-  }
-
-  public void setAuthorisationType(AuthorisationTypeEnum authorisationType) {
-    this.authorisationType = authorisationType;
-  }
-
-  public OBTransactionCardInstrument1 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Name of the cardholder using the card instrument.
-   * @return name
-  */
-  @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Name of the cardholder using the card instrument.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OBTransactionCardInstrument1 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked.
-   * @return identification
-  */
-  @Size(min = 1, max = 34) 
-  @Schema(name = "Identification", description = "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OBTransactionCardInstrument1 obTransactionCardInstrument1 = (OBTransactionCardInstrument1) o;
-    return Objects.equals(this.cardSchemeName, obTransactionCardInstrument1.cardSchemeName) &&
-        Objects.equals(this.authorisationType, obTransactionCardInstrument1.authorisationType) &&
-        Objects.equals(this.name, obTransactionCardInstrument1.name) &&
-        Objects.equals(this.identification, obTransactionCardInstrument1.identification);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(cardSchemeName, authorisationType, name, identification);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransactionCardInstrument1 {\n");
-    sb.append("    cardSchemeName: ").append(toIndentedString(cardSchemeName)).append("\n");
-    sb.append("    authorisationType: ").append(toIndentedString(authorisationType)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1AuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1AuthorisationType.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * The card authorisation type.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBTransactionCardInstrument1AuthorisationType {
+
+    CONSUMERDEVICE("ConsumerDevice"),
+
+    CONTACTLESS("Contactless"),
+
+    NONE("None"),
+
+    PIN("PIN");
+
+    private String value;
+
+    OBTransactionCardInstrument1AuthorisationType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBTransactionCardInstrument1AuthorisationType fromValue(String value) {
+        for (OBTransactionCardInstrument1AuthorisationType b : OBTransactionCardInstrument1AuthorisationType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1CardSchemeName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1CardSchemeName.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Name of the card scheme.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBTransactionCardInstrument1CardSchemeName {
+
+    AMERICANEXPRESS("AmericanExpress"),
+
+    DINERS("Diners"),
+
+    DISCOVER("Discover"),
+
+    MASTERCARD("MasterCard"),
+
+    VISA("VISA");
+
+    private String value;
+
+    OBTransactionCardInstrument1CardSchemeName(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBTransactionCardInstrument1CardSchemeName fromValue(String value) {
+        for (OBTransactionCardInstrument1CardSchemeName b : OBTransactionCardInstrument1CardSchemeName.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
@@ -15,14 +15,27 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import uk.org.openbanking.datamodel.account.OBBalanceType1Code;
+import uk.org.openbanking.datamodel.account.OBCreditDebitCode2;
+import uk.org.openbanking.datamodel.account.OBTransactionCashBalanceAmount;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account.
@@ -32,124 +45,130 @@ import jakarta.validation.constraints.NotNull;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransactionCashBalance {
 
-  private OBCreditDebitCode2 creditDebitIndicator;
+    private OBCreditDebitCode2 creditDebitIndicator;
 
-  private OBBalanceType1Code type;
+    private OBBalanceType1Code type;
 
-  private OBTransactionCashBalanceAmount amount;
+    private OBTransactionCashBalanceAmount amount;
 
-  public OBTransactionCashBalance() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransactionCashBalance(OBCreditDebitCode2 creditDebitIndicator, OBBalanceType1Code type, OBTransactionCashBalanceAmount amount) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    this.type = type;
-    this.amount = amount;
-  }
-
-  public OBTransactionCashBalance creditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-    return this;
-  }
-
-  /**
-   * Get creditDebitIndicator
-   * @return creditDebitIndicator
-  */
-  @NotNull @Valid 
-  @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("CreditDebitIndicator")
-  public OBCreditDebitCode2 getCreditDebitIndicator() {
-    return creditDebitIndicator;
-  }
-
-  public void setCreditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
-    this.creditDebitIndicator = creditDebitIndicator;
-  }
-
-  public OBTransactionCashBalance type(OBBalanceType1Code type) {
-    this.type = type;
-    return this;
-  }
-
-  /**
-   * Get type
-   * @return type
-  */
-  @NotNull @Valid 
-  @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Type")
-  public OBBalanceType1Code getType() {
-    return type;
-  }
-
-  public void setType(OBBalanceType1Code type) {
-    this.type = type;
-  }
-
-  public OBTransactionCashBalance amount(OBTransactionCashBalanceAmount amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * Get amount
-   * @return amount
-  */
-  @NotNull @Valid 
-  @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public OBTransactionCashBalanceAmount getAmount() {
-    return amount;
-  }
-
-  public void setAmount(OBTransactionCashBalanceAmount amount) {
-    this.amount = amount;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBTransactionCashBalance() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransactionCashBalance(OBCreditDebitCode2 creditDebitIndicator, OBBalanceType1Code type, OBTransactionCashBalanceAmount amount) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        this.type = type;
+        this.amount = amount;
     }
-    OBTransactionCashBalance obTransactionCashBalance = (OBTransactionCashBalance) o;
-    return Objects.equals(this.creditDebitIndicator, obTransactionCashBalance.creditDebitIndicator) &&
-        Objects.equals(this.type, obTransactionCashBalance.type) &&
-        Objects.equals(this.amount, obTransactionCashBalance.amount);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(creditDebitIndicator, type, amount);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransactionCashBalance {\n");
-    sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
-    sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBTransactionCashBalance creditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Get creditDebitIndicator
+     *
+     * @return creditDebitIndicator
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreditDebitIndicator", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreditDebitIndicator")
+    public OBCreditDebitCode2 getCreditDebitIndicator() {
+        return creditDebitIndicator;
+    }
+
+    public void setCreditDebitIndicator(OBCreditDebitCode2 creditDebitIndicator) {
+        this.creditDebitIndicator = creditDebitIndicator;
+    }
+
+    public OBTransactionCashBalance type(OBBalanceType1Code type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Get type
+     *
+     * @return type
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Type", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Type")
+    public OBBalanceType1Code getType() {
+        return type;
+    }
+
+    public void setType(OBBalanceType1Code type) {
+        this.type = type;
+    }
+
+    public OBTransactionCashBalance amount(OBTransactionCashBalanceAmount amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return amount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Amount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public OBTransactionCashBalanceAmount getAmount() {
+        return amount;
+    }
+
+    public void setAmount(OBTransactionCashBalanceAmount amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransactionCashBalance obTransactionCashBalance = (OBTransactionCashBalance) o;
+        return Objects.equals(this.creditDebitIndicator, obTransactionCashBalance.creditDebitIndicator) &&
+                Objects.equals(this.type, obTransactionCashBalance.type) &&
+                Objects.equals(this.amount, obTransactionCashBalance.amount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(creditDebitIndicator, type, amount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransactionCashBalance {\n");
+        sb.append("    creditDebitIndicator: ").append(toIndentedString(creditDebitIndicator)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
@@ -15,15 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 /**
  * Amount of money of the cash balance after a transaction entry is applied to the account..
@@ -34,99 +42,103 @@ import jakarta.validation.constraints.Pattern;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBTransactionCashBalanceAmount {
 
-  private String amount;
+    private String amount;
 
-  private String currency;
+    private String currency;
 
-  public OBTransactionCashBalanceAmount() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OBTransactionCashBalanceAmount(String amount, String currency) {
-    this.amount = amount;
-    this.currency = currency;
-  }
-
-  public OBTransactionCashBalanceAmount amount(String amount) {
-    this.amount = amount;
-    return this;
-  }
-
-  /**
-   * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-   * @return amount
-  */
-  @NotNull @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$") 
-  @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Amount")
-  public String getAmount() {
-    return amount;
-  }
-
-  public void setAmount(String amount) {
-    this.amount = amount;
-  }
-
-  public OBTransactionCashBalanceAmount currency(String currency) {
-    this.currency = currency;
-    return this;
-  }
-
-  /**
-   * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
-   * @return currency
-  */
-  @NotNull @Pattern(regexp = "^[A-Z]{3,3}$") 
-  @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Currency")
-  public String getCurrency() {
-    return currency;
-  }
-
-  public void setCurrency(String currency) {
-    this.currency = currency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OBTransactionCashBalanceAmount() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBTransactionCashBalanceAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
     }
-    OBTransactionCashBalanceAmount obTransactionCashBalanceAmount = (OBTransactionCashBalanceAmount) o;
-    return Objects.equals(this.amount, obTransactionCashBalanceAmount.amount) &&
-        Objects.equals(this.currency, obTransactionCashBalanceAmount.currency);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(amount, currency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OBTransactionCashBalanceAmount {\n");
-    sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
-    sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OBTransactionCashBalanceAmount amount(String amount) {
+        this.amount = amount;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBTransactionCashBalanceAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBTransactionCashBalanceAmount obTransactionCashBalanceAmount = (OBTransactionCashBalanceAmount) o;
+        return Objects.equals(this.amount, obTransactionCashBalanceAmount.amount) &&
+                Objects.equals(this.currency, obTransactionCashBalanceAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBTransactionCashBalanceAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionMutability1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionMutability1Code.java
@@ -15,10 +15,24 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import java.net.URI;
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Specifies the Mutability of the Transaction record.
@@ -26,35 +40,35 @@ import jakarta.annotation.Generated;
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public enum OBTransactionMutability1Code {
-  
-  MUTABLE("Mutable"),
-  
-  IMMUTABLE("Immutable");
 
-  private String value;
+    MUTABLE("Mutable"),
 
-  OBTransactionMutability1Code(String value) {
-    this.value = value;
-  }
+    IMMUTABLE("Immutable");
 
-  @JsonValue
-  public String getValue() {
-    return value;
-  }
+    private String value;
 
-  @Override
-  public String toString() {
-    return String.valueOf(value);
-  }
-
-  @JsonCreator
-  public static OBTransactionMutability1Code fromValue(String value) {
-    for (OBTransactionMutability1Code b : OBTransactionMutability1Code.values()) {
-      if (b.value.equals(value)) {
-        return b;
-      }
+    OBTransactionMutability1Code(String value) {
+        this.value = value;
     }
-    throw new IllegalArgumentException("Unexpected value '" + value + "'");
-  }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBTransactionMutability1Code fromValue(String value) {
+        for (OBTransactionMutability1Code b : OBTransactionMutability1Code.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
@@ -15,15 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other application frequencies that are not available in the standard code list
@@ -33,123 +40,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherApplicationFrequency {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherApplicationFrequency() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherApplicationFrequency(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherApplicationFrequency code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherApplicationFrequency name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherApplicationFrequency description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherApplicationFrequency() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherApplicationFrequency(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherApplicationFrequency otherApplicationFrequency = (OtherApplicationFrequency) o;
-    return Objects.equals(this.code, otherApplicationFrequency.code) &&
-        Objects.equals(this.name, otherApplicationFrequency.name) &&
-        Objects.equals(this.description, otherApplicationFrequency.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherApplicationFrequency {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherApplicationFrequency code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherApplicationFrequency name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherApplicationFrequency description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherApplicationFrequency otherApplicationFrequency = (OtherApplicationFrequency) o;
+        return Objects.equals(this.code, otherApplicationFrequency.code) &&
+                Objects.equals(this.name, otherApplicationFrequency.name) &&
+                Objects.equals(this.description, otherApplicationFrequency.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherApplicationFrequency {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
@@ -15,16 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other application frequencies not covered in the standard code list
@@ -35,123 +42,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherApplicationFrequency1 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherApplicationFrequency1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherApplicationFrequency1(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherApplicationFrequency1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherApplicationFrequency1 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherApplicationFrequency1 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherApplicationFrequency1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherApplicationFrequency1(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherApplicationFrequency1 otherApplicationFrequency1 = (OtherApplicationFrequency1) o;
-    return Objects.equals(this.code, otherApplicationFrequency1.code) &&
-        Objects.equals(this.name, otherApplicationFrequency1.name) &&
-        Objects.equals(this.description, otherApplicationFrequency1.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherApplicationFrequency1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherApplicationFrequency1 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherApplicationFrequency1 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherApplicationFrequency1 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherApplicationFrequency1 otherApplicationFrequency1 = (OtherApplicationFrequency1) o;
+        return Objects.equals(this.code, otherApplicationFrequency1.code) &&
+                Objects.equals(this.name, otherApplicationFrequency1.name) &&
+                Objects.equals(this.description, otherApplicationFrequency1.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherApplicationFrequency1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
@@ -15,15 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other interest rate types which are not available in the standard code list
@@ -33,123 +40,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherBankInterestType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherBankInterestType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherBankInterestType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherBankInterestType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherBankInterestType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherBankInterestType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherBankInterestType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherBankInterestType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherBankInterestType otherBankInterestType = (OtherBankInterestType) o;
-    return Objects.equals(this.code, otherBankInterestType.code) &&
-        Objects.equals(this.name, otherBankInterestType.name) &&
-        Objects.equals(this.description, otherBankInterestType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherBankInterestType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherBankInterestType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherBankInterestType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherBankInterestType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherBankInterestType otherBankInterestType = (OtherBankInterestType) o;
+        return Objects.equals(this.code, otherBankInterestType.code) &&
+                Objects.equals(this.name, otherBankInterestType.name) &&
+                Objects.equals(this.description, otherBankInterestType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherBankInterestType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
@@ -15,15 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other calculation frequency which is not available in the standard code set.
@@ -33,123 +40,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherCalculationFrequency {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherCalculationFrequency() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherCalculationFrequency(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherCalculationFrequency code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherCalculationFrequency name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherCalculationFrequency description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherCalculationFrequency() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherCalculationFrequency(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherCalculationFrequency otherCalculationFrequency = (OtherCalculationFrequency) o;
-    return Objects.equals(this.code, otherCalculationFrequency.code) &&
-        Objects.equals(this.name, otherCalculationFrequency.name) &&
-        Objects.equals(this.description, otherCalculationFrequency.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherCalculationFrequency {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherCalculationFrequency code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherCalculationFrequency name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherCalculationFrequency description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherCalculationFrequency otherCalculationFrequency = (OtherCalculationFrequency) o;
+        return Objects.equals(this.code, otherCalculationFrequency.code) &&
+                Objects.equals(this.name, otherCalculationFrequency.name) &&
+                Objects.equals(this.description, otherCalculationFrequency.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherCalculationFrequency {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
@@ -15,16 +15,23 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * Other calculation frequency which is not available in standard code set.
@@ -35,123 +42,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherCalculationFrequency1 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherCalculationFrequency1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherCalculationFrequency1(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherCalculationFrequency1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherCalculationFrequency1 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherCalculationFrequency1 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherCalculationFrequency1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherCalculationFrequency1(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherCalculationFrequency1 otherCalculationFrequency1 = (OtherCalculationFrequency1) o;
-    return Objects.equals(this.code, otherCalculationFrequency1.code) &&
-        Objects.equals(this.name, otherCalculationFrequency1.name) &&
-        Objects.equals(this.description, otherCalculationFrequency1.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherCalculationFrequency1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherCalculationFrequency1 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherCalculationFrequency1 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherCalculationFrequency1 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherCalculationFrequency1 otherCalculationFrequency1 = (OtherCalculationFrequency1) o;
+        return Objects.equals(this.code, otherCalculationFrequency1.code) &&
+                Objects.equals(this.name, otherCalculationFrequency1.name) &&
+                Objects.equals(this.description, otherCalculationFrequency1.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherCalculationFrequency1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
@@ -15,15 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 
 /**
  * OtherFeeCategoryType
@@ -32,123 +39,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeCategoryType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherFeeCategoryType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeCategoryType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeCategoryType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeCategoryType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeCategoryType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeeCategoryType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeCategoryType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherFeeCategoryType otherFeeCategoryType = (OtherFeeCategoryType) o;
-    return Objects.equals(this.code, otherFeeCategoryType.code) &&
-        Objects.equals(this.name, otherFeeCategoryType.name) &&
-        Objects.equals(this.description, otherFeeCategoryType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeCategoryType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherFeeCategoryType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeCategoryType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeCategoryType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeCategoryType otherFeeCategoryType = (OtherFeeCategoryType) o;
+        return Objects.equals(this.code, otherFeeCategoryType.code) &&
+                Objects.equals(this.name, otherFeeCategoryType.name) &&
+                Objects.equals(this.description, otherFeeCategoryType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeCategoryType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
@@ -33,123 +33,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeRateType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherFeeRateType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeRateType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeRateType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeRateType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeRateType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeeRateType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeRateType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherFeeRateType otherFeeRateType = (OtherFeeRateType) o;
-    return Objects.equals(this.code, otherFeeRateType.code) &&
-        Objects.equals(this.name, otherFeeRateType.name) &&
-        Objects.equals(this.description, otherFeeRateType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeRateType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherFeeRateType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeRateType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeRateType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeRateType otherFeeRateType = (OtherFeeRateType) o;
+        return Objects.equals(this.code, otherFeeRateType.code) &&
+                Objects.equals(this.name, otherFeeRateType.name) &&
+                Objects.equals(this.description, otherFeeRateType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeRateType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
@@ -35,123 +35,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeRateType1 {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherFeeRateType1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeRateType1(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeRateType1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeRateType1 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeRateType1 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeeRateType1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeRateType1(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherFeeRateType1 otherFeeRateType1 = (OtherFeeRateType1) o;
-    return Objects.equals(this.code, otherFeeRateType1.code) &&
-        Objects.equals(this.name, otherFeeRateType1.name) &&
-        Objects.equals(this.description, otherFeeRateType1.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeRateType1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherFeeRateType1 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeRateType1 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeRateType1 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeRateType1 otherFeeRateType1 = (OtherFeeRateType1) o;
+        return Objects.equals(this.code, otherFeeRateType1.code) &&
+                Objects.equals(this.name, otherFeeRateType1.name) &&
+                Objects.equals(this.description, otherFeeRateType1.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeRateType1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
@@ -33,123 +33,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherFeeType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeeType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherFeeType otherFeeType = (OtherFeeType) o;
-    return Objects.equals(this.code, otherFeeType.code) &&
-        Objects.equals(this.name, otherFeeType.name) &&
-        Objects.equals(this.description, otherFeeType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherFeeType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeType otherFeeType = (OtherFeeType) o;
+        return Objects.equals(this.code, otherFeeType.code) &&
+                Objects.equals(this.name, otherFeeType.name) &&
+                Objects.equals(this.description, otherFeeType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
@@ -17,13 +17,12 @@ package uk.org.openbanking.datamodel.account;
 
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -37,183 +36,156 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeType1 {
 
-  private String code;
+    private String code;
 
-  /**
-   * Categorisation of fees and charges into standard categories.
-   */
-  public enum FeeCategoryEnum {
-    OTHER("Other"),
-    
-    SERVICING("Servicing");
+    private FeeCategory feeCategory;
 
-    private String value;
+    private String name;
 
-    FeeCategoryEnum(String value) {
-      this.value = value;
+    private String description;
+
+    public OtherFeeType1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeType1(FeeCategory feeCategory, String name, String description) {
+        this.feeCategory = feeCategory;
+        this.name = name;
+        this.description = description;
+    }
+
+    public OtherFeeType1 code(String code) {
+        this.code = code;
+        return this;
+    }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeType1 feeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+        return this;
+    }
+
+    /**
+     * Get feeCategory
+     *
+     * @return feeCategory
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeCategory", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeCategory")
+    public FeeCategory getFeeCategory() {
+        return feeCategory;
+    }
+
+    public void setFeeCategory(FeeCategory feeCategory) {
+        this.feeCategory = feeCategory;
+    }
+
+    public OtherFeeType1 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeType1 description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeType1 otherFeeType1 = (OtherFeeType1) o;
+        return Objects.equals(this.code, otherFeeType1.code) &&
+                Objects.equals(this.feeCategory, otherFeeType1.feeCategory) &&
+                Objects.equals(this.name, otherFeeType1.name) &&
+                Objects.equals(this.description, otherFeeType1.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, feeCategory, name, description);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeType1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeCategoryEnum fromValue(String value) {
-      for (FeeCategoryEnum b : FeeCategoryEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private FeeCategoryEnum feeCategory;
-
-  private String name;
-
-  private String description;
-
-  public OtherFeeType1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeType1(FeeCategoryEnum feeCategory, String name, String description) {
-    this.feeCategory = feeCategory;
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeType1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeType1 feeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-    return this;
-  }
-
-  /**
-   * Categorisation of fees and charges into standard categories.
-   * @return feeCategory
-  */
-  @NotNull 
-  @Schema(name = "FeeCategory", description = "Categorisation of fees and charges into standard categories.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeCategory")
-  public FeeCategoryEnum getFeeCategory() {
-    return feeCategory;
-  }
-
-  public void setFeeCategory(FeeCategoryEnum feeCategory) {
-    this.feeCategory = feeCategory;
-  }
-
-  public OtherFeeType1 name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeType1 description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OtherFeeType1 otherFeeType1 = (OtherFeeType1) o;
-    return Objects.equals(this.code, otherFeeType1.code) &&
-        Objects.equals(this.feeCategory, otherFeeType1.feeCategory) &&
-        Objects.equals(this.name, otherFeeType1.name) &&
-        Objects.equals(this.description, otherFeeType1.description);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, feeCategory, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeType1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    feeCategory: ").append(toIndentedString(feeCategory)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeTypeInner.java
@@ -35,123 +35,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeeTypeInner {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherFeeTypeInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeeTypeInner(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherFeeTypeInner code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherFeeTypeInner name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherFeeTypeInner description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeeTypeInner() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeeTypeInner(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherFeeTypeInner otherFeeTypeInner = (OtherFeeTypeInner) o;
-    return Objects.equals(this.code, otherFeeTypeInner.code) &&
-        Objects.equals(this.name, otherFeeTypeInner.name) &&
-        Objects.equals(this.description, otherFeeTypeInner.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeeTypeInner {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherFeeTypeInner code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherFeeTypeInner name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherFeeTypeInner description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeeTypeInner otherFeeTypeInner = (OtherFeeTypeInner) o;
+        return Objects.equals(this.code, otherFeeTypeInner.code) &&
+                Objects.equals(this.name, otherFeeTypeInner.name) &&
+                Objects.equals(this.description, otherFeeTypeInner.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeeTypeInner {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
@@ -35,116 +35,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeesCharges {
 
-  @Valid
-  private List<@Valid FeeChargeDetailInner1> feeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid FeeChargeDetailInner1> feeChargeDetail = new ArrayList<>();
 
-  @Valid
-  private List<@Valid FeeChargeCapInner1> feeChargeCap;
+    @Valid
+    private List<@Valid FeeChargeCapInner1> feeChargeCap;
 
-  public OtherFeesCharges() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeesCharges(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OtherFeesCharges feeChargeDetail(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-    return this;
-  }
-
-  public OtherFeesCharges addFeeChargeDetailItem(FeeChargeDetailInner1 feeChargeDetailItem) {
-    if (this.feeChargeDetail == null) {
-      this.feeChargeDetail = new ArrayList<>();
+    public OtherFeesCharges() {
+        super();
     }
-    this.feeChargeDetail.add(feeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Other fees/charges details
-   * @return feeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "FeeChargeDetail", description = "Other fees/charges details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeChargeDetail")
-  public List<@Valid FeeChargeDetailInner1> getFeeChargeDetail() {
-    return feeChargeDetail;
-  }
-
-  public void setFeeChargeDetail(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OtherFeesCharges feeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public OtherFeesCharges addFeeChargeCapItem(FeeChargeCapInner1 feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeesCharges(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
     }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid FeeChargeCapInner1> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherFeesCharges feeChargeDetail(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OtherFeesCharges addFeeChargeDetailItem(FeeChargeDetailInner1 feeChargeDetailItem) {
+        if (this.feeChargeDetail == null) {
+            this.feeChargeDetail = new ArrayList<>();
+        }
+        this.feeChargeDetail.add(feeChargeDetailItem);
+        return this;
     }
-    OtherFeesCharges otherFeesCharges = (OtherFeesCharges) o;
-    return Objects.equals(this.feeChargeDetail, otherFeesCharges.feeChargeDetail) &&
-        Objects.equals(this.feeChargeCap, otherFeesCharges.feeChargeCap);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeChargeDetail, feeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeesCharges {\n");
-    sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Other fees/charges details
+     *
+     * @return feeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeChargeDetail", description = "Other fees/charges details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeChargeDetail")
+    public List<@Valid FeeChargeDetailInner1> getFeeChargeDetail() {
+        return feeChargeDetail;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setFeeChargeDetail(List<@Valid FeeChargeDetailInner1> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+    }
+
+    public OtherFeesCharges feeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public OtherFeesCharges addFeeChargeCapItem(FeeChargeCapInner1 feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid FeeChargeCapInner1> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid FeeChargeCapInner1> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeesCharges otherFeesCharges = (OtherFeesCharges) o;
+        return Objects.equals(this.feeChargeDetail, otherFeesCharges.feeChargeDetail) &&
+                Objects.equals(this.feeChargeCap, otherFeesCharges.feeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeChargeDetail, feeChargeCap);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeesCharges {\n");
+        sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesInner.java
@@ -15,20 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.FeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.FeeChargeDetailInner;
+import uk.org.openbanking.datamodel.account.OtherTariffType;
+import uk.org.openbanking.datamodel.account.TariffType;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
@@ -39,225 +52,195 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherFeesChargesInner {
 
-  /**
-   * TariffType which defines the fee and charges.
-   */
-  public enum TariffTypeEnum {
-    ELECTRONIC("Electronic"),
-    
-    MIXED("Mixed"),
-    
-    OTHER("Other");
+    private TariffType tariffType;
 
-    private String value;
+    private String tariffName;
 
-    TariffTypeEnum(String value) {
-      this.value = value;
+    private OtherTariffType otherTariffType;
+
+    @Valid
+    private List<@Valid FeeChargeDetailInner> feeChargeDetail = new ArrayList<>();
+
+    @Valid
+    private List<@Valid FeeChargeCapInner> feeChargeCap;
+
+    public OtherFeesChargesInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherFeesChargesInner(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+    }
+
+    public OtherFeesChargesInner tariffType(TariffType tariffType) {
+        this.tariffType = tariffType;
+        return this;
+    }
+
+    /**
+     * Get tariffType
+     *
+     * @return tariffType
+     */
+    @Valid
+    @Schema(name = "TariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TariffType")
+    public TariffType getTariffType() {
+        return tariffType;
+    }
+
+    public void setTariffType(TariffType tariffType) {
+        this.tariffType = tariffType;
+    }
+
+    public OtherFeesChargesInner tariffName(String tariffName) {
+        this.tariffName = tariffName;
+        return this;
+    }
+
+    /**
+     * Name of the tariff
+     *
+     * @return tariffName
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "TariffName", description = "Name of the tariff", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TariffName")
+    public String getTariffName() {
+        return tariffName;
+    }
+
+    public void setTariffName(String tariffName) {
+        this.tariffName = tariffName;
+    }
+
+    public OtherFeesChargesInner otherTariffType(OtherTariffType otherTariffType) {
+        this.otherTariffType = otherTariffType;
+        return this;
+    }
+
+    /**
+     * Get otherTariffType
+     *
+     * @return otherTariffType
+     */
+    @Valid
+    @Schema(name = "OtherTariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherTariffType")
+    public OtherTariffType getOtherTariffType() {
+        return otherTariffType;
+    }
+
+    public void setOtherTariffType(OtherTariffType otherTariffType) {
+        this.otherTariffType = otherTariffType;
+    }
+
+    public OtherFeesChargesInner feeChargeDetail(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+        return this;
+    }
+
+    public OtherFeesChargesInner addFeeChargeDetailItem(FeeChargeDetailInner feeChargeDetailItem) {
+        if (this.feeChargeDetail == null) {
+            this.feeChargeDetail = new ArrayList<>();
+        }
+        this.feeChargeDetail.add(feeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Other fees/charges details
+     *
+     * @return feeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeChargeDetail", description = "Other fees/charges details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeChargeDetail")
+    public List<@Valid FeeChargeDetailInner> getFeeChargeDetail() {
+        return feeChargeDetail;
+    }
+
+    public void setFeeChargeDetail(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
+        this.feeChargeDetail = feeChargeDetail;
+    }
+
+    public OtherFeesChargesInner feeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+        return this;
+    }
+
+    public OtherFeesChargesInner addFeeChargeCapItem(FeeChargeCapInner feeChargeCapItem) {
+        if (this.feeChargeCap == null) {
+            this.feeChargeCap = new ArrayList<>();
+        }
+        this.feeChargeCap.add(feeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
+     *
+     * @return feeChargeCap
+     */
+    @Valid
+    @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeChargeCap")
+    public List<@Valid FeeChargeCapInner> getFeeChargeCap() {
+        return feeChargeCap;
+    }
+
+    public void setFeeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
+        this.feeChargeCap = feeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherFeesChargesInner otherFeesChargesInner = (OtherFeesChargesInner) o;
+        return Objects.equals(this.tariffType, otherFeesChargesInner.tariffType) &&
+                Objects.equals(this.tariffName, otherFeesChargesInner.tariffName) &&
+                Objects.equals(this.otherTariffType, otherFeesChargesInner.otherTariffType) &&
+                Objects.equals(this.feeChargeDetail, otherFeesChargesInner.feeChargeDetail) &&
+                Objects.equals(this.feeChargeCap, otherFeesChargesInner.feeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tariffType, tariffName, otherTariffType, feeChargeDetail, feeChargeCap);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherFeesChargesInner {\n");
+        sb.append("    tariffType: ").append(toIndentedString(tariffType)).append("\n");
+        sb.append("    tariffName: ").append(toIndentedString(tariffName)).append("\n");
+        sb.append("    otherTariffType: ").append(toIndentedString(otherTariffType)).append("\n");
+        sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
+        sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TariffTypeEnum fromValue(String value) {
-      for (TariffTypeEnum b : TariffTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TariffTypeEnum tariffType;
-
-  private String tariffName;
-
-  private OtherTariffType otherTariffType;
-
-  @Valid
-  private List<@Valid FeeChargeDetailInner> feeChargeDetail = new ArrayList<>();
-
-  @Valid
-  private List<@Valid FeeChargeCapInner> feeChargeCap;
-
-  public OtherFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherFeesChargesInner(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OtherFeesChargesInner tariffType(TariffTypeEnum tariffType) {
-    this.tariffType = tariffType;
-    return this;
-  }
-
-  /**
-   * TariffType which defines the fee and charges.
-   * @return tariffType
-  */
-  
-  @Schema(name = "TariffType", description = "TariffType which defines the fee and charges.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TariffType")
-  public TariffTypeEnum getTariffType() {
-    return tariffType;
-  }
-
-  public void setTariffType(TariffTypeEnum tariffType) {
-    this.tariffType = tariffType;
-  }
-
-  public OtherFeesChargesInner tariffName(String tariffName) {
-    this.tariffName = tariffName;
-    return this;
-  }
-
-  /**
-   * Name of the tariff
-   * @return tariffName
-  */
-  @Size(min = 1, max = 350) 
-  @Schema(name = "TariffName", description = "Name of the tariff", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TariffName")
-  public String getTariffName() {
-    return tariffName;
-  }
-
-  public void setTariffName(String tariffName) {
-    this.tariffName = tariffName;
-  }
-
-  public OtherFeesChargesInner otherTariffType(OtherTariffType otherTariffType) {
-    this.otherTariffType = otherTariffType;
-    return this;
-  }
-
-  /**
-   * Get otherTariffType
-   * @return otherTariffType
-  */
-  @Valid 
-  @Schema(name = "OtherTariffType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherTariffType")
-  public OtherTariffType getOtherTariffType() {
-    return otherTariffType;
-  }
-
-  public void setOtherTariffType(OtherTariffType otherTariffType) {
-    this.otherTariffType = otherTariffType;
-  }
-
-  public OtherFeesChargesInner feeChargeDetail(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-    return this;
-  }
-
-  public OtherFeesChargesInner addFeeChargeDetailItem(FeeChargeDetailInner feeChargeDetailItem) {
-    if (this.feeChargeDetail == null) {
-      this.feeChargeDetail = new ArrayList<>();
-    }
-    this.feeChargeDetail.add(feeChargeDetailItem);
-    return this;
-  }
-
-  /**
-   * Other fees/charges details
-   * @return feeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "FeeChargeDetail", description = "Other fees/charges details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeChargeDetail")
-  public List<@Valid FeeChargeDetailInner> getFeeChargeDetail() {
-    return feeChargeDetail;
-  }
-
-  public void setFeeChargeDetail(List<@Valid FeeChargeDetailInner> feeChargeDetail) {
-    this.feeChargeDetail = feeChargeDetail;
-  }
-
-  public OtherFeesChargesInner feeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-    return this;
-  }
-
-  public OtherFeesChargesInner addFeeChargeCapItem(FeeChargeCapInner feeChargeCapItem) {
-    if (this.feeChargeCap == null) {
-      this.feeChargeCap = new ArrayList<>();
-    }
-    this.feeChargeCap.add(feeChargeCapItem);
-    return this;
-  }
-
-  /**
-   * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
-   * @return feeChargeCap
-  */
-  @Valid 
-  @Schema(name = "FeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeChargeCap")
-  public List<@Valid FeeChargeCapInner> getFeeChargeCap() {
-    return feeChargeCap;
-  }
-
-  public void setFeeChargeCap(List<@Valid FeeChargeCapInner> feeChargeCap) {
-    this.feeChargeCap = feeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OtherFeesChargesInner otherFeesChargesInner = (OtherFeesChargesInner) o;
-    return Objects.equals(this.tariffType, otherFeesChargesInner.tariffType) &&
-        Objects.equals(this.tariffName, otherFeesChargesInner.tariffName) &&
-        Objects.equals(this.otherTariffType, otherFeesChargesInner.otherTariffType) &&
-        Objects.equals(this.feeChargeDetail, otherFeesChargesInner.feeChargeDetail) &&
-        Objects.equals(this.feeChargeCap, otherFeesChargesInner.feeChargeCap);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tariffType, tariffName, otherTariffType, feeChargeDetail, feeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherFeesChargesInner {\n");
-    sb.append("    tariffType: ").append(toIndentedString(tariffType)).append("\n");
-    sb.append("    tariffName: ").append(toIndentedString(tariffName)).append("\n");
-    sb.append("    otherTariffType: ").append(toIndentedString(otherTariffType)).append("\n");
-    sb.append("    feeChargeDetail: ").append(toIndentedString(feeChargeDetail)).append("\n");
-    sb.append("    feeChargeCap: ").append(toIndentedString(feeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
@@ -33,123 +33,129 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OtherTariffType {
 
-  private String code;
+    private String code;
 
-  private String name;
+    private String name;
 
-  private String description;
+    private String description;
 
-  public OtherTariffType() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OtherTariffType(String name, String description) {
-    this.name = name;
-    this.description = description;
-  }
-
-  public OtherTariffType code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * The four letter Mnemonic used within an XML file to identify a code
-   * @return code
-  */
-  @Pattern(regexp = "^\\w{0,4}$") @Size(min = 0, max = 4) 
-  @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public OtherTariffType name(String name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Long name associated with the code
-   * @return name
-  */
-  @NotNull @Size(min = 1, max = 70) 
-  @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Name")
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public OtherTariffType description(String description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Description to describe the purpose of the code
-   * @return description
-  */
-  @NotNull @Size(min = 1, max = 350) 
-  @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Description")
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OtherTariffType() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OtherTariffType(String name, String description) {
+        this.name = name;
+        this.description = description;
     }
-    OtherTariffType otherTariffType = (OtherTariffType) o;
-    return Objects.equals(this.code, otherTariffType.code) &&
-        Objects.equals(this.name, otherTariffType.name) &&
-        Objects.equals(this.description, otherTariffType.description);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, name, description);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OtherTariffType {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    name: ").append(toIndentedString(name)).append("\n");
-    sb.append("    description: ").append(toIndentedString(description)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public OtherTariffType code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * The four letter Mnemonic used within an XML file to identify a code
+     *
+     * @return code
+     */
+    @Pattern(regexp = "^\\w{0,4}$")
+    @Size(min = 0, max = 4)
+    @Schema(name = "Code", description = "The four letter Mnemonic used within an XML file to identify a code", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OtherTariffType name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Long name associated with the code
+     *
+     * @return name
+     */
+    @NotNull
+    @Size(min = 1, max = 70)
+    @Schema(name = "Name", description = "Long name associated with the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OtherTariffType description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Description to describe the purpose of the code
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 350)
+    @Schema(name = "Description", description = "Description to describe the purpose of the code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OtherTariffType otherTariffType = (OtherTariffType) o;
+        return Objects.equals(this.code, otherTariffType.code) &&
+                Objects.equals(this.name, otherTariffType.name) &&
+                Objects.equals(this.description, otherTariffType.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, name, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OtherTariffType {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
@@ -35,116 +35,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class Overdraft {
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet = new ArrayList<>();
 
-  public Overdraft() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public Overdraft(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  public Overdraft notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public Overdraft addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public Overdraft() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Associated Notes about the overdraft rates
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Associated Notes about the overdraft rates", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public Overdraft overdraftTierBandSet(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-    return this;
-  }
-
-  public Overdraft addOverdraftTierBandSetItem(OverdraftTierBandSetInner overdraftTierBandSetItem) {
-    if (this.overdraftTierBandSet == null) {
-      this.overdraftTierBandSet = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public Overdraft(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
     }
-    this.overdraftTierBandSet.add(overdraftTierBandSetItem);
-    return this;
-  }
 
-  /**
-   * Tier band set details
-   * @return overdraftTierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBandSet", description = "Tier band set details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBandSet")
-  public List<@Valid OverdraftTierBandSetInner> getOverdraftTierBandSet() {
-    return overdraftTierBandSet;
-  }
-
-  public void setOverdraftTierBandSet(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public Overdraft notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public Overdraft addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
     }
-    Overdraft overdraft = (Overdraft) o;
-    return Objects.equals(this.notes, overdraft.notes) &&
-        Objects.equals(this.overdraftTierBandSet, overdraft.overdraftTierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(notes, overdraftTierBandSet);
-  }
+    /**
+     * Associated Notes about the overdraft rates
+     *
+     * @return notes
+     */
 
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class Overdraft {\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    @Schema(name = "Notes", description = "Associated Notes about the overdraft rates", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public Overdraft overdraftTierBandSet(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+        return this;
+    }
+
+    public Overdraft addOverdraftTierBandSetItem(OverdraftTierBandSetInner overdraftTierBandSetItem) {
+        if (this.overdraftTierBandSet == null) {
+            this.overdraftTierBandSet = new ArrayList<>();
+        }
+        this.overdraftTierBandSet.add(overdraftTierBandSetItem);
+        return this;
+    }
+
+    /**
+     * Tier band set details
+     *
+     * @return overdraftTierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBandSet", description = "Tier band set details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBandSet")
+    public List<@Valid OverdraftTierBandSetInner> getOverdraftTierBandSet() {
+        return overdraftTierBandSet;
+    }
+
+    public void setOverdraftTierBandSet(List<@Valid OverdraftTierBandSetInner> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Overdraft overdraft = (Overdraft) o;
+        return Objects.equals(this.notes, overdraft.notes) &&
+                Objects.equals(this.overdraftTierBandSet, overdraft.overdraftTierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notes, overdraftTierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Overdraft {\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
@@ -37,116 +37,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class Overdraft1 {
 
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
 
-  @Valid
-  private List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet = new ArrayList<>();
 
-  public Overdraft1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public Overdraft1(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  public Overdraft1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public Overdraft1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
+    public Overdraft1() {
+        super();
     }
-    this.notes.add(notesItem);
-    return this;
-  }
 
-  /**
-   * Associated Notes about the overdraft rates
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Associated Notes about the overdraft rates", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public Overdraft1 overdraftTierBandSet(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-    return this;
-  }
-
-  public Overdraft1 addOverdraftTierBandSetItem(OverdraftTierBandSetInner1 overdraftTierBandSetItem) {
-    if (this.overdraftTierBandSet == null) {
-      this.overdraftTierBandSet = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public Overdraft1(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
     }
-    this.overdraftTierBandSet.add(overdraftTierBandSetItem);
-    return this;
-  }
 
-  /**
-   * Tier band set details
-   * @return overdraftTierBandSet
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBandSet", description = "Tier band set details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBandSet")
-  public List<@Valid OverdraftTierBandSetInner1> getOverdraftTierBandSet() {
-    return overdraftTierBandSet;
-  }
-
-  public void setOverdraftTierBandSet(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
-    this.overdraftTierBandSet = overdraftTierBandSet;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public Overdraft1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public Overdraft1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
     }
-    Overdraft1 overdraft1 = (Overdraft1) o;
-    return Objects.equals(this.notes, overdraft1.notes) &&
-        Objects.equals(this.overdraftTierBandSet, overdraft1.overdraftTierBandSet);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(notes, overdraftTierBandSet);
-  }
+    /**
+     * Associated Notes about the overdraft rates
+     *
+     * @return notes
+     */
 
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class Overdraft1 {\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    @Schema(name = "Notes", description = "Associated Notes about the overdraft rates", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public Overdraft1 overdraftTierBandSet(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+        return this;
+    }
+
+    public Overdraft1 addOverdraftTierBandSetItem(OverdraftTierBandSetInner1 overdraftTierBandSetItem) {
+        if (this.overdraftTierBandSet == null) {
+            this.overdraftTierBandSet = new ArrayList<>();
+        }
+        this.overdraftTierBandSet.add(overdraftTierBandSetItem);
+        return this;
+    }
+
+    /**
+     * Tier band set details
+     *
+     * @return overdraftTierBandSet
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBandSet", description = "Tier band set details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBandSet")
+    public List<@Valid OverdraftTierBandSetInner1> getOverdraftTierBandSet() {
+        return overdraftTierBandSet;
+    }
+
+    public void setOverdraftTierBandSet(List<@Valid OverdraftTierBandSetInner1> overdraftTierBandSet) {
+        this.overdraftTierBandSet = overdraftTierBandSet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Overdraft1 overdraft1 = (Overdraft1) o;
+        return Objects.equals(this.notes, overdraft1.notes) &&
+                Objects.equals(this.overdraftTierBandSet, overdraft1.overdraftTierBandSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(notes, overdraftTierBandSet);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Overdraft1 {\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBandSet: ").append(toIndentedString(overdraftTierBandSet)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCap.java
@@ -15,20 +15,32 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.CappingPeriod1;
+import uk.org.openbanking.datamodel.account.FeeType2Inner1;
+import uk.org.openbanking.datamodel.account.MinMaxType1;
+import uk.org.openbanking.datamodel.account.OtherFeeTypeInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about any caps (maximum charges) that apply to a particular fee/charge
@@ -38,405 +50,281 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeeChargeCap {
 
-  /**
-   * Overdraft fee type
-   */
-  public enum FeeTypeEnum {
-    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
-    
-    EMERGENCYBORROWING("EmergencyBorrowing"),
-    
-    BORROWINGITEM("BorrowingItem"),
-    
-    OVERDRAFTRENEWAL("OverdraftRenewal"),
-    
-    ANNUALREVIEW("AnnualReview"),
-    
-    OVERDRAFTSETUP("OverdraftSetup"),
-    
-    SURCHARGE("Surcharge"),
-    
-    TEMPOVERDRAFT("TempOverdraft"),
-    
-    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
-    
-    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
-    
-    OTHER("Other"),
-    
-    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+    @Valid
+    private List<@Valid FeeType2Inner1> feeType = new ArrayList<>();
 
-    private String value;
+    private Boolean overdraftControlIndicator;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private MinMaxType1 minMaxType;
+
+    private Float feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private CappingPeriod1 cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OtherFeeTypeInner> otherFeeType;
+
+    public OverdraftFeeChargeCap() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeeChargeCap(List<@Valid FeeType2Inner1> feeType, MinMaxType1 minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCap feeType(List<@Valid FeeType2Inner1> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCap addFeeTypeItem(FeeType2Inner1 feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Fee/charge type which is being capped
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid FeeType2Inner1> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid FeeType2Inner1> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OverdraftFeeChargeCap overdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+        return this;
+    }
+
+    /**
+     * Specifies for the overdraft control feature/benefit
+     *
+     * @return overdraftControlIndicator
+     */
+
+    @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftControlIndicator")
+    public Boolean getOverdraftControlIndicator() {
+        return overdraftControlIndicator;
+    }
+
+    public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+    }
+
+    public OverdraftFeeChargeCap minMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public MinMaxType1 getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCap feeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Float getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OverdraftFeeChargeCap feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OverdraftFeeChargeCap cappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public CappingPeriod1 getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OverdraftFeeChargeCap notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftFeeChargeCap addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Notes related to Overdraft fee charge cap
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftFeeChargeCap otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCap addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Other fee type code which is not available in the standard code set
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeeChargeCap overdraftFeeChargeCap = (OverdraftFeeChargeCap) o;
+        return Objects.equals(this.feeType, overdraftFeeChargeCap.feeType) &&
+                Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeCap.overdraftControlIndicator) &&
+                Objects.equals(this.minMaxType, overdraftFeeChargeCap.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCap.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, overdraftFeeChargeCap.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, overdraftFeeChargeCap.cappingPeriod) &&
+                Objects.equals(this.notes, overdraftFeeChargeCap.notes) &&
+                Objects.equals(this.otherFeeType, overdraftFeeChargeCap.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, overdraftControlIndicator, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeeChargeCap {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private Boolean overdraftControlIndicator;
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   */
-  public enum MinMaxTypeEnum {
-    MINIMUM("Minimum"),
-    
-    MAXIMUM("Maximum");
-
-    private String value;
-
-    MinMaxTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MinMaxTypeEnum fromValue(String value) {
-      for (MinMaxTypeEnum b : MinMaxTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MinMaxTypeEnum minMaxType;
-
-  private Float feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   */
-  public enum CappingPeriodEnum {
-    ACADEMICTERM("AcademicTerm"),
-    
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    CappingPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CappingPeriodEnum fromValue(String value) {
-      for (CappingPeriodEnum b : CappingPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CappingPeriodEnum cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OtherFeeTypeInner> otherFeeType;
-
-  public OverdraftFeeChargeCap() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeeChargeCap(List<FeeTypeEnum> feeType, MinMaxTypeEnum minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCap feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCap addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Fee/charge type which is being capped
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OverdraftFeeChargeCap overdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-    return this;
-  }
-
-  /**
-   * Specifies for the overdraft control feature/benefit
-   * @return overdraftControlIndicator
-  */
-  
-  @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftControlIndicator")
-  public Boolean getOverdraftControlIndicator() {
-    return overdraftControlIndicator;
-  }
-
-  public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-  }
-
-  public OverdraftFeeChargeCap minMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   * @return minMaxType
-  */
-  @NotNull 
-  @Schema(name = "MinMaxType", description = "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public MinMaxTypeEnum getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCap feeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Float getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OverdraftFeeChargeCap feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OverdraftFeeChargeCap cappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   * @return cappingPeriod
-  */
-  
-  @Schema(name = "CappingPeriod", description = "Period e.g. day, week, month etc. for which the fee/charge is capped", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public CappingPeriodEnum getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OverdraftFeeChargeCap notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftFeeChargeCap addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Notes related to Overdraft fee charge cap
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftFeeChargeCap otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCap addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Other fee type code which is not available in the standard code set
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftFeeChargeCap overdraftFeeChargeCap = (OverdraftFeeChargeCap) o;
-    return Objects.equals(this.feeType, overdraftFeeChargeCap.feeType) &&
-        Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeCap.overdraftControlIndicator) &&
-        Objects.equals(this.minMaxType, overdraftFeeChargeCap.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCap.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, overdraftFeeChargeCap.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, overdraftFeeChargeCap.cappingPeriod) &&
-        Objects.equals(this.notes, overdraftFeeChargeCap.notes) &&
-        Objects.equals(this.otherFeeType, overdraftFeeChargeCap.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, overdraftControlIndicator, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeeChargeCap {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCapInner.java
@@ -15,21 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.CappingPeriod;
+import uk.org.openbanking.datamodel.account.FeeTypeInner;
+import uk.org.openbanking.datamodel.account.MinMaxType;
+import uk.org.openbanking.datamodel.account.OtherFeeTypeInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
@@ -40,379 +52,256 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeeChargeCapInner {
 
-  /**
-   * Overdraft fee type
-   */
-  public enum FeeTypeEnum {
-    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
-    
-    ANNUALREVIEW("AnnualReview"),
-    
-    EMERGENCYBORROWING("EmergencyBorrowing"),
-    
-    BORROWINGITEM("BorrowingItem"),
-    
-    OVERDRAFTRENEWAL("OverdraftRenewal"),
-    
-    OVERDRAFTSETUP("OverdraftSetup"),
-    
-    SURCHARGE("Surcharge"),
-    
-    TEMPOVERDRAFT("TempOverdraft"),
-    
-    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
-    
-    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
-    
-    OTHER("Other"),
-    
-    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+    @Valid
+    private List<@Valid FeeTypeInner> feeType = new ArrayList<>();
 
-    private String value;
+    private MinMaxType minMaxType;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Float feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private CappingPeriod cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OtherFeeTypeInner> otherFeeType;
+
+    public OverdraftFeeChargeCapInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeeChargeCapInner(List<@Valid FeeTypeInner> feeType, MinMaxType minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCapInner feeType(List<@Valid FeeTypeInner> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner addFeeTypeItem(FeeTypeInner feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Fee/charge type which is being capped
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid FeeTypeInner> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid FeeTypeInner> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OverdraftFeeChargeCapInner minMaxType(MinMaxType minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public MinMaxType getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(MinMaxType minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCapInner feeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Float getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OverdraftFeeChargeCapInner feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OverdraftFeeChargeCapInner cappingPeriod(CappingPeriod cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public CappingPeriod getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(CappingPeriod cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OverdraftFeeChargeCapInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Notes related to Overdraft fee charge cap
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftFeeChargeCapInner otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Other fee type code which is not available in the standard code set
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeeChargeCapInner overdraftFeeChargeCapInner = (OverdraftFeeChargeCapInner) o;
+        return Objects.equals(this.feeType, overdraftFeeChargeCapInner.feeType) &&
+                Objects.equals(this.minMaxType, overdraftFeeChargeCapInner.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCapInner.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, overdraftFeeChargeCapInner.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, overdraftFeeChargeCapInner.cappingPeriod) &&
+                Objects.equals(this.notes, overdraftFeeChargeCapInner.notes) &&
+                Objects.equals(this.otherFeeType, overdraftFeeChargeCapInner.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeeChargeCapInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  /**
-   * Min Max type
-   */
-  public enum MinMaxTypeEnum {
-    MINIMUM("Minimum"),
-    
-    MAXIMUM("Maximum");
-
-    private String value;
-
-    MinMaxTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MinMaxTypeEnum fromValue(String value) {
-      for (MinMaxTypeEnum b : MinMaxTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MinMaxTypeEnum minMaxType;
-
-  private Float feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   */
-  public enum CappingPeriodEnum {
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    CappingPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CappingPeriodEnum fromValue(String value) {
-      for (CappingPeriodEnum b : CappingPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CappingPeriodEnum cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OtherFeeTypeInner> otherFeeType;
-
-  public OverdraftFeeChargeCapInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeeChargeCapInner(List<FeeTypeEnum> feeType, MinMaxTypeEnum minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCapInner feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Fee/charge type which is being capped
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OverdraftFeeChargeCapInner minMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Min Max type
-   * @return minMaxType
-  */
-  @NotNull 
-  @Schema(name = "MinMaxType", description = "Min Max type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public MinMaxTypeEnum getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCapInner feeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Float getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OverdraftFeeChargeCapInner feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OverdraftFeeChargeCapInner cappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   * @return cappingPeriod
-  */
-  
-  @Schema(name = "CappingPeriod", description = "Period e.g. day, week, month etc. for which the fee/charge is capped", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public CappingPeriodEnum getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OverdraftFeeChargeCapInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Notes related to Overdraft fee charge cap
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftFeeChargeCapInner otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Other fee type code which is not available in the standard code set
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftFeeChargeCapInner overdraftFeeChargeCapInner = (OverdraftFeeChargeCapInner) o;
-    return Objects.equals(this.feeType, overdraftFeeChargeCapInner.feeType) &&
-        Objects.equals(this.minMaxType, overdraftFeeChargeCapInner.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCapInner.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, overdraftFeeChargeCapInner.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, overdraftFeeChargeCapInner.cappingPeriod) &&
-        Objects.equals(this.notes, overdraftFeeChargeCapInner.notes) &&
-        Objects.equals(this.otherFeeType, overdraftFeeChargeCapInner.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeeChargeCapInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeCapInner1.java
@@ -15,21 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.CappingPeriod1;
+import uk.org.openbanking.datamodel.account.FeeType2Inner1;
+import uk.org.openbanking.datamodel.account.MinMaxType1;
+import uk.org.openbanking.datamodel.account.OtherFeeTypeInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about any caps (maximum charges) that apply to a particular fee/charge
@@ -40,405 +52,281 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeeChargeCapInner1 {
 
-  /**
-   * Overdraft fee type
-   */
-  public enum FeeTypeEnum {
-    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
-    
-    EMERGENCYBORROWING("EmergencyBorrowing"),
-    
-    BORROWINGITEM("BorrowingItem"),
-    
-    OVERDRAFTRENEWAL("OverdraftRenewal"),
-    
-    ANNUALREVIEW("AnnualReview"),
-    
-    OVERDRAFTSETUP("OverdraftSetup"),
-    
-    SURCHARGE("Surcharge"),
-    
-    TEMPOVERDRAFT("TempOverdraft"),
-    
-    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
-    
-    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
-    
-    OTHER("Other"),
-    
-    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+    @Valid
+    private List<@Valid FeeType2Inner1> feeType = new ArrayList<>();
 
-    private String value;
+    private Boolean overdraftControlIndicator;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private MinMaxType1 minMaxType;
+
+    private Float feeCapOccurrence;
+
+    private String feeCapAmount;
+
+    private CappingPeriod1 cappingPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OtherFeeTypeInner> otherFeeType;
+
+    public OverdraftFeeChargeCapInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeeChargeCapInner1(List<@Valid FeeType2Inner1> feeType, MinMaxType1 minMaxType) {
+        this.feeType = feeType;
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCapInner1 feeType(List<@Valid FeeType2Inner1> feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner1 addFeeTypeItem(FeeType2Inner1 feeTypeItem) {
+        if (this.feeType == null) {
+            this.feeType = new ArrayList<>();
+        }
+        this.feeType.add(feeTypeItem);
+        return this;
+    }
+
+    /**
+     * Fee/charge type which is being capped
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public List<@Valid FeeType2Inner1> getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(List<@Valid FeeType2Inner1> feeType) {
+        this.feeType = feeType;
+    }
+
+    public OverdraftFeeChargeCapInner1 overdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+        return this;
+    }
+
+    /**
+     * Specifies for the overdraft control feature/benefit
+     *
+     * @return overdraftControlIndicator
+     */
+
+    @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftControlIndicator")
+    public Boolean getOverdraftControlIndicator() {
+        return overdraftControlIndicator;
+    }
+
+    public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+    }
+
+    public OverdraftFeeChargeCapInner1 minMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+        return this;
+    }
+
+    /**
+     * Get minMaxType
+     *
+     * @return minMaxType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "MinMaxType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("MinMaxType")
+    public MinMaxType1 getMinMaxType() {
+        return minMaxType;
+    }
+
+    public void setMinMaxType(MinMaxType1 minMaxType) {
+        this.minMaxType = minMaxType;
+    }
+
+    public OverdraftFeeChargeCapInner1 feeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+        return this;
+    }
+
+    /**
+     * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
+     *
+     * @return feeCapOccurrence
+     */
+
+    @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapOccurrence")
+    public Float getFeeCapOccurrence() {
+        return feeCapOccurrence;
+    }
+
+    public void setFeeCapOccurrence(Float feeCapOccurrence) {
+        this.feeCapOccurrence = feeCapOccurrence;
+    }
+
+    public OverdraftFeeChargeCapInner1 feeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+        return this;
+    }
+
+    /**
+     * Cap amount charged for a fee/charge
+     *
+     * @return feeCapAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeCapAmount")
+    public String getFeeCapAmount() {
+        return feeCapAmount;
+    }
+
+    public void setFeeCapAmount(String feeCapAmount) {
+        this.feeCapAmount = feeCapAmount;
+    }
+
+    public OverdraftFeeChargeCapInner1 cappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+        return this;
+    }
+
+    /**
+     * Get cappingPeriod
+     *
+     * @return cappingPeriod
+     */
+    @Valid
+    @Schema(name = "CappingPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CappingPeriod")
+    public CappingPeriod1 getCappingPeriod() {
+        return cappingPeriod;
+    }
+
+    public void setCappingPeriod(CappingPeriod1 cappingPeriod) {
+        this.cappingPeriod = cappingPeriod;
+    }
+
+    public OverdraftFeeChargeCapInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Notes related to Overdraft fee charge cap
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftFeeChargeCapInner1 otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    public OverdraftFeeChargeCapInner1 addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
+        if (this.otherFeeType == null) {
+            this.otherFeeType = new ArrayList<>();
+        }
+        this.otherFeeType.add(otherFeeTypeItem);
+        return this;
+    }
+
+    /**
+     * Other fee type code which is not available in the standard code set
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeeChargeCapInner1 overdraftFeeChargeCapInner1 = (OverdraftFeeChargeCapInner1) o;
+        return Objects.equals(this.feeType, overdraftFeeChargeCapInner1.feeType) &&
+                Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeCapInner1.overdraftControlIndicator) &&
+                Objects.equals(this.minMaxType, overdraftFeeChargeCapInner1.minMaxType) &&
+                Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCapInner1.feeCapOccurrence) &&
+                Objects.equals(this.feeCapAmount, overdraftFeeChargeCapInner1.feeCapAmount) &&
+                Objects.equals(this.cappingPeriod, overdraftFeeChargeCapInner1.cappingPeriod) &&
+                Objects.equals(this.notes, overdraftFeeChargeCapInner1.notes) &&
+                Objects.equals(this.otherFeeType, overdraftFeeChargeCapInner1.otherFeeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, overdraftControlIndicator, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeeChargeCapInner1 {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
+        sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
+        sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
+        sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
+        sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<FeeTypeEnum> feeType = new ArrayList<>();
-
-  private Boolean overdraftControlIndicator;
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   */
-  public enum MinMaxTypeEnum {
-    MINIMUM("Minimum"),
-    
-    MAXIMUM("Maximum");
-
-    private String value;
-
-    MinMaxTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static MinMaxTypeEnum fromValue(String value) {
-      for (MinMaxTypeEnum b : MinMaxTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private MinMaxTypeEnum minMaxType;
-
-  private Float feeCapOccurrence;
-
-  private String feeCapAmount;
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   */
-  public enum CappingPeriodEnum {
-    ACADEMICTERM("AcademicTerm"),
-    
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    CappingPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CappingPeriodEnum fromValue(String value) {
-      for (CappingPeriodEnum b : CappingPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CappingPeriodEnum cappingPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OtherFeeTypeInner> otherFeeType;
-
-  public OverdraftFeeChargeCapInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeeChargeCapInner1(List<FeeTypeEnum> feeType, MinMaxTypeEnum minMaxType) {
-    this.feeType = feeType;
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCapInner1 feeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner1 addFeeTypeItem(FeeTypeEnum feeTypeItem) {
-    if (this.feeType == null) {
-      this.feeType = new ArrayList<>();
-    }
-    this.feeType.add(feeTypeItem);
-    return this;
-  }
-
-  /**
-   * Fee/charge type which is being capped
-   * @return feeType
-  */
-  @NotNull @Size(min = 1) 
-  @Schema(name = "FeeType", description = "Fee/charge type which is being capped", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public List<FeeTypeEnum> getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(List<FeeTypeEnum> feeType) {
-    this.feeType = feeType;
-  }
-
-  public OverdraftFeeChargeCapInner1 overdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-    return this;
-  }
-
-  /**
-   * Specifies for the overdraft control feature/benefit
-   * @return overdraftControlIndicator
-  */
-  
-  @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftControlIndicator")
-  public Boolean getOverdraftControlIndicator() {
-    return overdraftControlIndicator;
-  }
-
-  public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-  }
-
-  public OverdraftFeeChargeCapInner1 minMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-    return this;
-  }
-
-  /**
-   * Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution
-   * @return minMaxType
-  */
-  @NotNull 
-  @Schema(name = "MinMaxType", description = "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("MinMaxType")
-  public MinMaxTypeEnum getMinMaxType() {
-    return minMaxType;
-  }
-
-  public void setMinMaxType(MinMaxTypeEnum minMaxType) {
-    this.minMaxType = minMaxType;
-  }
-
-  public OverdraftFeeChargeCapInner1 feeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-    return this;
-  }
-
-  /**
-   * fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount
-   * @return feeCapOccurrence
-  */
-  
-  @Schema(name = "FeeCapOccurrence", description = "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapOccurrence")
-  public Float getFeeCapOccurrence() {
-    return feeCapOccurrence;
-  }
-
-  public void setFeeCapOccurrence(Float feeCapOccurrence) {
-    this.feeCapOccurrence = feeCapOccurrence;
-  }
-
-  public OverdraftFeeChargeCapInner1 feeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-    return this;
-  }
-
-  /**
-   * Cap amount charged for a fee/charge
-   * @return feeCapAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeCapAmount", description = "Cap amount charged for a fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeCapAmount")
-  public String getFeeCapAmount() {
-    return feeCapAmount;
-  }
-
-  public void setFeeCapAmount(String feeCapAmount) {
-    this.feeCapAmount = feeCapAmount;
-  }
-
-  public OverdraftFeeChargeCapInner1 cappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-    return this;
-  }
-
-  /**
-   * Period e.g. day, week, month etc. for which the fee/charge is capped
-   * @return cappingPeriod
-  */
-  
-  @Schema(name = "CappingPeriod", description = "Period e.g. day, week, month etc. for which the fee/charge is capped", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CappingPeriod")
-  public CappingPeriodEnum getCappingPeriod() {
-    return cappingPeriod;
-  }
-
-  public void setCappingPeriod(CappingPeriodEnum cappingPeriod) {
-    this.cappingPeriod = cappingPeriod;
-  }
-
-  public OverdraftFeeChargeCapInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Notes related to Overdraft fee charge cap
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Notes related to Overdraft fee charge cap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftFeeChargeCapInner1 otherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  public OverdraftFeeChargeCapInner1 addOtherFeeTypeItem(OtherFeeTypeInner otherFeeTypeItem) {
-    if (this.otherFeeType == null) {
-      this.otherFeeType = new ArrayList<>();
-    }
-    this.otherFeeType.add(otherFeeTypeItem);
-    return this;
-  }
-
-  /**
-   * Other fee type code which is not available in the standard code set
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", description = "Other fee type code which is not available in the standard code set", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public List<@Valid OtherFeeTypeInner> getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(List<@Valid OtherFeeTypeInner> otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftFeeChargeCapInner1 overdraftFeeChargeCapInner1 = (OverdraftFeeChargeCapInner1) o;
-    return Objects.equals(this.feeType, overdraftFeeChargeCapInner1.feeType) &&
-        Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeCapInner1.overdraftControlIndicator) &&
-        Objects.equals(this.minMaxType, overdraftFeeChargeCapInner1.minMaxType) &&
-        Objects.equals(this.feeCapOccurrence, overdraftFeeChargeCapInner1.feeCapOccurrence) &&
-        Objects.equals(this.feeCapAmount, overdraftFeeChargeCapInner1.feeCapAmount) &&
-        Objects.equals(this.cappingPeriod, overdraftFeeChargeCapInner1.cappingPeriod) &&
-        Objects.equals(this.notes, overdraftFeeChargeCapInner1.notes) &&
-        Objects.equals(this.otherFeeType, overdraftFeeChargeCapInner1.otherFeeType);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, overdraftControlIndicator, minMaxType, feeCapOccurrence, feeCapAmount, cappingPeriod, notes, otherFeeType);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeeChargeCapInner1 {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
-    sb.append("    minMaxType: ").append(toIndentedString(minMaxType)).append("\n");
-    sb.append("    feeCapOccurrence: ").append(toIndentedString(feeCapOccurrence)).append("\n");
-    sb.append("    feeCapAmount: ").append(toIndentedString(feeCapAmount)).append("\n");
-    sb.append("    cappingPeriod: ").append(toIndentedString(cappingPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeDetailInner.java
@@ -15,21 +15,38 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.ApplicationFrequency1;
+import uk.org.openbanking.datamodel.account.CalculationFrequency1;
+import uk.org.openbanking.datamodel.account.FeeRateType;
+import uk.org.openbanking.datamodel.account.FeeType;
+import uk.org.openbanking.datamodel.account.OtherApplicationFrequency;
+import uk.org.openbanking.datamodel.account.OtherCalculationFrequency;
+import uk.org.openbanking.datamodel.account.OtherFeeRateType;
+import uk.org.openbanking.datamodel.account.OtherFeeType;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCapInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about the fees/charges
@@ -40,661 +57,446 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeeChargeDetailInner {
 
-  /**
-   * Overdraft fee type
-   */
-  public enum FeeTypeEnum {
-    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
-    
-    ANNUALREVIEW("AnnualReview"),
-    
-    EMERGENCYBORROWING("EmergencyBorrowing"),
-    
-    BORROWINGITEM("BorrowingItem"),
-    
-    OVERDRAFTRENEWAL("OverdraftRenewal"),
-    
-    OVERDRAFTSETUP("OverdraftSetup"),
-    
-    SURCHARGE("Surcharge"),
-    
-    TEMPOVERDRAFT("TempOverdraft"),
-    
-    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
-    
-    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
-    
-    OTHER("Other"),
-    
-    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+    private FeeType feeType;
 
-    private String value;
+    private Boolean negotiableIndicator;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private Boolean overdraftControlIndicator;
+
+    private String incrementalBorrowingAmount;
+
+    private String feeAmount;
+
+    private String feeRate;
+
+    private FeeRateType feeRateType;
+
+    private ApplicationFrequency1 applicationFrequency;
+
+    private CalculationFrequency1 calculationFrequency;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+
+    private OtherFeeType otherFeeType;
+
+    private OtherFeeRateType otherFeeRateType;
+
+    private OtherApplicationFrequency otherApplicationFrequency;
+
+    private OtherCalculationFrequency otherCalculationFrequency;
+
+    public OverdraftFeeChargeDetailInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeeChargeDetailInner(FeeType feeType, ApplicationFrequency1 applicationFrequency) {
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner feeType(FeeType feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public FeeType getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(FeeType feeType) {
+        this.feeType = feeType;
+    }
+
+    public OverdraftFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates whether fee and charges are negotiable
+     *
+     * @return negotiableIndicator
+     */
+
+    @Schema(name = "NegotiableIndicator", description = "Indicates whether fee and charges are negotiable", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("NegotiableIndicator")
+    public Boolean getNegotiableIndicator() {
+        return negotiableIndicator;
+    }
+
+    public void setNegotiableIndicator(Boolean negotiableIndicator) {
+        this.negotiableIndicator = negotiableIndicator;
+    }
+
+    public OverdraftFeeChargeDetailInner overdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.
+     *
+     * @return overdraftControlIndicator
+     */
+
+    @Schema(name = "OverdraftControlIndicator", description = "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftControlIndicator")
+    public Boolean getOverdraftControlIndicator() {
+        return overdraftControlIndicator;
+    }
+
+    public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+    }
+
+    public OverdraftFeeChargeDetailInner incrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+        return this;
+    }
+
+    /**
+     * Every additional tranche of an overdraft balance to which an overdraft fee is applied
+     *
+     * @return incrementalBorrowingAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("IncrementalBorrowingAmount")
+    public String getIncrementalBorrowingAmount() {
+        return incrementalBorrowingAmount;
+    }
+
+    public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+    }
+
+    public OverdraftFeeChargeDetailInner feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OverdraftFeeChargeDetailInner feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OverdraftFeeChargeDetailInner feeRateType(FeeRateType feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public FeeRateType getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(FeeRateType feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OverdraftFeeChargeDetailInner applicationFrequency(ApplicationFrequency1 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency1 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency1 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner calculationFrequency(CalculationFrequency1 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency1 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency1 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftFeeChargeDetailInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Free text for capturing any other info related to Overdraft Fees Charge Details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Free text for capturing any other info related to Overdraft Fees Charge Details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftFeeChargeDetailInner overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
+    }
+
+    public OverdraftFeeChargeDetailInner addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
+    }
+
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
+    }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OverdraftFeeChargeDetailInner otherFeeType(OtherFeeType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OtherFeeType getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OtherFeeType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OverdraftFeeChargeDetailInner otherFeeRateType(OtherFeeRateType otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OtherFeeRateType getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OtherFeeRateType otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OverdraftFeeChargeDetailInner otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeeChargeDetailInner overdraftFeeChargeDetailInner = (OverdraftFeeChargeDetailInner) o;
+        return Objects.equals(this.feeType, overdraftFeeChargeDetailInner.feeType) &&
+                Objects.equals(this.negotiableIndicator, overdraftFeeChargeDetailInner.negotiableIndicator) &&
+                Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeDetailInner.overdraftControlIndicator) &&
+                Objects.equals(this.incrementalBorrowingAmount, overdraftFeeChargeDetailInner.incrementalBorrowingAmount) &&
+                Objects.equals(this.feeAmount, overdraftFeeChargeDetailInner.feeAmount) &&
+                Objects.equals(this.feeRate, overdraftFeeChargeDetailInner.feeRate) &&
+                Objects.equals(this.feeRateType, overdraftFeeChargeDetailInner.feeRateType) &&
+                Objects.equals(this.applicationFrequency, overdraftFeeChargeDetailInner.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, overdraftFeeChargeDetailInner.calculationFrequency) &&
+                Objects.equals(this.notes, overdraftFeeChargeDetailInner.notes) &&
+                Objects.equals(this.overdraftFeeChargeCap, overdraftFeeChargeDetailInner.overdraftFeeChargeCap) &&
+                Objects.equals(this.otherFeeType, overdraftFeeChargeDetailInner.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, overdraftFeeChargeDetailInner.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, overdraftFeeChargeDetailInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, overdraftFeeChargeDetailInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, negotiableIndicator, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, overdraftFeeChargeCap, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeeChargeDetailInner {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
+        sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
+        sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private FeeTypeEnum feeType;
-
-  private Boolean negotiableIndicator;
-
-  private Boolean overdraftControlIndicator;
-
-  private String incrementalBorrowingAmount;
-
-  private String feeAmount;
-
-  private String feeRate;
-
-  /**
-   * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   */
-  public enum FeeRateTypeEnum {
-    GROSS("Gross"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    FeeRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeRateTypeEnum fromValue(String value) {
-      for (FeeRateTypeEnum b : FeeRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeRateTypeEnum feeRateType;
-
-  /**
-   * Frequency at which the overdraft charge is applied to the account
-   */
-  public enum ApplicationFrequencyEnum {
-    ONCLOSING("OnClosing"),
-    
-    ONOPENING("OnOpening"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONANNIVERSARY("OnAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHUNDREDPOUNDS("PerHundredPounds"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * How often is the overdraft fee/charge calculated for the account.
-   */
-  public enum CalculationFrequencyEnum {
-    ONCLOSING("OnClosing"),
-    
-    ONOPENING("OnOpening"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONANNIVERSARY("OnAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHUNDREDPOUNDS("PerHundredPounds"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
-
-  private OtherFeeType otherFeeType;
-
-  private OtherFeeRateType otherFeeRateType;
-
-  private OtherApplicationFrequency otherApplicationFrequency;
-
-  private OtherCalculationFrequency otherCalculationFrequency;
-
-  public OverdraftFeeChargeDetailInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeeChargeDetailInner(FeeTypeEnum feeType, ApplicationFrequencyEnum applicationFrequency) {
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner feeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Overdraft fee type
-   * @return feeType
-  */
-  @NotNull 
-  @Schema(name = "FeeType", description = "Overdraft fee type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public FeeTypeEnum getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-  }
-
-  public OverdraftFeeChargeDetailInner negotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates whether fee and charges are negotiable
-   * @return negotiableIndicator
-  */
-  
-  @Schema(name = "NegotiableIndicator", description = "Indicates whether fee and charges are negotiable", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("NegotiableIndicator")
-  public Boolean getNegotiableIndicator() {
-    return negotiableIndicator;
-  }
-
-  public void setNegotiableIndicator(Boolean negotiableIndicator) {
-    this.negotiableIndicator = negotiableIndicator;
-  }
-
-  public OverdraftFeeChargeDetailInner overdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.
-   * @return overdraftControlIndicator
-  */
-  
-  @Schema(name = "OverdraftControlIndicator", description = "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftControlIndicator")
-  public Boolean getOverdraftControlIndicator() {
-    return overdraftControlIndicator;
-  }
-
-  public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-  }
-
-  public OverdraftFeeChargeDetailInner incrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-    return this;
-  }
-
-  /**
-   * Every additional tranche of an overdraft balance to which an overdraft fee is applied
-   * @return incrementalBorrowingAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("IncrementalBorrowingAmount")
-  public String getIncrementalBorrowingAmount() {
-    return incrementalBorrowingAmount;
-  }
-
-  public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-  }
-
-  public OverdraftFeeChargeDetailInner feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OverdraftFeeChargeDetailInner feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OverdraftFeeChargeDetailInner feeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRateType
-  */
-  
-  @Schema(name = "FeeRateType", description = "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public FeeRateTypeEnum getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OverdraftFeeChargeDetailInner applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Frequency at which the overdraft charge is applied to the account
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "Frequency at which the overdraft charge is applied to the account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is the overdraft fee/charge calculated for the account.
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How often is the overdraft fee/charge calculated for the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftFeeChargeDetailInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Free text for capturing any other info related to Overdraft Fees Charge Details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Free text for capturing any other info related to Overdraft Fees Charge Details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftFeeChargeDetailInner overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OverdraftFeeChargeDetailInner addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
-    }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
-
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OverdraftFeeChargeDetailInner otherFeeType(OtherFeeType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OtherFeeType getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OtherFeeType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OverdraftFeeChargeDetailInner otherFeeRateType(OtherFeeRateType otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OtherFeeRateType getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OtherFeeRateType otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OverdraftFeeChargeDetailInner otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftFeeChargeDetailInner overdraftFeeChargeDetailInner = (OverdraftFeeChargeDetailInner) o;
-    return Objects.equals(this.feeType, overdraftFeeChargeDetailInner.feeType) &&
-        Objects.equals(this.negotiableIndicator, overdraftFeeChargeDetailInner.negotiableIndicator) &&
-        Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeDetailInner.overdraftControlIndicator) &&
-        Objects.equals(this.incrementalBorrowingAmount, overdraftFeeChargeDetailInner.incrementalBorrowingAmount) &&
-        Objects.equals(this.feeAmount, overdraftFeeChargeDetailInner.feeAmount) &&
-        Objects.equals(this.feeRate, overdraftFeeChargeDetailInner.feeRate) &&
-        Objects.equals(this.feeRateType, overdraftFeeChargeDetailInner.feeRateType) &&
-        Objects.equals(this.applicationFrequency, overdraftFeeChargeDetailInner.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, overdraftFeeChargeDetailInner.calculationFrequency) &&
-        Objects.equals(this.notes, overdraftFeeChargeDetailInner.notes) &&
-        Objects.equals(this.overdraftFeeChargeCap, overdraftFeeChargeDetailInner.overdraftFeeChargeCap) &&
-        Objects.equals(this.otherFeeType, overdraftFeeChargeDetailInner.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, overdraftFeeChargeDetailInner.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, overdraftFeeChargeDetailInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, overdraftFeeChargeDetailInner.otherCalculationFrequency);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, negotiableIndicator, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, overdraftFeeChargeCap, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeeChargeDetailInner {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    negotiableIndicator: ").append(toIndentedString(negotiableIndicator)).append("\n");
-    sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
-    sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeeChargeDetailInner1.java
@@ -15,21 +15,38 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.ApplicationFrequency4;
+import uk.org.openbanking.datamodel.account.CalculationFrequency4;
+import uk.org.openbanking.datamodel.account.FeeRateType2;
+import uk.org.openbanking.datamodel.account.FeeType2;
+import uk.org.openbanking.datamodel.account.OtherApplicationFrequency;
+import uk.org.openbanking.datamodel.account.OtherCalculationFrequency;
+import uk.org.openbanking.datamodel.account.OtherFeeRateType;
+import uk.org.openbanking.datamodel.account.OtherFeeType;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCap;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Details about the fees/charges
@@ -40,632 +57,412 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeeChargeDetailInner1 {
 
-  /**
-   * Overdraft fee type
-   */
-  public enum FeeTypeEnum {
-    ARRANGEDOVERDRAFT("ArrangedOverdraft"),
-    
-    EMERGENCYBORROWING("EmergencyBorrowing"),
-    
-    BORROWINGITEM("BorrowingItem"),
-    
-    OVERDRAFTRENEWAL("OverdraftRenewal"),
-    
-    ANNUALREVIEW("AnnualReview"),
-    
-    OVERDRAFTSETUP("OverdraftSetup"),
-    
-    SURCHARGE("Surcharge"),
-    
-    TEMPOVERDRAFT("TempOverdraft"),
-    
-    UNAUTHORISEDBORROWING("UnauthorisedBorrowing"),
-    
-    UNAUTHORISEDPAIDTRANS("UnauthorisedPaidTrans"),
-    
-    OTHER("Other"),
-    
-    UNAUTHORISEDUNPAIDTRANS("UnauthorisedUnpaidTrans");
+    private FeeType2 feeType;
 
-    private String value;
+    private Boolean overdraftControlIndicator;
 
-    FeeTypeEnum(String value) {
-      this.value = value;
+    private String incrementalBorrowingAmount;
+
+    private String feeAmount;
+
+    private String feeRate;
+
+    private FeeRateType2 feeRateType;
+
+    private ApplicationFrequency4 applicationFrequency;
+
+    private CalculationFrequency4 calculationFrequency;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OtherFeeType otherFeeType;
+
+    private OtherFeeRateType otherFeeRateType;
+
+    private OtherApplicationFrequency otherApplicationFrequency;
+
+    private OtherCalculationFrequency otherCalculationFrequency;
+
+    private OverdraftFeeChargeCap overdraftFeeChargeCap;
+
+    public OverdraftFeeChargeDetailInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeeChargeDetailInner1(FeeType2 feeType, ApplicationFrequency4 applicationFrequency) {
+        this.feeType = feeType;
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner1 feeType(FeeType2 feeType) {
+        this.feeType = feeType;
+        return this;
+    }
+
+    /**
+     * Get feeType
+     *
+     * @return feeType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FeeType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FeeType")
+    public FeeType2 getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(FeeType2 feeType) {
+        this.feeType = feeType;
+    }
+
+    public OverdraftFeeChargeDetailInner1 overdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+        return this;
+    }
+
+    /**
+     * Specifies for the overdraft control feature/benefit
+     *
+     * @return overdraftControlIndicator
+     */
+
+    @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftControlIndicator")
+    public Boolean getOverdraftControlIndicator() {
+        return overdraftControlIndicator;
+    }
+
+    public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
+        this.overdraftControlIndicator = overdraftControlIndicator;
+    }
+
+    public OverdraftFeeChargeDetailInner1 incrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+        return this;
+    }
+
+    /**
+     * Every additional tranche of an overdraft balance to which an overdraft fee is applied
+     *
+     * @return incrementalBorrowingAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("IncrementalBorrowingAmount")
+    public String getIncrementalBorrowingAmount() {
+        return incrementalBorrowingAmount;
+    }
+
+    public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
+        this.incrementalBorrowingAmount = incrementalBorrowingAmount;
+    }
+
+    public OverdraftFeeChargeDetailInner1 feeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+        return this;
+    }
+
+    /**
+     * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
+     *
+     * @return feeAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeAmount")
+    public String getFeeAmount() {
+        return feeAmount;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public OverdraftFeeChargeDetailInner1 feeRate(String feeRate) {
+        this.feeRate = feeRate;
+        return this;
+    }
+
+    /**
+     * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
+     *
+     * @return feeRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRate")
+    public String getFeeRate() {
+        return feeRate;
+    }
+
+    public void setFeeRate(String feeRate) {
+        this.feeRate = feeRate;
+    }
+
+    public OverdraftFeeChargeDetailInner1 feeRateType(FeeRateType2 feeRateType) {
+        this.feeRateType = feeRateType;
+        return this;
+    }
+
+    /**
+     * Get feeRateType
+     *
+     * @return feeRateType
+     */
+    @Valid
+    @Schema(name = "FeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeRateType")
+    public FeeRateType2 getFeeRateType() {
+        return feeRateType;
+    }
+
+    public void setFeeRateType(FeeRateType2 feeRateType) {
+        this.feeRateType = feeRateType;
+    }
+
+    public OverdraftFeeChargeDetailInner1 applicationFrequency(ApplicationFrequency4 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency4 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency4 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner1 calculationFrequency(CalculationFrequency4 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency4 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency4 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftFeeChargeDetailInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Free text for capturing any other info related to Overdraft Fees Charge Details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Free text for capturing any other info related to Overdraft Fees Charge Details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftFeeChargeDetailInner1 otherFeeType(OtherFeeType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeType
+     *
+     * @return otherFeeType
+     */
+    @Valid
+    @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeType")
+    public OtherFeeType getOtherFeeType() {
+        return otherFeeType;
+    }
+
+    public void setOtherFeeType(OtherFeeType otherFeeType) {
+        this.otherFeeType = otherFeeType;
+    }
+
+    public OverdraftFeeChargeDetailInner1 otherFeeRateType(OtherFeeRateType otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+        return this;
+    }
+
+    /**
+     * Get otherFeeRateType
+     *
+     * @return otherFeeRateType
+     */
+    @Valid
+    @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherFeeRateType")
+    public OtherFeeRateType getOtherFeeRateType() {
+        return otherFeeRateType;
+    }
+
+    public void setOtherFeeRateType(OtherFeeRateType otherFeeRateType) {
+        this.otherFeeRateType = otherFeeRateType;
+    }
+
+    public OverdraftFeeChargeDetailInner1 otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner1 otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    public OverdraftFeeChargeDetailInner1 overdraftFeeChargeCap(OverdraftFeeChargeCap overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
+    }
+
+    /**
+     * Get overdraftFeeChargeCap
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public OverdraftFeeChargeCap getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
+    }
+
+    public void setOverdraftFeeChargeCap(OverdraftFeeChargeCap overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailInner1 = (OverdraftFeeChargeDetailInner1) o;
+        return Objects.equals(this.feeType, overdraftFeeChargeDetailInner1.feeType) &&
+                Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeDetailInner1.overdraftControlIndicator) &&
+                Objects.equals(this.incrementalBorrowingAmount, overdraftFeeChargeDetailInner1.incrementalBorrowingAmount) &&
+                Objects.equals(this.feeAmount, overdraftFeeChargeDetailInner1.feeAmount) &&
+                Objects.equals(this.feeRate, overdraftFeeChargeDetailInner1.feeRate) &&
+                Objects.equals(this.feeRateType, overdraftFeeChargeDetailInner1.feeRateType) &&
+                Objects.equals(this.applicationFrequency, overdraftFeeChargeDetailInner1.applicationFrequency) &&
+                Objects.equals(this.calculationFrequency, overdraftFeeChargeDetailInner1.calculationFrequency) &&
+                Objects.equals(this.notes, overdraftFeeChargeDetailInner1.notes) &&
+                Objects.equals(this.otherFeeType, overdraftFeeChargeDetailInner1.otherFeeType) &&
+                Objects.equals(this.otherFeeRateType, overdraftFeeChargeDetailInner1.otherFeeRateType) &&
+                Objects.equals(this.otherApplicationFrequency, overdraftFeeChargeDetailInner1.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, overdraftFeeChargeDetailInner1.otherCalculationFrequency) &&
+                Objects.equals(this.overdraftFeeChargeCap, overdraftFeeChargeDetailInner1.overdraftFeeChargeCap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(feeType, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, overdraftFeeChargeCap);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeeChargeDetailInner1 {\n");
+        sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
+        sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
+        sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
+        sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
+        sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
+        sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
+        sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static FeeTypeEnum fromValue(String value) {
-      for (FeeTypeEnum b : FeeTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private FeeTypeEnum feeType;
-
-  private Boolean overdraftControlIndicator;
-
-  private String incrementalBorrowingAmount;
-
-  private String feeAmount;
-
-  private String feeRate;
-
-  /**
-   * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   */
-  public enum FeeRateTypeEnum {
-    LINKEDBASERATE("LinkedBaseRate"),
-    
-    GROSS("Gross"),
-    
-    NET("Net"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    FeeRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeRateTypeEnum fromValue(String value) {
-      for (FeeRateTypeEnum b : FeeRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeRateTypeEnum feeRateType;
-
-  /**
-   * Frequency at which the overdraft charge is applied to the account
-   */
-  public enum ApplicationFrequencyEnum {
-    ACCOUNTCLOSING("AccountClosing"),
-    
-    ACCOUNTOPENING("AccountOpening"),
-    
-    ACADEMICTERM("AcademicTerm"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * How often is the overdraft fee/charge calculated for the account.
-   */
-  public enum CalculationFrequencyEnum {
-    ACCOUNTCLOSING("AccountClosing"),
-    
-    ACCOUNTOPENING("AccountOpening"),
-    
-    ACADEMICTERM("AcademicTerm"),
-    
-    CHARGINGPERIOD("ChargingPeriod"),
-    
-    DAILY("Daily"),
-    
-    PERITEM("PerItem"),
-    
-    MONTHLY("Monthly"),
-    
-    ONACCOUNTANNIVERSARY("OnAccountAnniversary"),
-    
-    OTHER("Other"),
-    
-    PERHOUR("PerHour"),
-    
-    PEROCCURRENCE("PerOccurrence"),
-    
-    PERSHEET("PerSheet"),
-    
-    PERTRANSACTION("PerTransaction"),
-    
-    PERTRANSACTIONAMOUNT("PerTransactionAmount"),
-    
-    PERTRANSACTIONPERCENTAGE("PerTransactionPercentage"),
-    
-    QUARTERLY("Quarterly"),
-    
-    SIXMONTHLY("SixMonthly"),
-    
-    STATEMENTMONTHLY("StatementMonthly"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OtherFeeType otherFeeType;
-
-  private OtherFeeRateType otherFeeRateType;
-
-  private OtherApplicationFrequency otherApplicationFrequency;
-
-  private OtherCalculationFrequency otherCalculationFrequency;
-
-  private OverdraftFeeChargeCap overdraftFeeChargeCap;
-
-  public OverdraftFeeChargeDetailInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeeChargeDetailInner1(FeeTypeEnum feeType, ApplicationFrequencyEnum applicationFrequency) {
-    this.feeType = feeType;
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner1 feeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-    return this;
-  }
-
-  /**
-   * Overdraft fee type
-   * @return feeType
-  */
-  @NotNull 
-  @Schema(name = "FeeType", description = "Overdraft fee type", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FeeType")
-  public FeeTypeEnum getFeeType() {
-    return feeType;
-  }
-
-  public void setFeeType(FeeTypeEnum feeType) {
-    this.feeType = feeType;
-  }
-
-  public OverdraftFeeChargeDetailInner1 overdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-    return this;
-  }
-
-  /**
-   * Specifies for the overdraft control feature/benefit
-   * @return overdraftControlIndicator
-  */
-  
-  @Schema(name = "OverdraftControlIndicator", description = "Specifies for the overdraft control feature/benefit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftControlIndicator")
-  public Boolean getOverdraftControlIndicator() {
-    return overdraftControlIndicator;
-  }
-
-  public void setOverdraftControlIndicator(Boolean overdraftControlIndicator) {
-    this.overdraftControlIndicator = overdraftControlIndicator;
-  }
-
-  public OverdraftFeeChargeDetailInner1 incrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-    return this;
-  }
-
-  /**
-   * Every additional tranche of an overdraft balance to which an overdraft fee is applied
-   * @return incrementalBorrowingAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "IncrementalBorrowingAmount", description = "Every additional tranche of an overdraft balance to which an overdraft fee is applied", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("IncrementalBorrowingAmount")
-  public String getIncrementalBorrowingAmount() {
-    return incrementalBorrowingAmount;
-  }
-
-  public void setIncrementalBorrowingAmount(String incrementalBorrowingAmount) {
-    this.incrementalBorrowingAmount = incrementalBorrowingAmount;
-  }
-
-  public OverdraftFeeChargeDetailInner1 feeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-    return this;
-  }
-
-  /**
-   * Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)
-   * @return feeAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeAmount", description = "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeAmount")
-  public String getFeeAmount() {
-    return feeAmount;
-  }
-
-  public void setFeeAmount(String feeAmount) {
-    this.feeAmount = feeAmount;
-  }
-
-  public OverdraftFeeChargeDetailInner1 feeRate(String feeRate) {
-    this.feeRate = feeRate;
-    return this;
-  }
-
-  /**
-   * Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "FeeRate", description = "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRate")
-  public String getFeeRate() {
-    return feeRate;
-  }
-
-  public void setFeeRate(String feeRate) {
-    this.feeRate = feeRate;
-  }
-
-  public OverdraftFeeChargeDetailInner1 feeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-    return this;
-  }
-
-  /**
-   * Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)
-   * @return feeRateType
-  */
-  
-  @Schema(name = "FeeRateType", description = "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeRateType")
-  public FeeRateTypeEnum getFeeRateType() {
-    return feeRateType;
-  }
-
-  public void setFeeRateType(FeeRateTypeEnum feeRateType) {
-    this.feeRateType = feeRateType;
-  }
-
-  public OverdraftFeeChargeDetailInner1 applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * Frequency at which the overdraft charge is applied to the account
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "Frequency at which the overdraft charge is applied to the account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner1 calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is the overdraft fee/charge calculated for the account.
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How often is the overdraft fee/charge calculated for the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftFeeChargeDetailInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Free text for capturing any other info related to Overdraft Fees Charge Details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Free text for capturing any other info related to Overdraft Fees Charge Details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftFeeChargeDetailInner1 otherFeeType(OtherFeeType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeType
-   * @return otherFeeType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeType")
-  public OtherFeeType getOtherFeeType() {
-    return otherFeeType;
-  }
-
-  public void setOtherFeeType(OtherFeeType otherFeeType) {
-    this.otherFeeType = otherFeeType;
-  }
-
-  public OverdraftFeeChargeDetailInner1 otherFeeRateType(OtherFeeRateType otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-    return this;
-  }
-
-  /**
-   * Get otherFeeRateType
-   * @return otherFeeRateType
-  */
-  @Valid 
-  @Schema(name = "OtherFeeRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherFeeRateType")
-  public OtherFeeRateType getOtherFeeRateType() {
-    return otherFeeRateType;
-  }
-
-  public void setOtherFeeRateType(OtherFeeRateType otherFeeRateType) {
-    this.otherFeeRateType = otherFeeRateType;
-  }
-
-  public OverdraftFeeChargeDetailInner1 otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner1 otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  public OverdraftFeeChargeDetailInner1 overdraftFeeChargeCap(OverdraftFeeChargeCap overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  /**
-   * Get overdraftFeeChargeCap
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public OverdraftFeeChargeCap getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(OverdraftFeeChargeCap overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailInner1 = (OverdraftFeeChargeDetailInner1) o;
-    return Objects.equals(this.feeType, overdraftFeeChargeDetailInner1.feeType) &&
-        Objects.equals(this.overdraftControlIndicator, overdraftFeeChargeDetailInner1.overdraftControlIndicator) &&
-        Objects.equals(this.incrementalBorrowingAmount, overdraftFeeChargeDetailInner1.incrementalBorrowingAmount) &&
-        Objects.equals(this.feeAmount, overdraftFeeChargeDetailInner1.feeAmount) &&
-        Objects.equals(this.feeRate, overdraftFeeChargeDetailInner1.feeRate) &&
-        Objects.equals(this.feeRateType, overdraftFeeChargeDetailInner1.feeRateType) &&
-        Objects.equals(this.applicationFrequency, overdraftFeeChargeDetailInner1.applicationFrequency) &&
-        Objects.equals(this.calculationFrequency, overdraftFeeChargeDetailInner1.calculationFrequency) &&
-        Objects.equals(this.notes, overdraftFeeChargeDetailInner1.notes) &&
-        Objects.equals(this.otherFeeType, overdraftFeeChargeDetailInner1.otherFeeType) &&
-        Objects.equals(this.otherFeeRateType, overdraftFeeChargeDetailInner1.otherFeeRateType) &&
-        Objects.equals(this.otherApplicationFrequency, overdraftFeeChargeDetailInner1.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, overdraftFeeChargeDetailInner1.otherCalculationFrequency) &&
-        Objects.equals(this.overdraftFeeChargeCap, overdraftFeeChargeDetailInner1.overdraftFeeChargeCap);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(feeType, overdraftControlIndicator, incrementalBorrowingAmount, feeAmount, feeRate, feeRateType, applicationFrequency, calculationFrequency, notes, otherFeeType, otherFeeRateType, otherApplicationFrequency, otherCalculationFrequency, overdraftFeeChargeCap);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeeChargeDetailInner1 {\n");
-    sb.append("    feeType: ").append(toIndentedString(feeType)).append("\n");
-    sb.append("    overdraftControlIndicator: ").append(toIndentedString(overdraftControlIndicator)).append("\n");
-    sb.append("    incrementalBorrowingAmount: ").append(toIndentedString(incrementalBorrowingAmount)).append("\n");
-    sb.append("    feeAmount: ").append(toIndentedString(feeAmount)).append("\n");
-    sb.append("    feeRate: ").append(toIndentedString(feeRate)).append("\n");
-    sb.append("    feeRateType: ").append(toIndentedString(feeRateType)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherFeeType: ").append(toIndentedString(otherFeeType)).append("\n");
-    sb.append("    otherFeeRateType: ").append(toIndentedString(otherFeeRateType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner.java
@@ -15,18 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeDetailInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Overdraft fees and charges
@@ -37,116 +49,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeesChargesInner {
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OverdraftFeesChargesInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeesChargesInner(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OverdraftFeesChargesInner() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeesChargesInner(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Details about the fees/charges
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OverdraftFeesChargesInner overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OverdraftFeesChargesInner addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OverdraftFeesChargesInner overdraftFeesChargesInner = (OverdraftFeesChargesInner) o;
-    return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeesChargesInner {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OverdraftFeesChargesInner overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OverdraftFeesChargesInner addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Details about the fees/charges
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeesChargesInner overdraftFeesChargesInner = (OverdraftFeesChargesInner) o;
+        return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeesChargesInner {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner1.java
@@ -15,18 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCapInner;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeDetailInner;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Overdraft fees and charges details
@@ -37,116 +49,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeesChargesInner1 {
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OverdraftFeesChargesInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeesChargesInner1(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OverdraftFeesChargesInner1 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner1 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OverdraftFeesChargesInner1() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OverdraftFeesChargesInner1 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner1 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeesChargesInner1(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Details about the fees/charges
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OverdraftFeesChargesInner1 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OverdraftFeesChargesInner1 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OverdraftFeesChargesInner1 overdraftFeesChargesInner1 = (OverdraftFeesChargesInner1) o;
-    return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner1.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner1.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeesChargesInner1 {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OverdraftFeeChargeCapInner> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OverdraftFeesChargesInner1 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OverdraftFeesChargesInner1 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Details about the fees/charges
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OverdraftFeeChargeDetailInner> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeesChargesInner1 overdraftFeesChargesInner1 = (OverdraftFeesChargesInner1) o;
+        return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner1.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner1.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeesChargesInner1 {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner2.java
@@ -15,18 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCapInner1;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeDetailInner1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Overdraft fees and charges
@@ -37,116 +49,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeesChargesInner2 {
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OverdraftFeesChargesInner2() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeesChargesInner2(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OverdraftFeesChargesInner2 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner2 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner1 overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OverdraftFeesChargesInner2() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OverdraftFeeChargeCapInner1> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OverdraftFeesChargesInner2 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner2 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeesChargesInner2(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Details about the fees/charges
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OverdraftFeeChargeDetailInner1> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OverdraftFeesChargesInner2 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OverdraftFeesChargesInner2 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner1 overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OverdraftFeesChargesInner2 overdraftFeesChargesInner2 = (OverdraftFeesChargesInner2) o;
-    return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner2.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner2.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeesChargesInner2 {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OverdraftFeeChargeCapInner1> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OverdraftFeesChargesInner2 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OverdraftFeesChargesInner2 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Details about the fees/charges
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OverdraftFeeChargeDetailInner1> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeesChargesInner2 overdraftFeesChargesInner2 = (OverdraftFeesChargesInner2) o;
+        return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner2.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner2.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeesChargesInner2 {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftFeesChargesInner3.java
@@ -15,18 +15,30 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeCapInner1;
+import uk.org.openbanking.datamodel.account.OverdraftFeeChargeDetailInner1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Overdraft fees and charges details
@@ -37,116 +49,120 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftFeesChargesInner3 {
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap;
+    @Valid
+    private List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap;
 
-  @Valid
-  private List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail = new ArrayList<>();
+    @Valid
+    private List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail = new ArrayList<>();
 
-  public OverdraftFeesChargesInner3() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftFeesChargesInner3(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  public OverdraftFeesChargesInner3 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner3 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner1 overdraftFeeChargeCapItem) {
-    if (this.overdraftFeeChargeCap == null) {
-      this.overdraftFeeChargeCap = new ArrayList<>();
+    public OverdraftFeesChargesInner3() {
+        super();
     }
-    this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
-    return this;
-  }
 
-  /**
-   * Details about any caps (maximum charges) that apply to a particular fee/charge
-   * @return overdraftFeeChargeCap
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeeChargeCap")
-  public List<@Valid OverdraftFeeChargeCapInner1> getOverdraftFeeChargeCap() {
-    return overdraftFeeChargeCap;
-  }
-
-  public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
-    this.overdraftFeeChargeCap = overdraftFeeChargeCap;
-  }
-
-  public OverdraftFeesChargesInner3 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-    return this;
-  }
-
-  public OverdraftFeesChargesInner3 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailItem) {
-    if (this.overdraftFeeChargeDetail == null) {
-      this.overdraftFeeChargeDetail = new ArrayList<>();
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftFeesChargesInner3(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
     }
-    this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
-    return this;
-  }
 
-  /**
-   * Details about the fees/charges
-   * @return overdraftFeeChargeDetail
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftFeeChargeDetail")
-  public List<@Valid OverdraftFeeChargeDetailInner1> getOverdraftFeeChargeDetail() {
-    return overdraftFeeChargeDetail;
-  }
-
-  public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
-    this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public OverdraftFeesChargesInner3 overdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+        return this;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    public OverdraftFeesChargesInner3 addOverdraftFeeChargeCapItem(OverdraftFeeChargeCapInner1 overdraftFeeChargeCapItem) {
+        if (this.overdraftFeeChargeCap == null) {
+            this.overdraftFeeChargeCap = new ArrayList<>();
+        }
+        this.overdraftFeeChargeCap.add(overdraftFeeChargeCapItem);
+        return this;
     }
-    OverdraftFeesChargesInner3 overdraftFeesChargesInner3 = (OverdraftFeesChargesInner3) o;
-    return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner3.overdraftFeeChargeCap) &&
-        Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner3.overdraftFeeChargeDetail);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftFeesChargesInner3 {\n");
-    sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
-    sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    /**
+     * Details about any caps (maximum charges) that apply to a particular fee/charge
+     *
+     * @return overdraftFeeChargeCap
+     */
+    @Valid
+    @Schema(name = "OverdraftFeeChargeCap", description = "Details about any caps (maximum charges) that apply to a particular fee/charge", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeeChargeCap")
+    public List<@Valid OverdraftFeeChargeCapInner1> getOverdraftFeeChargeCap() {
+        return overdraftFeeChargeCap;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    public void setOverdraftFeeChargeCap(List<@Valid OverdraftFeeChargeCapInner1> overdraftFeeChargeCap) {
+        this.overdraftFeeChargeCap = overdraftFeeChargeCap;
+    }
+
+    public OverdraftFeesChargesInner3 overdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+        return this;
+    }
+
+    public OverdraftFeesChargesInner3 addOverdraftFeeChargeDetailItem(OverdraftFeeChargeDetailInner1 overdraftFeeChargeDetailItem) {
+        if (this.overdraftFeeChargeDetail == null) {
+            this.overdraftFeeChargeDetail = new ArrayList<>();
+        }
+        this.overdraftFeeChargeDetail.add(overdraftFeeChargeDetailItem);
+        return this;
+    }
+
+    /**
+     * Details about the fees/charges
+     *
+     * @return overdraftFeeChargeDetail
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftFeeChargeDetail", description = "Details about the fees/charges", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftFeeChargeDetail")
+    public List<@Valid OverdraftFeeChargeDetailInner1> getOverdraftFeeChargeDetail() {
+        return overdraftFeeChargeDetail;
+    }
+
+    public void setOverdraftFeeChargeDetail(List<@Valid OverdraftFeeChargeDetailInner1> overdraftFeeChargeDetail) {
+        this.overdraftFeeChargeDetail = overdraftFeeChargeDetail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftFeesChargesInner3 overdraftFeesChargesInner3 = (OverdraftFeesChargesInner3) o;
+        return Objects.equals(this.overdraftFeeChargeCap, overdraftFeesChargesInner3.overdraftFeeChargeCap) &&
+                Objects.equals(this.overdraftFeeChargeDetail, overdraftFeesChargesInner3.overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overdraftFeeChargeCap, overdraftFeeChargeDetail);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftFeesChargesInner3 {\n");
+        sb.append("    overdraftFeeChargeCap: ").append(toIndentedString(overdraftFeeChargeCap)).append("\n");
+        sb.append("    overdraftFeeChargeDetail: ").append(toIndentedString(overdraftFeeChargeDetail)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftInterestChargingCoverage.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OverdraftInterestChargingCoverage {
+
+    BANDED("Banded"),
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    OverdraftInterestChargingCoverage(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OverdraftInterestChargingCoverage fromValue(String value) {
+        for (OverdraftInterestChargingCoverage b : OverdraftInterestChargingCoverage.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftInterestChargingCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftInterestChargingCoverage1.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Interest charged on whole amount or tiered/banded
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OverdraftInterestChargingCoverage1 {
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    OverdraftInterestChargingCoverage1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OverdraftInterestChargingCoverage1 fromValue(String value) {
+        for (OverdraftInterestChargingCoverage1 b : OverdraftInterestChargingCoverage1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandInner.java
@@ -15,21 +15,32 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.AgreementPeriod;
+import uk.org.openbanking.datamodel.account.OverdraftFeesChargesInner;
+import uk.org.openbanking.datamodel.account.OverdraftInterestChargingCoverage;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Provides overdraft details for a specific tier or band
@@ -40,436 +51,369 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftTierBandInner {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMin;
+    private String tierValueMin;
 
-  private String tierValueMax;
+    private String tierValueMax;
 
-  private String EAR;
+    private String EAR;
 
-  private String representativeAPR;
+    private String representativeAPR;
 
-  private Float agreementLengthMin;
+    private Float agreementLengthMin;
 
-  private Float agreementLengthMax;
+    private Float agreementLengthMax;
 
-  /**
-   * Specifies the period of a fixed length overdraft agreement
-   */
-  public enum AgreementPeriodEnum {
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
+    private AgreementPeriod agreementPeriod;
 
-    private String value;
+    private OverdraftInterestChargingCoverage overdraftInterestChargingCoverage;
 
-    AgreementPeriodEnum(String value) {
-      this.value = value;
+    private Boolean bankGuaranteedIndicator;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges;
+
+    public OverdraftTierBandInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftTierBandInner(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OverdraftTierBandInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OverdraftTierBandInner tierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+        return this;
+    }
+
+    /**
+     * Minimum value of Overdraft Tier/Band
+     *
+     * @return tierValueMin
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMin")
+    public String getTierValueMin() {
+        return tierValueMin;
+    }
+
+    public void setTierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OverdraftTierBandInner tierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+        return this;
+    }
+
+    /**
+     * Maximum value of Overdraft Tier/Band
+     *
+     * @return tierValueMax
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMax")
+    public String getTierValueMax() {
+        return tierValueMax;
+    }
+
+    public void setTierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+    }
+
+    public OverdraftTierBandInner EAR(String EAR) {
+        this.EAR = EAR;
+        return this;
+    }
+
+    /**
+     * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
+     *
+     * @return EAR
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EAR")
+    public String getEAR() {
+        return EAR;
+    }
+
+    public void setEAR(String EAR) {
+        this.EAR = EAR;
+    }
+
+    public OverdraftTierBandInner representativeAPR(String representativeAPR) {
+        this.representativeAPR = representativeAPR;
+        return this;
+    }
+
+    /**
+     * An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
+     *
+     * @return representativeAPR
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "RepresentativeAPR", description = "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepresentativeAPR")
+    public String getRepresentativeAPR() {
+        return representativeAPR;
+    }
+
+    public void setRepresentativeAPR(String representativeAPR) {
+        this.representativeAPR = representativeAPR;
+    }
+
+    public OverdraftTierBandInner agreementLengthMin(Float agreementLengthMin) {
+        this.agreementLengthMin = agreementLengthMin;
+        return this;
+    }
+
+    /**
+     * Specifies the minimum length of a band for a fixed overdraft agreement
+     *
+     * @return agreementLengthMin
+     */
+
+    @Schema(name = "AgreementLengthMin", description = "Specifies the minimum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementLengthMin")
+    public Float getAgreementLengthMin() {
+        return agreementLengthMin;
+    }
+
+    public void setAgreementLengthMin(Float agreementLengthMin) {
+        this.agreementLengthMin = agreementLengthMin;
+    }
+
+    public OverdraftTierBandInner agreementLengthMax(Float agreementLengthMax) {
+        this.agreementLengthMax = agreementLengthMax;
+        return this;
+    }
+
+    /**
+     * Specifies the maximum length of a band for a fixed overdraft agreement
+     *
+     * @return agreementLengthMax
+     */
+
+    @Schema(name = "AgreementLengthMax", description = "Specifies the maximum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementLengthMax")
+    public Float getAgreementLengthMax() {
+        return agreementLengthMax;
+    }
+
+    public void setAgreementLengthMax(Float agreementLengthMax) {
+        this.agreementLengthMax = agreementLengthMax;
+    }
+
+    public OverdraftTierBandInner agreementPeriod(AgreementPeriod agreementPeriod) {
+        this.agreementPeriod = agreementPeriod;
+        return this;
+    }
+
+    /**
+     * Get agreementPeriod
+     *
+     * @return agreementPeriod
+     */
+    @Valid
+    @Schema(name = "AgreementPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AgreementPeriod")
+    public AgreementPeriod getAgreementPeriod() {
+        return agreementPeriod;
+    }
+
+    public void setAgreementPeriod(AgreementPeriod agreementPeriod) {
+        this.agreementPeriod = agreementPeriod;
+    }
+
+    public OverdraftTierBandInner overdraftInterestChargingCoverage(OverdraftInterestChargingCoverage overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+        return this;
+    }
+
+    /**
+     * Get overdraftInterestChargingCoverage
+     *
+     * @return overdraftInterestChargingCoverage
+     */
+    @Valid
+    @Schema(name = "OverdraftInterestChargingCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftInterestChargingCoverage")
+    public OverdraftInterestChargingCoverage getOverdraftInterestChargingCoverage() {
+        return overdraftInterestChargingCoverage;
+    }
+
+    public void setOverdraftInterestChargingCoverage(OverdraftInterestChargingCoverage overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+    }
+
+    public OverdraftTierBandInner bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.
+     *
+     * @return bankGuaranteedIndicator
+     */
+
+    @Schema(name = "BankGuaranteedIndicator", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankGuaranteedIndicator")
+    public Boolean getBankGuaranteedIndicator() {
+        return bankGuaranteedIndicator;
+    }
+
+    public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+    }
+
+    public OverdraftTierBandInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftTierBandInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier/band details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier/band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftTierBandInner overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OverdraftTierBandInner addOverdraftFeesChargesItem(OverdraftFeesChargesInner overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Overdraft fees and charges
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OverdraftFeesChargesInner> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftTierBandInner overdraftTierBandInner = (OverdraftTierBandInner) o;
+        return Objects.equals(this.identification, overdraftTierBandInner.identification) &&
+                Objects.equals(this.tierValueMin, overdraftTierBandInner.tierValueMin) &&
+                Objects.equals(this.tierValueMax, overdraftTierBandInner.tierValueMax) &&
+                Objects.equals(this.EAR, overdraftTierBandInner.EAR) &&
+                Objects.equals(this.representativeAPR, overdraftTierBandInner.representativeAPR) &&
+                Objects.equals(this.agreementLengthMin, overdraftTierBandInner.agreementLengthMin) &&
+                Objects.equals(this.agreementLengthMax, overdraftTierBandInner.agreementLengthMax) &&
+                Objects.equals(this.agreementPeriod, overdraftTierBandInner.agreementPeriod) &&
+                Objects.equals(this.overdraftInterestChargingCoverage, overdraftTierBandInner.overdraftInterestChargingCoverage) &&
+                Objects.equals(this.bankGuaranteedIndicator, overdraftTierBandInner.bankGuaranteedIndicator) &&
+                Objects.equals(this.notes, overdraftTierBandInner.notes) &&
+                Objects.equals(this.overdraftFeesCharges, overdraftTierBandInner.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMin, tierValueMax, EAR, representativeAPR, agreementLengthMin, agreementLengthMax, agreementPeriod, overdraftInterestChargingCoverage, bankGuaranteedIndicator, notes, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftTierBandInner {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
+        sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
+        sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
+        sb.append("    representativeAPR: ").append(toIndentedString(representativeAPR)).append("\n");
+        sb.append("    agreementLengthMin: ").append(toIndentedString(agreementLengthMin)).append("\n");
+        sb.append("    agreementLengthMax: ").append(toIndentedString(agreementLengthMax)).append("\n");
+        sb.append("    agreementPeriod: ").append(toIndentedString(agreementPeriod)).append("\n");
+        sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
+        sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static AgreementPeriodEnum fromValue(String value) {
-      for (AgreementPeriodEnum b : AgreementPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private AgreementPeriodEnum agreementPeriod;
-
-  /**
-   * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.
-   */
-  public enum OverdraftInterestChargingCoverageEnum {
-    BANDED("Banded"),
-    
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
-
-    private String value;
-
-    OverdraftInterestChargingCoverageEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static OverdraftInterestChargingCoverageEnum fromValue(String value) {
-      for (OverdraftInterestChargingCoverageEnum b : OverdraftInterestChargingCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage;
-
-  private Boolean bankGuaranteedIndicator;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges;
-
-  public OverdraftTierBandInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftTierBandInner(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OverdraftTierBandInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OverdraftTierBandInner tierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-    return this;
-  }
-
-  /**
-   * Minimum value of Overdraft Tier/Band
-   * @return tierValueMin
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMin")
-  public String getTierValueMin() {
-    return tierValueMin;
-  }
-
-  public void setTierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OverdraftTierBandInner tierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-    return this;
-  }
-
-  /**
-   * Maximum value of Overdraft Tier/Band
-   * @return tierValueMax
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMax")
-  public String getTierValueMax() {
-    return tierValueMax;
-  }
-
-  public void setTierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-  }
-
-  public OverdraftTierBandInner EAR(String EAR) {
-    this.EAR = EAR;
-    return this;
-  }
-
-  /**
-   * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
-   * @return EAR
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("EAR")
-  public String getEAR() {
-    return EAR;
-  }
-
-  public void setEAR(String EAR) {
-    this.EAR = EAR;
-  }
-
-  public OverdraftTierBandInner representativeAPR(String representativeAPR) {
-    this.representativeAPR = representativeAPR;
-    return this;
-  }
-
-  /**
-   * An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
-   * @return representativeAPR
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "RepresentativeAPR", description = "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepresentativeAPR")
-  public String getRepresentativeAPR() {
-    return representativeAPR;
-  }
-
-  public void setRepresentativeAPR(String representativeAPR) {
-    this.representativeAPR = representativeAPR;
-  }
-
-  public OverdraftTierBandInner agreementLengthMin(Float agreementLengthMin) {
-    this.agreementLengthMin = agreementLengthMin;
-    return this;
-  }
-
-  /**
-   * Specifies the minimum length of a band for a fixed overdraft agreement
-   * @return agreementLengthMin
-  */
-  
-  @Schema(name = "AgreementLengthMin", description = "Specifies the minimum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementLengthMin")
-  public Float getAgreementLengthMin() {
-    return agreementLengthMin;
-  }
-
-  public void setAgreementLengthMin(Float agreementLengthMin) {
-    this.agreementLengthMin = agreementLengthMin;
-  }
-
-  public OverdraftTierBandInner agreementLengthMax(Float agreementLengthMax) {
-    this.agreementLengthMax = agreementLengthMax;
-    return this;
-  }
-
-  /**
-   * Specifies the maximum length of a band for a fixed overdraft agreement
-   * @return agreementLengthMax
-  */
-  
-  @Schema(name = "AgreementLengthMax", description = "Specifies the maximum length of a band for a fixed overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementLengthMax")
-  public Float getAgreementLengthMax() {
-    return agreementLengthMax;
-  }
-
-  public void setAgreementLengthMax(Float agreementLengthMax) {
-    this.agreementLengthMax = agreementLengthMax;
-  }
-
-  public OverdraftTierBandInner agreementPeriod(AgreementPeriodEnum agreementPeriod) {
-    this.agreementPeriod = agreementPeriod;
-    return this;
-  }
-
-  /**
-   * Specifies the period of a fixed length overdraft agreement
-   * @return agreementPeriod
-  */
-  
-  @Schema(name = "AgreementPeriod", description = "Specifies the period of a fixed length overdraft agreement", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AgreementPeriod")
-  public AgreementPeriodEnum getAgreementPeriod() {
-    return agreementPeriod;
-  }
-
-  public void setAgreementPeriod(AgreementPeriodEnum agreementPeriod) {
-    this.agreementPeriod = agreementPeriod;
-  }
-
-  public OverdraftTierBandInner overdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-    return this;
-  }
-
-  /**
-   * Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.
-   * @return overdraftInterestChargingCoverage
-  */
-  
-  @Schema(name = "OverdraftInterestChargingCoverage", description = "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftInterestChargingCoverage")
-  public OverdraftInterestChargingCoverageEnum getOverdraftInterestChargingCoverage() {
-    return overdraftInterestChargingCoverage;
-  }
-
-  public void setOverdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-  }
-
-  public OverdraftTierBandInner bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.
-   * @return bankGuaranteedIndicator
-  */
-  
-  @Schema(name = "BankGuaranteedIndicator", description = "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankGuaranteedIndicator")
-  public Boolean getBankGuaranteedIndicator() {
-    return bankGuaranteedIndicator;
-  }
-
-  public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-  }
-
-  public OverdraftTierBandInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftTierBandInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier/band details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier/band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftTierBandInner overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OverdraftTierBandInner addOverdraftFeesChargesItem(OverdraftFeesChargesInner overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Overdraft fees and charges
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OverdraftFeesChargesInner> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftTierBandInner overdraftTierBandInner = (OverdraftTierBandInner) o;
-    return Objects.equals(this.identification, overdraftTierBandInner.identification) &&
-        Objects.equals(this.tierValueMin, overdraftTierBandInner.tierValueMin) &&
-        Objects.equals(this.tierValueMax, overdraftTierBandInner.tierValueMax) &&
-        Objects.equals(this.EAR, overdraftTierBandInner.EAR) &&
-        Objects.equals(this.representativeAPR, overdraftTierBandInner.representativeAPR) &&
-        Objects.equals(this.agreementLengthMin, overdraftTierBandInner.agreementLengthMin) &&
-        Objects.equals(this.agreementLengthMax, overdraftTierBandInner.agreementLengthMax) &&
-        Objects.equals(this.agreementPeriod, overdraftTierBandInner.agreementPeriod) &&
-        Objects.equals(this.overdraftInterestChargingCoverage, overdraftTierBandInner.overdraftInterestChargingCoverage) &&
-        Objects.equals(this.bankGuaranteedIndicator, overdraftTierBandInner.bankGuaranteedIndicator) &&
-        Objects.equals(this.notes, overdraftTierBandInner.notes) &&
-        Objects.equals(this.overdraftFeesCharges, overdraftTierBandInner.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMin, tierValueMax, EAR, representativeAPR, agreementLengthMin, agreementLengthMax, agreementPeriod, overdraftInterestChargingCoverage, bankGuaranteedIndicator, notes, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftTierBandInner {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
-    sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
-    sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
-    sb.append("    representativeAPR: ").append(toIndentedString(representativeAPR)).append("\n");
-    sb.append("    agreementLengthMin: ").append(toIndentedString(agreementLengthMin)).append("\n");
-    sb.append("    agreementLengthMax: ").append(toIndentedString(agreementLengthMax)).append("\n");
-    sb.append("    agreementPeriod: ").append(toIndentedString(agreementPeriod)).append("\n");
-    sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
-    sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandInner1.java
@@ -15,21 +15,31 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeesChargesInner2;
+import uk.org.openbanking.datamodel.account.OverdraftInterestChargingCoverage1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Provides overdraft details for a specific tier or band
@@ -40,319 +50,294 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftTierBandInner1 {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMin;
+    private String tierValueMin;
 
-  private String tierValueMax;
+    private String tierValueMax;
 
-  /**
-   * Interest charged on whole amount or tiered/banded
-   */
-  public enum OverdraftInterestChargingCoverageEnum {
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
+    private OverdraftInterestChargingCoverage1 overdraftInterestChargingCoverage;
 
-    private String value;
+    private Boolean bankGuaranteedIndicator;
 
-    OverdraftInterestChargingCoverageEnum(String value) {
-      this.value = value;
+    private String EAR;
+
+    private String representativeAPR;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges;
+
+    public OverdraftTierBandInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftTierBandInner1(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OverdraftTierBandInner1 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OverdraftTierBandInner1 tierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+        return this;
+    }
+
+    /**
+     * Minimum value of Overdraft Tier/Band
+     *
+     * @return tierValueMin
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMin")
+    public String getTierValueMin() {
+        return tierValueMin;
+    }
+
+    public void setTierValueMin(String tierValueMin) {
+        this.tierValueMin = tierValueMin;
+    }
+
+    public OverdraftTierBandInner1 tierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+        return this;
+    }
+
+    /**
+     * Maximum value of Overdraft Tier/Band
+     *
+     * @return tierValueMax
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMax")
+    public String getTierValueMax() {
+        return tierValueMax;
+    }
+
+    public void setTierValueMax(String tierValueMax) {
+        this.tierValueMax = tierValueMax;
+    }
+
+    public OverdraftTierBandInner1 overdraftInterestChargingCoverage(OverdraftInterestChargingCoverage1 overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+        return this;
+    }
+
+    /**
+     * Get overdraftInterestChargingCoverage
+     *
+     * @return overdraftInterestChargingCoverage
+     */
+    @Valid
+    @Schema(name = "OverdraftInterestChargingCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftInterestChargingCoverage")
+    public OverdraftInterestChargingCoverage1 getOverdraftInterestChargingCoverage() {
+        return overdraftInterestChargingCoverage;
+    }
+
+    public void setOverdraftInterestChargingCoverage(OverdraftInterestChargingCoverage1 overdraftInterestChargingCoverage) {
+        this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
+    }
+
+    public OverdraftTierBandInner1 bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically
+     *
+     * @return bankGuaranteedIndicator
+     */
+
+    @Schema(name = "BankGuaranteedIndicator", description = "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankGuaranteedIndicator")
+    public Boolean getBankGuaranteedIndicator() {
+        return bankGuaranteedIndicator;
+    }
+
+    public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
+        this.bankGuaranteedIndicator = bankGuaranteedIndicator;
+    }
+
+    public OverdraftTierBandInner1 EAR(String EAR) {
+        this.EAR = EAR;
+        return this;
+    }
+
+    /**
+     * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
+     *
+     * @return EAR
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EAR")
+    public String getEAR() {
+        return EAR;
+    }
+
+    public void setEAR(String EAR) {
+        this.EAR = EAR;
+    }
+
+    public OverdraftTierBandInner1 representativeAPR(String representativeAPR) {
+        this.representativeAPR = representativeAPR;
+        return this;
+    }
+
+    /**
+     * An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
+     *
+     * @return representativeAPR
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "RepresentativeAPR", description = "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("RepresentativeAPR")
+    public String getRepresentativeAPR() {
+        return representativeAPR;
+    }
+
+    public void setRepresentativeAPR(String representativeAPR) {
+        this.representativeAPR = representativeAPR;
+    }
+
+    public OverdraftTierBandInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftTierBandInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier/band details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier/band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftTierBandInner1 overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OverdraftTierBandInner1 addOverdraftFeesChargesItem(OverdraftFeesChargesInner2 overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Overdraft fees and charges
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OverdraftFeesChargesInner2> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftTierBandInner1 overdraftTierBandInner1 = (OverdraftTierBandInner1) o;
+        return Objects.equals(this.identification, overdraftTierBandInner1.identification) &&
+                Objects.equals(this.tierValueMin, overdraftTierBandInner1.tierValueMin) &&
+                Objects.equals(this.tierValueMax, overdraftTierBandInner1.tierValueMax) &&
+                Objects.equals(this.overdraftInterestChargingCoverage, overdraftTierBandInner1.overdraftInterestChargingCoverage) &&
+                Objects.equals(this.bankGuaranteedIndicator, overdraftTierBandInner1.bankGuaranteedIndicator) &&
+                Objects.equals(this.EAR, overdraftTierBandInner1.EAR) &&
+                Objects.equals(this.representativeAPR, overdraftTierBandInner1.representativeAPR) &&
+                Objects.equals(this.notes, overdraftTierBandInner1.notes) &&
+                Objects.equals(this.overdraftFeesCharges, overdraftTierBandInner1.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMin, tierValueMax, overdraftInterestChargingCoverage, bankGuaranteedIndicator, EAR, representativeAPR, notes, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftTierBandInner1 {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
+        sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
+        sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
+        sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
+        sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
+        sb.append("    representativeAPR: ").append(toIndentedString(representativeAPR)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static OverdraftInterestChargingCoverageEnum fromValue(String value) {
-      for (OverdraftInterestChargingCoverageEnum b : OverdraftInterestChargingCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage;
-
-  private Boolean bankGuaranteedIndicator;
-
-  private String EAR;
-
-  private String representativeAPR;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges;
-
-  public OverdraftTierBandInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftTierBandInner1(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OverdraftTierBandInner1 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OverdraftTierBandInner1 tierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-    return this;
-  }
-
-  /**
-   * Minimum value of Overdraft Tier/Band
-   * @return tierValueMin
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMin", description = "Minimum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMin")
-  public String getTierValueMin() {
-    return tierValueMin;
-  }
-
-  public void setTierValueMin(String tierValueMin) {
-    this.tierValueMin = tierValueMin;
-  }
-
-  public OverdraftTierBandInner1 tierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-    return this;
-  }
-
-  /**
-   * Maximum value of Overdraft Tier/Band
-   * @return tierValueMax
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMax", description = "Maximum value of Overdraft Tier/Band", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMax")
-  public String getTierValueMax() {
-    return tierValueMax;
-  }
-
-  public void setTierValueMax(String tierValueMax) {
-    this.tierValueMax = tierValueMax;
-  }
-
-  public OverdraftTierBandInner1 overdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-    return this;
-  }
-
-  /**
-   * Interest charged on whole amount or tiered/banded
-   * @return overdraftInterestChargingCoverage
-  */
-  
-  @Schema(name = "OverdraftInterestChargingCoverage", description = "Interest charged on whole amount or tiered/banded", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftInterestChargingCoverage")
-  public OverdraftInterestChargingCoverageEnum getOverdraftInterestChargingCoverage() {
-    return overdraftInterestChargingCoverage;
-  }
-
-  public void setOverdraftInterestChargingCoverage(OverdraftInterestChargingCoverageEnum overdraftInterestChargingCoverage) {
-    this.overdraftInterestChargingCoverage = overdraftInterestChargingCoverage;
-  }
-
-  public OverdraftTierBandInner1 bankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically
-   * @return bankGuaranteedIndicator
-  */
-  
-  @Schema(name = "BankGuaranteedIndicator", description = "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankGuaranteedIndicator")
-  public Boolean getBankGuaranteedIndicator() {
-    return bankGuaranteedIndicator;
-  }
-
-  public void setBankGuaranteedIndicator(Boolean bankGuaranteedIndicator) {
-    this.bankGuaranteedIndicator = bankGuaranteedIndicator;
-  }
-
-  public OverdraftTierBandInner1 EAR(String EAR) {
-    this.EAR = EAR;
-    return this;
-  }
-
-  /**
-   * EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.
-   * @return EAR
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "EAR", description = "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently used interchangeably), being the actual annual interest rate of an Overdraft.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("EAR")
-  public String getEAR() {
-    return EAR;
-  }
-
-  public void setEAR(String EAR) {
-    this.EAR = EAR;
-  }
-
-  public OverdraftTierBandInner1 representativeAPR(String representativeAPR) {
-    this.representativeAPR = representativeAPR;
-    return this;
-  }
-
-  /**
-   * An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
-   * @return representativeAPR
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "RepresentativeAPR", description = "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("RepresentativeAPR")
-  public String getRepresentativeAPR() {
-    return representativeAPR;
-  }
-
-  public void setRepresentativeAPR(String representativeAPR) {
-    this.representativeAPR = representativeAPR;
-  }
-
-  public OverdraftTierBandInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftTierBandInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier/band details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier/band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftTierBandInner1 overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OverdraftTierBandInner1 addOverdraftFeesChargesItem(OverdraftFeesChargesInner2 overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Overdraft fees and charges
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OverdraftFeesChargesInner2> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner2> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftTierBandInner1 overdraftTierBandInner1 = (OverdraftTierBandInner1) o;
-    return Objects.equals(this.identification, overdraftTierBandInner1.identification) &&
-        Objects.equals(this.tierValueMin, overdraftTierBandInner1.tierValueMin) &&
-        Objects.equals(this.tierValueMax, overdraftTierBandInner1.tierValueMax) &&
-        Objects.equals(this.overdraftInterestChargingCoverage, overdraftTierBandInner1.overdraftInterestChargingCoverage) &&
-        Objects.equals(this.bankGuaranteedIndicator, overdraftTierBandInner1.bankGuaranteedIndicator) &&
-        Objects.equals(this.EAR, overdraftTierBandInner1.EAR) &&
-        Objects.equals(this.representativeAPR, overdraftTierBandInner1.representativeAPR) &&
-        Objects.equals(this.notes, overdraftTierBandInner1.notes) &&
-        Objects.equals(this.overdraftFeesCharges, overdraftTierBandInner1.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMin, tierValueMax, overdraftInterestChargingCoverage, bankGuaranteedIndicator, EAR, representativeAPR, notes, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftTierBandInner1 {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMin: ").append(toIndentedString(tierValueMin)).append("\n");
-    sb.append("    tierValueMax: ").append(toIndentedString(tierValueMax)).append("\n");
-    sb.append("    overdraftInterestChargingCoverage: ").append(toIndentedString(overdraftInterestChargingCoverage)).append("\n");
-    sb.append("    bankGuaranteedIndicator: ").append(toIndentedString(bankGuaranteedIndicator)).append("\n");
-    sb.append("    EAR: ").append(toIndentedString(EAR)).append("\n");
-    sb.append("    representativeAPR: ").append(toIndentedString(representativeAPR)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandSetInner.java
@@ -15,21 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeesChargesInner1;
+import uk.org.openbanking.datamodel.account.OverdraftTierBandInner;
+import uk.org.openbanking.datamodel.account.OverdraftType;
+import uk.org.openbanking.datamodel.account.TierBandMethod1;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Tier band set details
@@ -40,342 +52,281 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftTierBandSetInner {
 
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   */
-  public enum TierBandMethodEnum {
-    BANDED("Banded"),
-    
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
+    private TierBandMethod1 tierBandMethod;
 
-    private String value;
+    private OverdraftType overdraftType;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private String identification;
+
+    private Boolean authorisedIndicator;
+
+    private String bufferAmount;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OverdraftTierBandInner> overdraftTierBand = new ArrayList<>();
+
+    @Valid
+    private List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges;
+
+    public OverdraftTierBandSetInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftTierBandSetInner(TierBandMethod1 tierBandMethod, List<@Valid OverdraftTierBandInner> overdraftTierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OverdraftTierBandSetInner tierBandMethod(TierBandMethod1 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public TierBandMethod1 getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(TierBandMethod1 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public OverdraftTierBandSetInner overdraftType(OverdraftType overdraftType) {
+        this.overdraftType = overdraftType;
+        return this;
+    }
+
+    /**
+     * Get overdraftType
+     *
+     * @return overdraftType
+     */
+    @Valid
+    @Schema(name = "OverdraftType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftType")
+    public OverdraftType getOverdraftType() {
+        return overdraftType;
+    }
+
+    public void setOverdraftType(OverdraftType overdraftType) {
+        this.overdraftType = overdraftType;
+    }
+
+    public OverdraftTierBandSetInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft product.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OverdraftTierBandSetInner authorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
+     *
+     * @return authorisedIndicator
+     */
+
+    @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AuthorisedIndicator")
+    public Boolean getAuthorisedIndicator() {
+        return authorisedIndicator;
+    }
+
+    public void setAuthorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+    }
+
+    public OverdraftTierBandSetInner bufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+        return this;
+    }
+
+    /**
+     * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
+     *
+     * @return bufferAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BufferAmount")
+    public String getBufferAmount() {
+        return bufferAmount;
+    }
+
+    public void setBufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+    }
+
+    public OverdraftTierBandSetInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the overdraft Tier Band Set details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the overdraft Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftTierBandSetInner overdraftTierBand(List<@Valid OverdraftTierBandInner> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner addOverdraftTierBandItem(OverdraftTierBandInner overdraftTierBandItem) {
+        if (this.overdraftTierBand == null) {
+            this.overdraftTierBand = new ArrayList<>();
+        }
+        this.overdraftTierBand.add(overdraftTierBandItem);
+        return this;
+    }
+
+    /**
+     * Provides overdraft details for a specific tier or band
+     *
+     * @return overdraftTierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBand", description = "Provides overdraft details for a specific tier or band", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBand")
+    public List<@Valid OverdraftTierBandInner> getOverdraftTierBand() {
+        return overdraftTierBand;
+    }
+
+    public void setOverdraftTierBand(List<@Valid OverdraftTierBandInner> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OverdraftTierBandSetInner overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner addOverdraftFeesChargesItem(OverdraftFeesChargesInner1 overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Overdraft fees and charges details
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OverdraftFeesChargesInner1> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftTierBandSetInner overdraftTierBandSetInner = (OverdraftTierBandSetInner) o;
+        return Objects.equals(this.tierBandMethod, overdraftTierBandSetInner.tierBandMethod) &&
+                Objects.equals(this.overdraftType, overdraftTierBandSetInner.overdraftType) &&
+                Objects.equals(this.identification, overdraftTierBandSetInner.identification) &&
+                Objects.equals(this.authorisedIndicator, overdraftTierBandSetInner.authorisedIndicator) &&
+                Objects.equals(this.bufferAmount, overdraftTierBandSetInner.bufferAmount) &&
+                Objects.equals(this.notes, overdraftTierBandSetInner.notes) &&
+                Objects.equals(this.overdraftTierBand, overdraftTierBandSetInner.overdraftTierBand) &&
+                Objects.equals(this.overdraftFeesCharges, overdraftTierBandSetInner.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftTierBandSetInner {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
+        sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   */
-  public enum OverdraftTypeEnum {
-    COMMITTED("Committed"),
-    
-    ONDEMAND("OnDemand");
-
-    private String value;
-
-    OverdraftTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static OverdraftTypeEnum fromValue(String value) {
-      for (OverdraftTypeEnum b : OverdraftTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private OverdraftTypeEnum overdraftType;
-
-  private String identification;
-
-  private Boolean authorisedIndicator;
-
-  private String bufferAmount;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OverdraftTierBandInner> overdraftTierBand = new ArrayList<>();
-
-  @Valid
-  private List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges;
-
-  public OverdraftTierBandSetInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftTierBandSetInner(TierBandMethodEnum tierBandMethod, List<@Valid OverdraftTierBandInner> overdraftTierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OverdraftTierBandSetInner tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public OverdraftTierBandSetInner overdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-    return this;
-  }
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   * @return overdraftType
-  */
-  
-  @Schema(name = "OverdraftType", description = "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftType")
-  public OverdraftTypeEnum getOverdraftType() {
-    return overdraftType;
-  }
-
-  public void setOverdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-  }
-
-  public OverdraftTierBandSetInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft product.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OverdraftTierBandSetInner authorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
-   * @return authorisedIndicator
-  */
-  
-  @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AuthorisedIndicator")
-  public Boolean getAuthorisedIndicator() {
-    return authorisedIndicator;
-  }
-
-  public void setAuthorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-  }
-
-  public OverdraftTierBandSetInner bufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-    return this;
-  }
-
-  /**
-   * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
-   * @return bufferAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BufferAmount")
-  public String getBufferAmount() {
-    return bufferAmount;
-  }
-
-  public void setBufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-  }
-
-  public OverdraftTierBandSetInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the overdraft Tier Band Set details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the overdraft Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftTierBandSetInner overdraftTierBand(List<@Valid OverdraftTierBandInner> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner addOverdraftTierBandItem(OverdraftTierBandInner overdraftTierBandItem) {
-    if (this.overdraftTierBand == null) {
-      this.overdraftTierBand = new ArrayList<>();
-    }
-    this.overdraftTierBand.add(overdraftTierBandItem);
-    return this;
-  }
-
-  /**
-   * Provides overdraft details for a specific tier or band
-   * @return overdraftTierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBand", description = "Provides overdraft details for a specific tier or band", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBand")
-  public List<@Valid OverdraftTierBandInner> getOverdraftTierBand() {
-    return overdraftTierBand;
-  }
-
-  public void setOverdraftTierBand(List<@Valid OverdraftTierBandInner> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OverdraftTierBandSetInner overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner addOverdraftFeesChargesItem(OverdraftFeesChargesInner1 overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Overdraft fees and charges details
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OverdraftFeesChargesInner1> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner1> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftTierBandSetInner overdraftTierBandSetInner = (OverdraftTierBandSetInner) o;
-    return Objects.equals(this.tierBandMethod, overdraftTierBandSetInner.tierBandMethod) &&
-        Objects.equals(this.overdraftType, overdraftTierBandSetInner.overdraftType) &&
-        Objects.equals(this.identification, overdraftTierBandSetInner.identification) &&
-        Objects.equals(this.authorisedIndicator, overdraftTierBandSetInner.authorisedIndicator) &&
-        Objects.equals(this.bufferAmount, overdraftTierBandSetInner.bufferAmount) &&
-        Objects.equals(this.notes, overdraftTierBandSetInner.notes) &&
-        Objects.equals(this.overdraftTierBand, overdraftTierBandSetInner.overdraftTierBand) &&
-        Objects.equals(this.overdraftFeesCharges, overdraftTierBandSetInner.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftTierBandSetInner {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
-    sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftTierBandSetInner1.java
@@ -15,21 +15,33 @@
  */
 package uk.org.openbanking.datamodel.account;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URI;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Generated;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import uk.org.openbanking.datamodel.account.OverdraftFeesChargesInner3;
+import uk.org.openbanking.datamodel.account.OverdraftTierBandInner1;
+import uk.org.openbanking.datamodel.account.OverdraftType1;
+import uk.org.openbanking.datamodel.account.TierBandMethod3;
+
+import java.time.OffsetDateTime;
+
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
+import jakarta.annotation.Generated;
 
 /**
  * Tier band set details
@@ -40,344 +52,281 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OverdraftTierBandSetInner1 {
 
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   */
-  public enum TierBandMethodEnum {
-    TIERED("Tiered"),
-    
-    WHOLE("Whole"),
-    
-    BANDED("Banded");
+    private TierBandMethod3 tierBandMethod;
 
-    private String value;
+    private OverdraftType1 overdraftType;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private String identification;
+
+    private Boolean authorisedIndicator;
+
+    private String bufferAmount;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid OverdraftTierBandInner1> overdraftTierBand = new ArrayList<>();
+
+    @Valid
+    private List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges;
+
+    public OverdraftTierBandSetInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public OverdraftTierBandSetInner1(TierBandMethod3 tierBandMethod, List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OverdraftTierBandSetInner1 tierBandMethod(TierBandMethod3 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public TierBandMethod3 getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(TierBandMethod3 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public OverdraftTierBandSetInner1 overdraftType(OverdraftType1 overdraftType) {
+        this.overdraftType = overdraftType;
+        return this;
+    }
+
+    /**
+     * Get overdraftType
+     *
+     * @return overdraftType
+     */
+    @Valid
+    @Schema(name = "OverdraftType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftType")
+    public OverdraftType1 getOverdraftType() {
+        return overdraftType;
+    }
+
+    public void setOverdraftType(OverdraftType1 overdraftType) {
+        this.overdraftType = overdraftType;
+    }
+
+    public OverdraftTierBandSetInner1 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a overdraft product.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OverdraftTierBandSetInner1 authorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
+     *
+     * @return authorisedIndicator
+     */
+
+    @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AuthorisedIndicator")
+    public Boolean getAuthorisedIndicator() {
+        return authorisedIndicator;
+    }
+
+    public void setAuthorisedIndicator(Boolean authorisedIndicator) {
+        this.authorisedIndicator = authorisedIndicator;
+    }
+
+    public OverdraftTierBandSetInner1 bufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+        return this;
+    }
+
+    /**
+     * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
+     *
+     * @return bufferAmount
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BufferAmount")
+    public String getBufferAmount() {
+        return bufferAmount;
+    }
+
+    public void setBufferAmount(String bufferAmount) {
+        this.bufferAmount = bufferAmount;
+    }
+
+    public OverdraftTierBandSetInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the overdraft Tier Band Set details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the overdraft Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public OverdraftTierBandSetInner1 overdraftTierBand(List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner1 addOverdraftTierBandItem(OverdraftTierBandInner1 overdraftTierBandItem) {
+        if (this.overdraftTierBand == null) {
+            this.overdraftTierBand = new ArrayList<>();
+        }
+        this.overdraftTierBand.add(overdraftTierBandItem);
+        return this;
+    }
+
+    /**
+     * Provides overdraft details for a specific tier or band
+     *
+     * @return overdraftTierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "OverdraftTierBand", description = "Provides overdraft details for a specific tier or band", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("OverdraftTierBand")
+    public List<@Valid OverdraftTierBandInner1> getOverdraftTierBand() {
+        return overdraftTierBand;
+    }
+
+    public void setOverdraftTierBand(List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
+        this.overdraftTierBand = overdraftTierBand;
+    }
+
+    public OverdraftTierBandSetInner1 overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+        return this;
+    }
+
+    public OverdraftTierBandSetInner1 addOverdraftFeesChargesItem(OverdraftFeesChargesInner3 overdraftFeesChargesItem) {
+        if (this.overdraftFeesCharges == null) {
+            this.overdraftFeesCharges = new ArrayList<>();
+        }
+        this.overdraftFeesCharges.add(overdraftFeesChargesItem);
+        return this;
+    }
+
+    /**
+     * Overdraft fees and charges details
+     *
+     * @return overdraftFeesCharges
+     */
+    @Valid
+    @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OverdraftFeesCharges")
+    public List<@Valid OverdraftFeesChargesInner3> getOverdraftFeesCharges() {
+        return overdraftFeesCharges;
+    }
+
+    public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges) {
+        this.overdraftFeesCharges = overdraftFeesCharges;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OverdraftTierBandSetInner1 overdraftTierBandSetInner1 = (OverdraftTierBandSetInner1) o;
+        return Objects.equals(this.tierBandMethod, overdraftTierBandSetInner1.tierBandMethod) &&
+                Objects.equals(this.overdraftType, overdraftTierBandSetInner1.overdraftType) &&
+                Objects.equals(this.identification, overdraftTierBandSetInner1.identification) &&
+                Objects.equals(this.authorisedIndicator, overdraftTierBandSetInner1.authorisedIndicator) &&
+                Objects.equals(this.bufferAmount, overdraftTierBandSetInner1.bufferAmount) &&
+                Objects.equals(this.notes, overdraftTierBandSetInner1.notes) &&
+                Objects.equals(this.overdraftTierBand, overdraftTierBandSetInner1.overdraftTierBand) &&
+                Objects.equals(this.overdraftFeesCharges, overdraftTierBandSetInner1.overdraftFeesCharges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OverdraftTierBandSetInner1 {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
+        sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
+        sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   */
-  public enum OverdraftTypeEnum {
-    COMMITTED("Committed"),
-    
-    ONDEMAND("OnDemand"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    OverdraftTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static OverdraftTypeEnum fromValue(String value) {
-      for (OverdraftTypeEnum b : OverdraftTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private OverdraftTypeEnum overdraftType;
-
-  private String identification;
-
-  private Boolean authorisedIndicator;
-
-  private String bufferAmount;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid OverdraftTierBandInner1> overdraftTierBand = new ArrayList<>();
-
-  @Valid
-  private List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges;
-
-  public OverdraftTierBandSetInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public OverdraftTierBandSetInner1(TierBandMethodEnum tierBandMethod, List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OverdraftTierBandSetInner1 tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public OverdraftTierBandSetInner1 overdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-    return this;
-  }
-
-  /**
-   * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
-   * @return overdraftType
-  */
-  
-  @Schema(name = "OverdraftType", description = "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftType")
-  public OverdraftTypeEnum getOverdraftType() {
-    return overdraftType;
-  }
-
-  public void setOverdraftType(OverdraftTypeEnum overdraftType) {
-    this.overdraftType = overdraftType;
-  }
-
-  public OverdraftTierBandSetInner1 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a overdraft product.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a overdraft product.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public OverdraftTierBandSetInner1 authorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-    return this;
-  }
-
-  /**
-   * Indicates if the Overdraft is authorised (Y) or unauthorised (N)
-   * @return authorisedIndicator
-  */
-  
-  @Schema(name = "AuthorisedIndicator", description = "Indicates if the Overdraft is authorised (Y) or unauthorised (N)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("AuthorisedIndicator")
-  public Boolean getAuthorisedIndicator() {
-    return authorisedIndicator;
-  }
-
-  public void setAuthorisedIndicator(Boolean authorisedIndicator) {
-    this.authorisedIndicator = authorisedIndicator;
-  }
-
-  public OverdraftTierBandSetInner1 bufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-    return this;
-  }
-
-  /**
-   * When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.
-   * @return bufferAmount
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BufferAmount", description = "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BufferAmount")
-  public String getBufferAmount() {
-    return bufferAmount;
-  }
-
-  public void setBufferAmount(String bufferAmount) {
-    this.bufferAmount = bufferAmount;
-  }
-
-  public OverdraftTierBandSetInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the overdraft Tier Band Set details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the overdraft Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public OverdraftTierBandSetInner1 overdraftTierBand(List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner1 addOverdraftTierBandItem(OverdraftTierBandInner1 overdraftTierBandItem) {
-    if (this.overdraftTierBand == null) {
-      this.overdraftTierBand = new ArrayList<>();
-    }
-    this.overdraftTierBand.add(overdraftTierBandItem);
-    return this;
-  }
-
-  /**
-   * Provides overdraft details for a specific tier or band
-   * @return overdraftTierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "OverdraftTierBand", description = "Provides overdraft details for a specific tier or band", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("OverdraftTierBand")
-  public List<@Valid OverdraftTierBandInner1> getOverdraftTierBand() {
-    return overdraftTierBand;
-  }
-
-  public void setOverdraftTierBand(List<@Valid OverdraftTierBandInner1> overdraftTierBand) {
-    this.overdraftTierBand = overdraftTierBand;
-  }
-
-  public OverdraftTierBandSetInner1 overdraftFeesCharges(List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-    return this;
-  }
-
-  public OverdraftTierBandSetInner1 addOverdraftFeesChargesItem(OverdraftFeesChargesInner3 overdraftFeesChargesItem) {
-    if (this.overdraftFeesCharges == null) {
-      this.overdraftFeesCharges = new ArrayList<>();
-    }
-    this.overdraftFeesCharges.add(overdraftFeesChargesItem);
-    return this;
-  }
-
-  /**
-   * Overdraft fees and charges details
-   * @return overdraftFeesCharges
-  */
-  @Valid 
-  @Schema(name = "OverdraftFeesCharges", description = "Overdraft fees and charges details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OverdraftFeesCharges")
-  public List<@Valid OverdraftFeesChargesInner3> getOverdraftFeesCharges() {
-    return overdraftFeesCharges;
-  }
-
-  public void setOverdraftFeesCharges(List<@Valid OverdraftFeesChargesInner3> overdraftFeesCharges) {
-    this.overdraftFeesCharges = overdraftFeesCharges;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    OverdraftTierBandSetInner1 overdraftTierBandSetInner1 = (OverdraftTierBandSetInner1) o;
-    return Objects.equals(this.tierBandMethod, overdraftTierBandSetInner1.tierBandMethod) &&
-        Objects.equals(this.overdraftType, overdraftTierBandSetInner1.overdraftType) &&
-        Objects.equals(this.identification, overdraftTierBandSetInner1.identification) &&
-        Objects.equals(this.authorisedIndicator, overdraftTierBandSetInner1.authorisedIndicator) &&
-        Objects.equals(this.bufferAmount, overdraftTierBandSetInner1.bufferAmount) &&
-        Objects.equals(this.notes, overdraftTierBandSetInner1.notes) &&
-        Objects.equals(this.overdraftTierBand, overdraftTierBandSetInner1.overdraftTierBand) &&
-        Objects.equals(this.overdraftFeesCharges, overdraftTierBandSetInner1.overdraftFeesCharges);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, overdraftType, identification, authorisedIndicator, bufferAmount, notes, overdraftTierBand, overdraftFeesCharges);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class OverdraftTierBandSetInner1 {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    overdraftType: ").append(toIndentedString(overdraftType)).append("\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    authorisedIndicator: ").append(toIndentedString(authorisedIndicator)).append("\n");
-    sb.append("    bufferAmount: ").append(toIndentedString(bufferAmount)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    overdraftTierBand: ").append(toIndentedString(overdraftTierBand)).append("\n");
-    sb.append("    overdraftFeesCharges: ").append(toIndentedString(overdraftFeesCharges)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OverdraftType {
+
+    COMMITTED("Committed"),
+
+    ONDEMAND("OnDemand");
+
+    private String value;
+
+    OverdraftType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OverdraftType fromValue(String value) {
+        for (OverdraftType b : OverdraftType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftType1.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OverdraftType1 {
+
+    COMMITTED("Committed"),
+
+    ONDEMAND("OnDemand"),
+
+    OTHER("Other");
+
+    private String value;
+
+    OverdraftType1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OverdraftType1 fromValue(String value) {
+        for (OverdraftType1 b : OverdraftType1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
@@ -19,9 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -35,243 +33,157 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class ProductDetails {
 
-  /**
-   * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. 
-   */
-  public enum SegmentEnum {
-    CLIENTACCOUNT("ClientAccount"),
-    
-    STANDARD("Standard"),
-    
-    NONCOMMERCIALCHAITIESCLBSOC("NonCommercialChaitiesClbSoc"),
-    
-    NONCOMMERCIALPUBLICAUTHGOVT("NonCommercialPublicAuthGovt"),
-    
-    RELIGIOUS("Religious"),
-    
-    SECTORSPECIFIC("SectorSpecific"),
-    
-    STARTUP("Startup"),
-    
-    SWITCHER("Switcher");
+    @Valid
+    private List<@Valid SegmentInner> segment;
 
-    private String value;
+    private Float feeFreeLength;
 
-    SegmentEnum(String value) {
-      this.value = value;
+    private FeeFreeLengthPeriod feeFreeLengthPeriod;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    public ProductDetails segment(List<@Valid SegmentInner> segment) {
+        this.segment = segment;
+        return this;
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    public ProductDetails addSegmentItem(SegmentInner segmentItem) {
+        if (this.segment == null) {
+            this.segment = new ArrayList<>();
+        }
+        this.segment.add(segmentItem);
+        return this;
+    }
+
+    /**
+     * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on.
+     *
+     * @return segment
+     */
+    @Valid
+    @Schema(name = "Segment", description = "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Segment")
+    public List<@Valid SegmentInner> getSegment() {
+        return segment;
+    }
+
+    public void setSegment(List<@Valid SegmentInner> segment) {
+        this.segment = segment;
+    }
+
+    public ProductDetails feeFreeLength(Float feeFreeLength) {
+        this.feeFreeLength = feeFreeLength;
+        return this;
+    }
+
+    /**
+     * The length/duration of the fee free period
+     *
+     * @return feeFreeLength
+     */
+
+    @Schema(name = "FeeFreeLength", description = "The length/duration of the fee free period", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeFreeLength")
+    public Float getFeeFreeLength() {
+        return feeFreeLength;
+    }
+
+    public void setFeeFreeLength(Float feeFreeLength) {
+        this.feeFreeLength = feeFreeLength;
+    }
+
+    public ProductDetails feeFreeLengthPeriod(FeeFreeLengthPeriod feeFreeLengthPeriod) {
+        this.feeFreeLengthPeriod = feeFreeLengthPeriod;
+        return this;
+    }
+
+    /**
+     * Get feeFreeLengthPeriod
+     *
+     * @return feeFreeLengthPeriod
+     */
+    @Valid
+    @Schema(name = "FeeFreeLengthPeriod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FeeFreeLengthPeriod")
+    public FeeFreeLengthPeriod getFeeFreeLengthPeriod() {
+        return feeFreeLengthPeriod;
+    }
+
+    public void setFeeFreeLengthPeriod(FeeFreeLengthPeriod feeFreeLengthPeriod) {
+        this.feeFreeLengthPeriod = feeFreeLengthPeriod;
+    }
+
+    public ProductDetails notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public ProductDetails addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Core product details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Core product details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProductDetails productDetails = (ProductDetails) o;
+        return Objects.equals(this.segment, productDetails.segment) &&
+                Objects.equals(this.feeFreeLength, productDetails.feeFreeLength) &&
+                Objects.equals(this.feeFreeLengthPeriod, productDetails.feeFreeLengthPeriod) &&
+                Objects.equals(this.notes, productDetails.notes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segment, feeFreeLength, feeFreeLengthPeriod, notes);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProductDetails {\n");
+        sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
+        sb.append("    feeFreeLength: ").append(toIndentedString(feeFreeLength)).append("\n");
+        sb.append("    feeFreeLengthPeriod: ").append(toIndentedString(feeFreeLengthPeriod)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static SegmentEnum fromValue(String value) {
-      for (SegmentEnum b : SegmentEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<SegmentEnum> segment;
-
-  private Float feeFreeLength;
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the promotional length
-   */
-  public enum FeeFreeLengthPeriodEnum {
-    DAY("Day"),
-    
-    HALF_YEAR("Half Year"),
-    
-    MONTH("Month"),
-    
-    QUARTER("Quarter"),
-    
-    WEEK("Week"),
-    
-    YEAR("Year");
-
-    private String value;
-
-    FeeFreeLengthPeriodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FeeFreeLengthPeriodEnum fromValue(String value) {
-      for (FeeFreeLengthPeriodEnum b : FeeFreeLengthPeriodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FeeFreeLengthPeriodEnum feeFreeLengthPeriod;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  public ProductDetails segment(List<SegmentEnum> segment) {
-    this.segment = segment;
-    return this;
-  }
-
-  public ProductDetails addSegmentItem(SegmentEnum segmentItem) {
-    if (this.segment == null) {
-      this.segment = new ArrayList<>();
-    }
-    this.segment.add(segmentItem);
-    return this;
-  }
-
-  /**
-   * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. 
-   * @return segment
-  */
-  
-  @Schema(name = "Segment", description = "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on. ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Segment")
-  public List<SegmentEnum> getSegment() {
-    return segment;
-  }
-
-  public void setSegment(List<SegmentEnum> segment) {
-    this.segment = segment;
-  }
-
-  public ProductDetails feeFreeLength(Float feeFreeLength) {
-    this.feeFreeLength = feeFreeLength;
-    return this;
-  }
-
-  /**
-   * The length/duration of the fee free period
-   * @return feeFreeLength
-  */
-  
-  @Schema(name = "FeeFreeLength", description = "The length/duration of the fee free period", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeFreeLength")
-  public Float getFeeFreeLength() {
-    return feeFreeLength;
-  }
-
-  public void setFeeFreeLength(Float feeFreeLength) {
-    this.feeFreeLength = feeFreeLength;
-  }
-
-  public ProductDetails feeFreeLengthPeriod(FeeFreeLengthPeriodEnum feeFreeLengthPeriod) {
-    this.feeFreeLengthPeriod = feeFreeLengthPeriod;
-    return this;
-  }
-
-  /**
-   * The unit of period (days, weeks, months etc.) of the promotional length
-   * @return feeFreeLengthPeriod
-  */
-  
-  @Schema(name = "FeeFreeLengthPeriod", description = "The unit of period (days, weeks, months etc.) of the promotional length", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("FeeFreeLengthPeriod")
-  public FeeFreeLengthPeriodEnum getFeeFreeLengthPeriod() {
-    return feeFreeLengthPeriod;
-  }
-
-  public void setFeeFreeLengthPeriod(FeeFreeLengthPeriodEnum feeFreeLengthPeriod) {
-    this.feeFreeLengthPeriod = feeFreeLengthPeriod;
-  }
-
-  public ProductDetails notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public ProductDetails addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Core product details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Core product details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ProductDetails productDetails = (ProductDetails) o;
-    return Objects.equals(this.segment, productDetails.segment) &&
-        Objects.equals(this.feeFreeLength, productDetails.feeFreeLength) &&
-        Objects.equals(this.feeFreeLengthPeriod, productDetails.feeFreeLengthPeriod) &&
-        Objects.equals(this.notes, productDetails.notes);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(segment, feeFreeLength, feeFreeLengthPeriod, notes);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ProductDetails {\n");
-    sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
-    sb.append("    feeFreeLength: ").append(toIndentedString(feeFreeLength)).append("\n");
-    sb.append("    feeFreeLengthPeriod: ").append(toIndentedString(feeFreeLengthPeriod)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -38,188 +36,132 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class ProductDetails1 {
 
-  /**
-   * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. 
-   */
-  public enum SegmentEnum {
-    BASIC("Basic"),
-    
-    BENEFITANDREWARD("BenefitAndReward"),
-    
-    CREDITINTEREST("CreditInterest"),
-    
-    CASHBACK("Cashback"),
-    
-    GENERAL("General"),
-    
-    GRADUATE("Graduate"),
-    
-    OTHER("Other"),
-    
-    OVERDRAFT("Overdraft"),
-    
-    PACKAGED("Packaged"),
-    
-    PREMIUM("Premium"),
-    
-    REWARD("Reward"),
-    
-    STUDENT("Student"),
-    
-    YOUNGADULT("YoungAdult"),
-    
-    YOUTH("Youth");
+    @Valid
+    private List<@Valid SegmentInner1> segment;
 
-    private String value;
+    private String monthlyMaximumCharge;
 
-    SegmentEnum(String value) {
-      this.value = value;
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    public ProductDetails1 segment(List<@Valid SegmentInner1> segment) {
+        this.segment = segment;
+        return this;
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    public ProductDetails1 addSegmentItem(SegmentInner1 segmentItem) {
+        if (this.segment == null) {
+            this.segment = new ArrayList<>();
+        }
+        this.segment.add(segmentItem);
+        return this;
+    }
+
+    /**
+     * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on.
+     *
+     * @return segment
+     */
+    @Valid
+    @Schema(name = "Segment", description = "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Segment")
+    public List<@Valid SegmentInner1> getSegment() {
+        return segment;
+    }
+
+    public void setSegment(List<@Valid SegmentInner1> segment) {
+        this.segment = segment;
+    }
+
+    public ProductDetails1 monthlyMaximumCharge(String monthlyMaximumCharge) {
+        this.monthlyMaximumCharge = monthlyMaximumCharge;
+        return this;
+    }
+
+    /**
+     * The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order
+     *
+     * @return monthlyMaximumCharge
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "MonthlyMaximumCharge", description = "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MonthlyMaximumCharge")
+    public String getMonthlyMaximumCharge() {
+        return monthlyMaximumCharge;
+    }
+
+    public void setMonthlyMaximumCharge(String monthlyMaximumCharge) {
+        this.monthlyMaximumCharge = monthlyMaximumCharge;
+    }
+
+    public ProductDetails1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public ProductDetails1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Core product details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Core product details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProductDetails1 productDetails1 = (ProductDetails1) o;
+        return Objects.equals(this.segment, productDetails1.segment) &&
+                Objects.equals(this.monthlyMaximumCharge, productDetails1.monthlyMaximumCharge) &&
+                Objects.equals(this.notes, productDetails1.notes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segment, monthlyMaximumCharge, notes);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProductDetails1 {\n");
+        sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
+        sb.append("    monthlyMaximumCharge: ").append(toIndentedString(monthlyMaximumCharge)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static SegmentEnum fromValue(String value) {
-      for (SegmentEnum b : SegmentEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  @Valid
-  private List<SegmentEnum> segment;
-
-  private String monthlyMaximumCharge;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  public ProductDetails1 segment(List<SegmentEnum> segment) {
-    this.segment = segment;
-    return this;
-  }
-
-  public ProductDetails1 addSegmentItem(SegmentEnum segmentItem) {
-    if (this.segment == null) {
-      this.segment = new ArrayList<>();
-    }
-    this.segment.add(segmentItem);
-    return this;
-  }
-
-  /**
-   * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. 
-   * @return segment
-  */
-  
-  @Schema(name = "Segment", description = "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on. ", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Segment")
-  public List<SegmentEnum> getSegment() {
-    return segment;
-  }
-
-  public void setSegment(List<SegmentEnum> segment) {
-    this.segment = segment;
-  }
-
-  public ProductDetails1 monthlyMaximumCharge(String monthlyMaximumCharge) {
-    this.monthlyMaximumCharge = monthlyMaximumCharge;
-    return this;
-  }
-
-  /**
-   * The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order
-   * @return monthlyMaximumCharge
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "MonthlyMaximumCharge", description = "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("MonthlyMaximumCharge")
-  public String getMonthlyMaximumCharge() {
-    return monthlyMaximumCharge;
-  }
-
-  public void setMonthlyMaximumCharge(String monthlyMaximumCharge) {
-    this.monthlyMaximumCharge = monthlyMaximumCharge;
-  }
-
-  public ProductDetails1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public ProductDetails1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Core product details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Core product details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    ProductDetails1 productDetails1 = (ProductDetails1) o;
-    return Objects.equals(this.segment, productDetails1.segment) &&
-        Objects.equals(this.monthlyMaximumCharge, productDetails1.monthlyMaximumCharge) &&
-        Objects.equals(this.notes, productDetails1.notes);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(segment, monthlyMaximumCharge, notes);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ProductDetails1 {\n");
-    sb.append("    segment: ").append(toIndentedString(segment)).append("\n");
-    sb.append("    monthlyMaximumCharge: ").append(toIndentedString(monthlyMaximumCharge)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
@@ -15,14 +15,22 @@
  */
 package uk.org.openbanking.datamodel.account;
 
+import java.net.URI;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
+import java.time.OffsetDateTime;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+
+import java.util.*;
+
 import jakarta.annotation.Generated;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 /**
  * Set of elements to fully identify a proprietary bank transaction code.
@@ -32,98 +40,101 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class ProprietaryBankTransactionCodeStructure1 {
 
-  private String code;
+    private String code;
 
-  private String issuer;
+    private String issuer;
 
-  public ProprietaryBankTransactionCodeStructure1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public ProprietaryBankTransactionCodeStructure1(String code) {
-    this.code = code;
-  }
-
-  public ProprietaryBankTransactionCodeStructure1 code(String code) {
-    this.code = code;
-    return this;
-  }
-
-  /**
-   * Proprietary bank transaction code to identify the underlying transaction.
-   * @return code
-  */
-  @NotNull @Size(min = 1, max = 35) 
-  @Schema(name = "Code", description = "Proprietary bank transaction code to identify the underlying transaction.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Code")
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public ProprietaryBankTransactionCodeStructure1 issuer(String issuer) {
-    this.issuer = issuer;
-    return this;
-  }
-
-  /**
-   * Identification of the issuer of the proprietary bank transaction code.
-   * @return issuer
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Issuer", description = "Identification of the issuer of the proprietary bank transaction code.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Issuer")
-  public String getIssuer() {
-    return issuer;
-  }
-
-  public void setIssuer(String issuer) {
-    this.issuer = issuer;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    public ProprietaryBankTransactionCodeStructure1() {
+        super();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    /**
+     * Constructor with only required parameters
+     */
+    public ProprietaryBankTransactionCodeStructure1(String code) {
+        this.code = code;
     }
-    ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCodeStructure1 = (ProprietaryBankTransactionCodeStructure1) o;
-    return Objects.equals(this.code, proprietaryBankTransactionCodeStructure1.code) &&
-        Objects.equals(this.issuer, proprietaryBankTransactionCodeStructure1.issuer);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(code, issuer);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class ProprietaryBankTransactionCodeStructure1 {\n");
-    sb.append("    code: ").append(toIndentedString(code)).append("\n");
-    sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
+    public ProprietaryBankTransactionCodeStructure1 code(String code) {
+        this.code = code;
+        return this;
     }
-    return o.toString().replace("\n", "\n    ");
-  }
+
+    /**
+     * Proprietary bank transaction code to identify the underlying transaction.
+     *
+     * @return code
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "Code", description = "Proprietary bank transaction code to identify the underlying transaction.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public ProprietaryBankTransactionCodeStructure1 issuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+
+    /**
+     * Identification of the issuer of the proprietary bank transaction code.
+     *
+     * @return issuer
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Issuer", description = "Identification of the issuer of the proprietary bank transaction code.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Issuer")
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ProprietaryBankTransactionCodeStructure1 proprietaryBankTransactionCodeStructure1 = (ProprietaryBankTransactionCodeStructure1) o;
+        return Objects.equals(this.code, proprietaryBankTransactionCodeStructure1.code) &&
+                Objects.equals(this.issuer, proprietaryBankTransactionCodeStructure1.issuer);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, issuer);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ProprietaryBankTransactionCodeStructure1 {\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    issuer: ").append(toIndentedString(issuer)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/SegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/SegmentInner.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to BCA products, they are segmented in relation to different markets that they wish to focus on.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum SegmentInner {
+
+    CLIENTACCOUNT("ClientAccount"),
+
+    STANDARD("Standard"),
+
+    NONCOMMERCIALCHAITIESCLBSOC("NonCommercialChaitiesClbSoc"),
+
+    NONCOMMERCIALPUBLICAUTHGOVT("NonCommercialPublicAuthGovt"),
+
+    RELIGIOUS("Religious"),
+
+    SECTORSPECIFIC("SectorSpecific"),
+
+    STARTUP("Startup"),
+
+    SWITCHER("Switcher");
+
+    private String value;
+
+    SegmentInner(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static SegmentInner fromValue(String value) {
+        for (SegmentInner b : SegmentInner.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/SegmentInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/SegmentInner1.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.  Read more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd  With respect to PCA products, they are segmented in relation to different markets that they wish to focus on.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum SegmentInner1 {
+
+    BASIC("Basic"),
+
+    BENEFITANDREWARD("BenefitAndReward"),
+
+    CREDITINTEREST("CreditInterest"),
+
+    CASHBACK("Cashback"),
+
+    GENERAL("General"),
+
+    GRADUATE("Graduate"),
+
+    OTHER("Other"),
+
+    OVERDRAFT("Overdraft"),
+
+    PACKAGED("Packaged"),
+
+    PREMIUM("Premium"),
+
+    REWARD("Reward"),
+
+    STUDENT("Student"),
+
+    YOUNGADULT("YoungAdult"),
+
+    YOUTH("Youth");
+
+    private String value;
+
+    SegmentInner1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static SegmentInner1 fromValue(String value) {
+        for (SegmentInner1 b : SegmentInner1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TariffType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * TariffType which defines the fee and charges.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum TariffType {
+
+    ELECTRONIC("Electronic"),
+
+    MIXED("Mixed"),
+
+    OTHER("Other");
+
+    private String value;
+
+    TariffType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static TariffType fromValue(String value) {
+        for (TariffType b : TariffType.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandInner.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -40,599 +38,416 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class TierBandInner {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMinimum;
+    private String tierValueMinimum;
 
-  private String tierValueMaximum;
+    private String tierValueMaximum;
 
-  /**
-   * How often is credit interest calculated for the account.
-   */
-  public enum CalculationFrequencyEnum {
-    DAILY("Daily"),
-    
-    HALFYEARLY("HalfYearly"),
-    
-    MONTHLY("Monthly"),
-    
-    OTHER("Other"),
-    
-    QUARTERLY("Quarterly"),
-    
-    PERSTATEMENTDATE("PerStatementDate"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
+    private CalculationFrequency calculationFrequency;
 
-    private String value;
+    private ApplicationFrequency applicationFrequency;
 
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
+    private DepositInterestAppliedCoverage depositInterestAppliedCoverage;
+
+    private FixedVariableInterestRateType fixedVariableInterestRateType;
+
+    private String AER;
+
+    private BankInterestRateType bankInterestRateType;
+
+    private String bankInterestRate;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OtherBankInterestType otherBankInterestType;
+
+    private OtherApplicationFrequency otherApplicationFrequency;
+
+    private OtherCalculationFrequency otherCalculationFrequency;
+
+    public TierBandInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public TierBandInner(String tierValueMinimum, ApplicationFrequency applicationFrequency, FixedVariableInterestRateType fixedVariableInterestRateType, String AER) {
+        this.tierValueMinimum = tierValueMinimum;
+        this.applicationFrequency = applicationFrequency;
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        this.AER = AER;
+    }
+
+    public TierBandInner identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a BCA.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a BCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public TierBandInner tierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+        return this;
+    }
+
+    /**
+     * Minimum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMinimum
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMinimum")
+    public String getTierValueMinimum() {
+        return tierValueMinimum;
+    }
+
+    public void setTierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+    }
+
+    public TierBandInner tierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+        return this;
+    }
+
+    /**
+     * Maximum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMaximum
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMaximum")
+    public String getTierValueMaximum() {
+        return tierValueMaximum;
+    }
+
+    public void setTierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+    }
+
+    public TierBandInner calculationFrequency(CalculationFrequency calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public TierBandInner applicationFrequency(ApplicationFrequency applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public TierBandInner depositInterestAppliedCoverage(DepositInterestAppliedCoverage depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+        return this;
+    }
+
+    /**
+     * Get depositInterestAppliedCoverage
+     *
+     * @return depositInterestAppliedCoverage
+     */
+    @Valid
+    @Schema(name = "DepositInterestAppliedCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DepositInterestAppliedCoverage")
+    public DepositInterestAppliedCoverage getDepositInterestAppliedCoverage() {
+        return depositInterestAppliedCoverage;
+    }
+
+    public void setDepositInterestAppliedCoverage(DepositInterestAppliedCoverage depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+    }
+
+    public TierBandInner fixedVariableInterestRateType(FixedVariableInterestRateType fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get fixedVariableInterestRateType
+     *
+     * @return fixedVariableInterestRateType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FixedVariableInterestRateType")
+    public FixedVariableInterestRateType getFixedVariableInterestRateType() {
+        return fixedVariableInterestRateType;
+    }
+
+    public void setFixedVariableInterestRateType(FixedVariableInterestRateType fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+    }
+
+    public TierBandInner AER(String AER) {
+        this.AER = AER;
+        return this;
+    }
+
+    /**
+     * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
+     *
+     * @return AER
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AER")
+    public String getAER() {
+        return AER;
+    }
+
+    public void setAER(String AER) {
+        this.AER = AER;
+    }
+
+    public TierBandInner bankInterestRateType(BankInterestRateType bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get bankInterestRateType
+     *
+     * @return bankInterestRateType
+     */
+    @Valid
+    @Schema(name = "BankInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRateType")
+    public BankInterestRateType getBankInterestRateType() {
+        return bankInterestRateType;
+    }
+
+    public void setBankInterestRateType(BankInterestRateType bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+    }
+
+    public TierBandInner bankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+        return this;
+    }
+
+    /**
+     * Bank Interest for the BCA product
+     *
+     * @return bankInterestRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BankInterestRate", description = "Bank Interest for the BCA product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRate")
+    public String getBankInterestRate() {
+        return bankInterestRate;
+    }
+
+    public void setBankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+    }
+
+    public TierBandInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public TierBandInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier Band details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public TierBandInner otherBankInterestType(OtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+        return this;
+    }
+
+    /**
+     * Get otherBankInterestType
+     *
+     * @return otherBankInterestType
+     */
+    @Valid
+    @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherBankInterestType")
+    public OtherBankInterestType getOtherBankInterestType() {
+        return otherBankInterestType;
+    }
+
+    public void setOtherBankInterestType(OtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+    }
+
+    public TierBandInner otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public TierBandInner otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TierBandInner tierBandInner = (TierBandInner) o;
+        return Objects.equals(this.identification, tierBandInner.identification) &&
+                Objects.equals(this.tierValueMinimum, tierBandInner.tierValueMinimum) &&
+                Objects.equals(this.tierValueMaximum, tierBandInner.tierValueMaximum) &&
+                Objects.equals(this.calculationFrequency, tierBandInner.calculationFrequency) &&
+                Objects.equals(this.applicationFrequency, tierBandInner.applicationFrequency) &&
+                Objects.equals(this.depositInterestAppliedCoverage, tierBandInner.depositInterestAppliedCoverage) &&
+                Objects.equals(this.fixedVariableInterestRateType, tierBandInner.fixedVariableInterestRateType) &&
+                Objects.equals(this.AER, tierBandInner.AER) &&
+                Objects.equals(this.bankInterestRateType, tierBandInner.bankInterestRateType) &&
+                Objects.equals(this.bankInterestRate, tierBandInner.bankInterestRate) &&
+                Objects.equals(this.notes, tierBandInner.notes) &&
+                Objects.equals(this.otherBankInterestType, tierBandInner.otherBankInterestType) &&
+                Objects.equals(this.otherApplicationFrequency, tierBandInner.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, tierBandInner.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TierBandInner {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
+        sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
+        sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
+        sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
+        sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
+        sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  /**
-   * How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.
-   */
-  public enum ApplicationFrequencyEnum {
-    DAILY("Daily"),
-    
-    HALFYEARLY("HalfYearly"),
-    
-    MONTHLY("Monthly"),
-    
-    OTHER("Other"),
-    
-    QUARTERLY("Quarterly"),
-    
-    PERSTATEMENTDATE("PerStatementDate"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * Amount on which Interest applied.
-   */
-  public enum DepositInterestAppliedCoverageEnum {
-    BANDED("Banded"),
-    
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
-
-    private String value;
-
-    DepositInterestAppliedCoverageEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DepositInterestAppliedCoverageEnum fromValue(String value) {
-      for (DepositInterestAppliedCoverageEnum b : DepositInterestAppliedCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage;
-
-  /**
-   * Type of interest rate, Fixed or Variable
-   */
-  public enum FixedVariableInterestRateTypeEnum {
-    FIXED("Fixed"),
-    
-    VARIABLE("Variable");
-
-    private String value;
-
-    FixedVariableInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FixedVariableInterestRateTypeEnum fromValue(String value) {
-      for (FixedVariableInterestRateTypeEnum b : FixedVariableInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FixedVariableInterestRateTypeEnum fixedVariableInterestRateType;
-
-  private String AER;
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.
-   */
-  public enum BankInterestRateTypeEnum {
-    GROSS("Gross"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    BankInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static BankInterestRateTypeEnum fromValue(String value) {
-      for (BankInterestRateTypeEnum b : BankInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private BankInterestRateTypeEnum bankInterestRateType;
-
-  private String bankInterestRate;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OtherBankInterestType otherBankInterestType;
-
-  private OtherApplicationFrequency otherApplicationFrequency;
-
-  private OtherCalculationFrequency otherCalculationFrequency;
-
-  public TierBandInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public TierBandInner(String tierValueMinimum, ApplicationFrequencyEnum applicationFrequency, FixedVariableInterestRateTypeEnum fixedVariableInterestRateType, String AER) {
-    this.tierValueMinimum = tierValueMinimum;
-    this.applicationFrequency = applicationFrequency;
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    this.AER = AER;
-  }
-
-  public TierBandInner identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a BCA.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a BCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public TierBandInner tierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-    return this;
-  }
-
-  /**
-   * Minimum deposit value for which the credit interest tier applies.
-   * @return tierValueMinimum
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMinimum")
-  public String getTierValueMinimum() {
-    return tierValueMinimum;
-  }
-
-  public void setTierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-  }
-
-  public TierBandInner tierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-    return this;
-  }
-
-  /**
-   * Maximum deposit value for which the credit interest tier applies.
-   * @return tierValueMaximum
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMaximum")
-  public String getTierValueMaximum() {
-    return tierValueMaximum;
-  }
-
-  public void setTierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-  }
-
-  public TierBandInner calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is credit interest calculated for the account.
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How often is credit interest calculated for the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public TierBandInner applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public TierBandInner depositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-    return this;
-  }
-
-  /**
-   * Amount on which Interest applied.
-   * @return depositInterestAppliedCoverage
-  */
-  
-  @Schema(name = "DepositInterestAppliedCoverage", description = "Amount on which Interest applied.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DepositInterestAppliedCoverage")
-  public DepositInterestAppliedCoverageEnum getDepositInterestAppliedCoverage() {
-    return depositInterestAppliedCoverage;
-  }
-
-  public void setDepositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-  }
-
-  public TierBandInner fixedVariableInterestRateType(FixedVariableInterestRateTypeEnum fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    return this;
-  }
-
-  /**
-   * Type of interest rate, Fixed or Variable
-   * @return fixedVariableInterestRateType
-  */
-  @NotNull 
-  @Schema(name = "FixedVariableInterestRateType", description = "Type of interest rate, Fixed or Variable", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FixedVariableInterestRateType")
-  public FixedVariableInterestRateTypeEnum getFixedVariableInterestRateType() {
-    return fixedVariableInterestRateType;
-  }
-
-  public void setFixedVariableInterestRateType(FixedVariableInterestRateTypeEnum fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-  }
-
-  public TierBandInner AER(String AER) {
-    this.AER = AER;
-    return this;
-  }
-
-  /**
-   * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
-   * @return AER
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AER")
-  public String getAER() {
-    return AER;
-  }
-
-  public void setAER(String AER) {
-    this.AER = AER;
-  }
-
-  public TierBandInner bankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-    return this;
-  }
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.
-   * @return bankInterestRateType
-  */
-  
-  @Schema(name = "BankInterestRateType", description = "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRateType")
-  public BankInterestRateTypeEnum getBankInterestRateType() {
-    return bankInterestRateType;
-  }
-
-  public void setBankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-  }
-
-  public TierBandInner bankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-    return this;
-  }
-
-  /**
-   * Bank Interest for the BCA product
-   * @return bankInterestRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BankInterestRate", description = "Bank Interest for the BCA product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRate")
-  public String getBankInterestRate() {
-    return bankInterestRate;
-  }
-
-  public void setBankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-  }
-
-  public TierBandInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public TierBandInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier Band details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public TierBandInner otherBankInterestType(OtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-    return this;
-  }
-
-  /**
-   * Get otherBankInterestType
-   * @return otherBankInterestType
-  */
-  @Valid 
-  @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherBankInterestType")
-  public OtherBankInterestType getOtherBankInterestType() {
-    return otherBankInterestType;
-  }
-
-  public void setOtherBankInterestType(OtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-  }
-
-  public TierBandInner otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public TierBandInner otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TierBandInner tierBandInner = (TierBandInner) o;
-    return Objects.equals(this.identification, tierBandInner.identification) &&
-        Objects.equals(this.tierValueMinimum, tierBandInner.tierValueMinimum) &&
-        Objects.equals(this.tierValueMaximum, tierBandInner.tierValueMaximum) &&
-        Objects.equals(this.calculationFrequency, tierBandInner.calculationFrequency) &&
-        Objects.equals(this.applicationFrequency, tierBandInner.applicationFrequency) &&
-        Objects.equals(this.depositInterestAppliedCoverage, tierBandInner.depositInterestAppliedCoverage) &&
-        Objects.equals(this.fixedVariableInterestRateType, tierBandInner.fixedVariableInterestRateType) &&
-        Objects.equals(this.AER, tierBandInner.AER) &&
-        Objects.equals(this.bankInterestRateType, tierBandInner.bankInterestRateType) &&
-        Objects.equals(this.bankInterestRate, tierBandInner.bankInterestRate) &&
-        Objects.equals(this.notes, tierBandInner.notes) &&
-        Objects.equals(this.otherBankInterestType, tierBandInner.otherBankInterestType) &&
-        Objects.equals(this.otherApplicationFrequency, tierBandInner.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, tierBandInner.otherCalculationFrequency);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class TierBandInner {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
-    sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
-    sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
-    sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
-    sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
-    sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandInner1.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -40,605 +38,416 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class TierBandInner1 {
 
-  private String identification;
+    private String identification;
 
-  private String tierValueMinimum;
+    private String tierValueMinimum;
 
-  private String tierValueMaximum;
+    private String tierValueMaximum;
 
-  /**
-   * How often is credit interest calculated for the account.
-   */
-  public enum CalculationFrequencyEnum {
-    PERACADEMICTERM("PerAcademicTerm"),
-    
-    DAILY("Daily"),
-    
-    HALFYEARLY("HalfYearly"),
-    
-    MONTHLY("Monthly"),
-    
-    OTHER("Other"),
-    
-    QUARTERLY("Quarterly"),
-    
-    PERSTATEMENTDATE("PerStatementDate"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
+    private CalculationFrequency3 calculationFrequency;
 
-    private String value;
+    private ApplicationFrequency3 applicationFrequency;
 
-    CalculationFrequencyEnum(String value) {
-      this.value = value;
+    private DepositInterestAppliedCoverage1 depositInterestAppliedCoverage;
+
+    private FixedVariableInterestRateType fixedVariableInterestRateType;
+
+    private String AER;
+
+    private BankInterestRateType1 bankInterestRateType;
+
+    private String bankInterestRate;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    private OtherBankInterestType otherBankInterestType;
+
+    private OtherApplicationFrequency otherApplicationFrequency;
+
+    private OtherCalculationFrequency otherCalculationFrequency;
+
+    public TierBandInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public TierBandInner1(String tierValueMinimum, ApplicationFrequency3 applicationFrequency, FixedVariableInterestRateType fixedVariableInterestRateType, String AER) {
+        this.tierValueMinimum = tierValueMinimum;
+        this.applicationFrequency = applicationFrequency;
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        this.AER = AER;
+    }
+
+    public TierBandInner1 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Unique and unambiguous identification of a  Tier Band for a PCA.
+     *
+     * @return identification
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a PCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public TierBandInner1 tierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+        return this;
+    }
+
+    /**
+     * Minimum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMinimum
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierValueMinimum")
+    public String getTierValueMinimum() {
+        return tierValueMinimum;
+    }
+
+    public void setTierValueMinimum(String tierValueMinimum) {
+        this.tierValueMinimum = tierValueMinimum;
+    }
+
+    public TierBandInner1 tierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+        return this;
+    }
+
+    /**
+     * Maximum deposit value for which the credit interest tier applies.
+     *
+     * @return tierValueMaximum
+     */
+    @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TierValueMaximum")
+    public String getTierValueMaximum() {
+        return tierValueMaximum;
+    }
+
+    public void setTierValueMaximum(String tierValueMaximum) {
+        this.tierValueMaximum = tierValueMaximum;
+    }
+
+    public TierBandInner1 calculationFrequency(CalculationFrequency3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get calculationFrequency
+     *
+     * @return calculationFrequency
+     */
+    @Valid
+    @Schema(name = "CalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationFrequency")
+    public CalculationFrequency3 getCalculationFrequency() {
+        return calculationFrequency;
+    }
+
+    public void setCalculationFrequency(CalculationFrequency3 calculationFrequency) {
+        this.calculationFrequency = calculationFrequency;
+    }
+
+    public TierBandInner1 applicationFrequency(ApplicationFrequency3 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get applicationFrequency
+     *
+     * @return applicationFrequency
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "ApplicationFrequency", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ApplicationFrequency")
+    public ApplicationFrequency3 getApplicationFrequency() {
+        return applicationFrequency;
+    }
+
+    public void setApplicationFrequency(ApplicationFrequency3 applicationFrequency) {
+        this.applicationFrequency = applicationFrequency;
+    }
+
+    public TierBandInner1 depositInterestAppliedCoverage(DepositInterestAppliedCoverage1 depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+        return this;
+    }
+
+    /**
+     * Get depositInterestAppliedCoverage
+     *
+     * @return depositInterestAppliedCoverage
+     */
+    @Valid
+    @Schema(name = "DepositInterestAppliedCoverage", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DepositInterestAppliedCoverage")
+    public DepositInterestAppliedCoverage1 getDepositInterestAppliedCoverage() {
+        return depositInterestAppliedCoverage;
+    }
+
+    public void setDepositInterestAppliedCoverage(DepositInterestAppliedCoverage1 depositInterestAppliedCoverage) {
+        this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
+    }
+
+    public TierBandInner1 fixedVariableInterestRateType(FixedVariableInterestRateType fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get fixedVariableInterestRateType
+     *
+     * @return fixedVariableInterestRateType
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "FixedVariableInterestRateType", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FixedVariableInterestRateType")
+    public FixedVariableInterestRateType getFixedVariableInterestRateType() {
+        return fixedVariableInterestRateType;
+    }
+
+    public void setFixedVariableInterestRateType(FixedVariableInterestRateType fixedVariableInterestRateType) {
+        this.fixedVariableInterestRateType = fixedVariableInterestRateType;
+    }
+
+    public TierBandInner1 AER(String AER) {
+        this.AER = AER;
+        return this;
+    }
+
+    /**
+     * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
+     *
+     * @return AER
+     */
+    @NotNull
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("AER")
+    public String getAER() {
+        return AER;
+    }
+
+    public void setAER(String AER) {
+        this.AER = AER;
+    }
+
+    public TierBandInner1 bankInterestRateType(BankInterestRateType1 bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+        return this;
+    }
+
+    /**
+     * Get bankInterestRateType
+     *
+     * @return bankInterestRateType
+     */
+    @Valid
+    @Schema(name = "BankInterestRateType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRateType")
+    public BankInterestRateType1 getBankInterestRateType() {
+        return bankInterestRateType;
+    }
+
+    public void setBankInterestRateType(BankInterestRateType1 bankInterestRateType) {
+        this.bankInterestRateType = bankInterestRateType;
+    }
+
+    public TierBandInner1 bankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+        return this;
+    }
+
+    /**
+     * Bank Interest for the PCA product
+     *
+     * @return bankInterestRate
+     */
+    @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$")
+    @Schema(name = "BankInterestRate", description = "Bank Interest for the PCA product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BankInterestRate")
+    public String getBankInterestRate() {
+        return bankInterestRate;
+    }
+
+    public void setBankInterestRate(String bankInterestRate) {
+        this.bankInterestRate = bankInterestRate;
+    }
+
+    public TierBandInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public TierBandInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier Band details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public TierBandInner1 otherBankInterestType(OtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+        return this;
+    }
+
+    /**
+     * Get otherBankInterestType
+     *
+     * @return otherBankInterestType
+     */
+    @Valid
+    @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherBankInterestType")
+    public OtherBankInterestType getOtherBankInterestType() {
+        return otherBankInterestType;
+    }
+
+    public void setOtherBankInterestType(OtherBankInterestType otherBankInterestType) {
+        this.otherBankInterestType = otherBankInterestType;
+    }
+
+    public TierBandInner1 otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherApplicationFrequency
+     *
+     * @return otherApplicationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherApplicationFrequency")
+    public OtherApplicationFrequency getOtherApplicationFrequency() {
+        return otherApplicationFrequency;
+    }
+
+    public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
+        this.otherApplicationFrequency = otherApplicationFrequency;
+    }
+
+    public TierBandInner1 otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+        return this;
+    }
+
+    /**
+     * Get otherCalculationFrequency
+     *
+     * @return otherCalculationFrequency
+     */
+    @Valid
+    @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("OtherCalculationFrequency")
+    public OtherCalculationFrequency getOtherCalculationFrequency() {
+        return otherCalculationFrequency;
+    }
+
+    public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
+        this.otherCalculationFrequency = otherCalculationFrequency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TierBandInner1 tierBandInner1 = (TierBandInner1) o;
+        return Objects.equals(this.identification, tierBandInner1.identification) &&
+                Objects.equals(this.tierValueMinimum, tierBandInner1.tierValueMinimum) &&
+                Objects.equals(this.tierValueMaximum, tierBandInner1.tierValueMaximum) &&
+                Objects.equals(this.calculationFrequency, tierBandInner1.calculationFrequency) &&
+                Objects.equals(this.applicationFrequency, tierBandInner1.applicationFrequency) &&
+                Objects.equals(this.depositInterestAppliedCoverage, tierBandInner1.depositInterestAppliedCoverage) &&
+                Objects.equals(this.fixedVariableInterestRateType, tierBandInner1.fixedVariableInterestRateType) &&
+                Objects.equals(this.AER, tierBandInner1.AER) &&
+                Objects.equals(this.bankInterestRateType, tierBandInner1.bankInterestRateType) &&
+                Objects.equals(this.bankInterestRate, tierBandInner1.bankInterestRate) &&
+                Objects.equals(this.notes, tierBandInner1.notes) &&
+                Objects.equals(this.otherBankInterestType, tierBandInner1.otherBankInterestType) &&
+                Objects.equals(this.otherApplicationFrequency, tierBandInner1.otherApplicationFrequency) &&
+                Objects.equals(this.otherCalculationFrequency, tierBandInner1.otherCalculationFrequency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TierBandInner1 {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
+        sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
+        sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
+        sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
+        sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
+        sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
+        sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
+        sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
+        sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
+        sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
+        sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static CalculationFrequencyEnum fromValue(String value) {
-      for (CalculationFrequencyEnum b : CalculationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private CalculationFrequencyEnum calculationFrequency;
-
-  /**
-   * How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.
-   */
-  public enum ApplicationFrequencyEnum {
-    PERACADEMICTERM("PerAcademicTerm"),
-    
-    DAILY("Daily"),
-    
-    HALFYEARLY("HalfYearly"),
-    
-    MONTHLY("Monthly"),
-    
-    OTHER("Other"),
-    
-    QUARTERLY("Quarterly"),
-    
-    PERSTATEMENTDATE("PerStatementDate"),
-    
-    WEEKLY("Weekly"),
-    
-    YEARLY("Yearly");
-
-    private String value;
-
-    ApplicationFrequencyEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static ApplicationFrequencyEnum fromValue(String value) {
-      for (ApplicationFrequencyEnum b : ApplicationFrequencyEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private ApplicationFrequencyEnum applicationFrequency;
-
-  /**
-   * Amount on which Interest applied.
-   */
-  public enum DepositInterestAppliedCoverageEnum {
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
-
-    private String value;
-
-    DepositInterestAppliedCoverageEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DepositInterestAppliedCoverageEnum fromValue(String value) {
-      for (DepositInterestAppliedCoverageEnum b : DepositInterestAppliedCoverageEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage;
-
-  /**
-   * Type of interest rate, Fixed or Variable
-   */
-  public enum FixedVariableInterestRateTypeEnum {
-    FIXED("Fixed"),
-    
-    VARIABLE("Variable");
-
-    private String value;
-
-    FixedVariableInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static FixedVariableInterestRateTypeEnum fromValue(String value) {
-      for (FixedVariableInterestRateTypeEnum b : FixedVariableInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private FixedVariableInterestRateTypeEnum fixedVariableInterestRateType;
-
-  private String AER;
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.
-   */
-  public enum BankInterestRateTypeEnum {
-    LINKEDBASERATE("LinkedBaseRate"),
-    
-    GROSS("Gross"),
-    
-    NET("Net"),
-    
-    OTHER("Other");
-
-    private String value;
-
-    BankInterestRateTypeEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static BankInterestRateTypeEnum fromValue(String value) {
-      for (BankInterestRateTypeEnum b : BankInterestRateTypeEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private BankInterestRateTypeEnum bankInterestRateType;
-
-  private String bankInterestRate;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  private OtherBankInterestType otherBankInterestType;
-
-  private OtherApplicationFrequency otherApplicationFrequency;
-
-  private OtherCalculationFrequency otherCalculationFrequency;
-
-  public TierBandInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public TierBandInner1(String tierValueMinimum, ApplicationFrequencyEnum applicationFrequency, FixedVariableInterestRateTypeEnum fixedVariableInterestRateType, String AER) {
-    this.tierValueMinimum = tierValueMinimum;
-    this.applicationFrequency = applicationFrequency;
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    this.AER = AER;
-  }
-
-  public TierBandInner1 identification(String identification) {
-    this.identification = identification;
-    return this;
-  }
-
-  /**
-   * Unique and unambiguous identification of a  Tier Band for a PCA.
-   * @return identification
-  */
-  @Size(min = 1, max = 35) 
-  @Schema(name = "Identification", description = "Unique and unambiguous identification of a  Tier Band for a PCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Identification")
-  public String getIdentification() {
-    return identification;
-  }
-
-  public void setIdentification(String identification) {
-    this.identification = identification;
-  }
-
-  public TierBandInner1 tierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-    return this;
-  }
-
-  /**
-   * Minimum deposit value for which the credit interest tier applies.
-   * @return tierValueMinimum
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMinimum", description = "Minimum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierValueMinimum")
-  public String getTierValueMinimum() {
-    return tierValueMinimum;
-  }
-
-  public void setTierValueMinimum(String tierValueMinimum) {
-    this.tierValueMinimum = tierValueMinimum;
-  }
-
-  public TierBandInner1 tierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-    return this;
-  }
-
-  /**
-   * Maximum deposit value for which the credit interest tier applies.
-   * @return tierValueMaximum
-  */
-  @Pattern(regexp = "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "TierValueMaximum", description = "Maximum deposit value for which the credit interest tier applies.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("TierValueMaximum")
-  public String getTierValueMaximum() {
-    return tierValueMaximum;
-  }
-
-  public void setTierValueMaximum(String tierValueMaximum) {
-    this.tierValueMaximum = tierValueMaximum;
-  }
-
-  public TierBandInner1 calculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is credit interest calculated for the account.
-   * @return calculationFrequency
-  */
-  
-  @Schema(name = "CalculationFrequency", description = "How often is credit interest calculated for the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationFrequency")
-  public CalculationFrequencyEnum getCalculationFrequency() {
-    return calculationFrequency;
-  }
-
-  public void setCalculationFrequency(CalculationFrequencyEnum calculationFrequency) {
-    this.calculationFrequency = calculationFrequency;
-  }
-
-  public TierBandInner1 applicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-    return this;
-  }
-
-  /**
-   * How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.
-   * @return applicationFrequency
-  */
-  @NotNull 
-  @Schema(name = "ApplicationFrequency", description = "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA.", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("ApplicationFrequency")
-  public ApplicationFrequencyEnum getApplicationFrequency() {
-    return applicationFrequency;
-  }
-
-  public void setApplicationFrequency(ApplicationFrequencyEnum applicationFrequency) {
-    this.applicationFrequency = applicationFrequency;
-  }
-
-  public TierBandInner1 depositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-    return this;
-  }
-
-  /**
-   * Amount on which Interest applied.
-   * @return depositInterestAppliedCoverage
-  */
-  
-  @Schema(name = "DepositInterestAppliedCoverage", description = "Amount on which Interest applied.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("DepositInterestAppliedCoverage")
-  public DepositInterestAppliedCoverageEnum getDepositInterestAppliedCoverage() {
-    return depositInterestAppliedCoverage;
-  }
-
-  public void setDepositInterestAppliedCoverage(DepositInterestAppliedCoverageEnum depositInterestAppliedCoverage) {
-    this.depositInterestAppliedCoverage = depositInterestAppliedCoverage;
-  }
-
-  public TierBandInner1 fixedVariableInterestRateType(FixedVariableInterestRateTypeEnum fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-    return this;
-  }
-
-  /**
-   * Type of interest rate, Fixed or Variable
-   * @return fixedVariableInterestRateType
-  */
-  @NotNull 
-  @Schema(name = "FixedVariableInterestRateType", description = "Type of interest rate, Fixed or Variable", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("FixedVariableInterestRateType")
-  public FixedVariableInterestRateTypeEnum getFixedVariableInterestRateType() {
-    return fixedVariableInterestRateType;
-  }
-
-  public void setFixedVariableInterestRateType(FixedVariableInterestRateTypeEnum fixedVariableInterestRateType) {
-    this.fixedVariableInterestRateType = fixedVariableInterestRateType;
-  }
-
-  public TierBandInner1 AER(String AER) {
-    this.AER = AER;
-    return this;
-  }
-
-  /**
-   * The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A
-   * @return AER
-  */
-  @NotNull @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "AER", description = "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made.   Read more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("AER")
-  public String getAER() {
-    return AER;
-  }
-
-  public void setAER(String AER) {
-    this.AER = AER;
-  }
-
-  public TierBandInner1 bankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-    return this;
-  }
-
-  /**
-   * Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.
-   * @return bankInterestRateType
-  */
-  
-  @Schema(name = "BankInterestRateType", description = "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRateType")
-  public BankInterestRateTypeEnum getBankInterestRateType() {
-    return bankInterestRateType;
-  }
-
-  public void setBankInterestRateType(BankInterestRateTypeEnum bankInterestRateType) {
-    this.bankInterestRateType = bankInterestRateType;
-  }
-
-  public TierBandInner1 bankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-    return this;
-  }
-
-  /**
-   * Bank Interest for the PCA product
-   * @return bankInterestRate
-  */
-  @Pattern(regexp = "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  @Schema(name = "BankInterestRate", description = "Bank Interest for the PCA product", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("BankInterestRate")
-  public String getBankInterestRate() {
-    return bankInterestRate;
-  }
-
-  public void setBankInterestRate(String bankInterestRate) {
-    this.bankInterestRate = bankInterestRate;
-  }
-
-  public TierBandInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public TierBandInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier Band details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public TierBandInner1 otherBankInterestType(OtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-    return this;
-  }
-
-  /**
-   * Get otherBankInterestType
-   * @return otherBankInterestType
-  */
-  @Valid 
-  @Schema(name = "OtherBankInterestType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherBankInterestType")
-  public OtherBankInterestType getOtherBankInterestType() {
-    return otherBankInterestType;
-  }
-
-  public void setOtherBankInterestType(OtherBankInterestType otherBankInterestType) {
-    this.otherBankInterestType = otherBankInterestType;
-  }
-
-  public TierBandInner1 otherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherApplicationFrequency
-   * @return otherApplicationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherApplicationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherApplicationFrequency")
-  public OtherApplicationFrequency getOtherApplicationFrequency() {
-    return otherApplicationFrequency;
-  }
-
-  public void setOtherApplicationFrequency(OtherApplicationFrequency otherApplicationFrequency) {
-    this.otherApplicationFrequency = otherApplicationFrequency;
-  }
-
-  public TierBandInner1 otherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-    return this;
-  }
-
-  /**
-   * Get otherCalculationFrequency
-   * @return otherCalculationFrequency
-  */
-  @Valid 
-  @Schema(name = "OtherCalculationFrequency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("OtherCalculationFrequency")
-  public OtherCalculationFrequency getOtherCalculationFrequency() {
-    return otherCalculationFrequency;
-  }
-
-  public void setOtherCalculationFrequency(OtherCalculationFrequency otherCalculationFrequency) {
-    this.otherCalculationFrequency = otherCalculationFrequency;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TierBandInner1 tierBandInner1 = (TierBandInner1) o;
-    return Objects.equals(this.identification, tierBandInner1.identification) &&
-        Objects.equals(this.tierValueMinimum, tierBandInner1.tierValueMinimum) &&
-        Objects.equals(this.tierValueMaximum, tierBandInner1.tierValueMaximum) &&
-        Objects.equals(this.calculationFrequency, tierBandInner1.calculationFrequency) &&
-        Objects.equals(this.applicationFrequency, tierBandInner1.applicationFrequency) &&
-        Objects.equals(this.depositInterestAppliedCoverage, tierBandInner1.depositInterestAppliedCoverage) &&
-        Objects.equals(this.fixedVariableInterestRateType, tierBandInner1.fixedVariableInterestRateType) &&
-        Objects.equals(this.AER, tierBandInner1.AER) &&
-        Objects.equals(this.bankInterestRateType, tierBandInner1.bankInterestRateType) &&
-        Objects.equals(this.bankInterestRate, tierBandInner1.bankInterestRate) &&
-        Objects.equals(this.notes, tierBandInner1.notes) &&
-        Objects.equals(this.otherBankInterestType, tierBandInner1.otherBankInterestType) &&
-        Objects.equals(this.otherApplicationFrequency, tierBandInner1.otherApplicationFrequency) &&
-        Objects.equals(this.otherCalculationFrequency, tierBandInner1.otherCalculationFrequency);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class TierBandInner1 {\n");
-    sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
-    sb.append("    tierValueMinimum: ").append(toIndentedString(tierValueMinimum)).append("\n");
-    sb.append("    tierValueMaximum: ").append(toIndentedString(tierValueMaximum)).append("\n");
-    sb.append("    calculationFrequency: ").append(toIndentedString(calculationFrequency)).append("\n");
-    sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
-    sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
-    sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
-    sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
-    sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
-    sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    otherBankInterestType: ").append(toIndentedString(otherBankInterestType)).append("\n");
-    sb.append("    otherApplicationFrequency: ").append(toIndentedString(otherApplicationFrequency)).append("\n");
-    sb.append("    otherCalculationFrequency: ").append(toIndentedString(otherCalculationFrequency)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum TierBandMethod {
+
+    BANDED("Banded"),
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    TierBandMethod(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static TierBandMethod fromValue(String value) {
+        for (TierBandMethod b : TierBandMethod.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod1.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum TierBandMethod1 {
+
+    BANDED("Banded"),
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    TierBandMethod1(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static TierBandMethod1 fromValue(String value) {
+        for (TierBandMethod1 b : TierBandMethod1.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod2.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum TierBandMethod2 {
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole");
+
+    private String value;
+
+    TierBandMethod2(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static TierBandMethod2 fromValue(String value) {
+        for (TierBandMethod2 b : TierBandMethod2.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandMethod3.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * The methodology of how overdraft is charged. It can be: 'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable).  'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation 'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum TierBandMethod3 {
+
+    TIERED("Tiered"),
+
+    WHOLE("Whole"),
+
+    BANDED("Banded");
+
+    private String value;
+
+    TierBandMethod3(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static TierBandMethod3 fromValue(String value) {
+        for (TierBandMethod3 b : TierBandMethod3.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandSetInner.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -39,297 +37,199 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class TierBandSetInner {
 
-  /**
-   * The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance
-   */
-  public enum TierBandMethodEnum {
-    BANDED("Banded"),
-    
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
+    private TierBandMethod tierBandMethod;
 
-    private String value;
+    private CalculationMethod calculationMethod;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private Destination destination;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid TierBandInner> tierBand = new ArrayList<>();
+
+    public TierBandSetInner() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public TierBandSetInner(TierBandMethod tierBandMethod, Destination destination, List<@Valid TierBandInner> tierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.destination = destination;
+        this.tierBand = tierBand;
+    }
+
+    public TierBandSetInner tierBandMethod(TierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public TierBandMethod getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(TierBandMethod tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public TierBandSetInner calculationMethod(CalculationMethod calculationMethod) {
+        this.calculationMethod = calculationMethod;
+        return this;
+    }
+
+    /**
+     * Get calculationMethod
+     *
+     * @return calculationMethod
+     */
+    @Valid
+    @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationMethod")
+    public CalculationMethod getCalculationMethod() {
+        return calculationMethod;
+    }
+
+    public void setCalculationMethod(CalculationMethod calculationMethod) {
+        this.calculationMethod = calculationMethod;
+    }
+
+    public TierBandSetInner destination(Destination destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    /**
+     * Get destination
+     *
+     * @return destination
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Destination", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Destination")
+    public Destination getDestination() {
+        return destination;
+    }
+
+    public void setDestination(Destination destination) {
+        this.destination = destination;
+    }
+
+    public TierBandSetInner notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public TierBandSetInner addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier Band Set details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public TierBandSetInner tierBand(List<@Valid TierBandInner> tierBand) {
+        this.tierBand = tierBand;
+        return this;
+    }
+
+    public TierBandSetInner addTierBandItem(TierBandInner tierBandItem) {
+        if (this.tierBand == null) {
+            this.tierBand = new ArrayList<>();
+        }
+        this.tierBand.add(tierBandItem);
+        return this;
+    }
+
+    /**
+     * Tier Band Details
+     *
+     * @return tierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBand", description = "Tier Band Details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBand")
+    public List<@Valid TierBandInner> getTierBand() {
+        return tierBand;
+    }
+
+    public void setTierBand(List<@Valid TierBandInner> tierBand) {
+        this.tierBand = tierBand;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TierBandSetInner tierBandSetInner = (TierBandSetInner) o;
+        return Objects.equals(this.tierBandMethod, tierBandSetInner.tierBandMethod) &&
+                Objects.equals(this.calculationMethod, tierBandSetInner.calculationMethod) &&
+                Objects.equals(this.destination, tierBandSetInner.destination) &&
+                Objects.equals(this.notes, tierBandSetInner.notes) &&
+                Objects.equals(this.tierBand, tierBandSetInner.tierBand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, calculationMethod, destination, notes, tierBand);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TierBandSetInner {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
+        sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  /**
-   * Methods of calculating interest
-   */
-  public enum CalculationMethodEnum {
-    COMPOUND("Compound"),
-    
-    SIMPLEINTEREST("SimpleInterest");
-
-    private String value;
-
-    CalculationMethodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationMethodEnum fromValue(String value) {
-      for (CalculationMethodEnum b : CalculationMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationMethodEnum calculationMethod;
-
-  /**
-   * Describes whether accrued interest is payable only to the BCA or to another bank account
-   */
-  public enum DestinationEnum {
-    PAYAWAY("PayAway"),
-    
-    SELFCREDIT("SelfCredit");
-
-    private String value;
-
-    DestinationEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DestinationEnum fromValue(String value) {
-      for (DestinationEnum b : DestinationEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DestinationEnum destination;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid TierBandInner> tierBand = new ArrayList<>();
-
-  public TierBandSetInner() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public TierBandSetInner(TierBandMethodEnum tierBandMethod, DestinationEnum destination, List<@Valid TierBandInner> tierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.destination = destination;
-    this.tierBand = tierBand;
-  }
-
-  public TierBandSetInner tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how credit interest is paid/applied. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the BCA balance", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public TierBandSetInner calculationMethod(CalculationMethodEnum calculationMethod) {
-    this.calculationMethod = calculationMethod;
-    return this;
-  }
-
-  /**
-   * Methods of calculating interest
-   * @return calculationMethod
-  */
-  
-  @Schema(name = "CalculationMethod", description = "Methods of calculating interest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationMethod")
-  public CalculationMethodEnum getCalculationMethod() {
-    return calculationMethod;
-  }
-
-  public void setCalculationMethod(CalculationMethodEnum calculationMethod) {
-    this.calculationMethod = calculationMethod;
-  }
-
-  public TierBandSetInner destination(DestinationEnum destination) {
-    this.destination = destination;
-    return this;
-  }
-
-  /**
-   * Describes whether accrued interest is payable only to the BCA or to another bank account
-   * @return destination
-  */
-  @NotNull 
-  @Schema(name = "Destination", description = "Describes whether accrued interest is payable only to the BCA or to another bank account", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("Destination")
-  public DestinationEnum getDestination() {
-    return destination;
-  }
-
-  public void setDestination(DestinationEnum destination) {
-    this.destination = destination;
-  }
-
-  public TierBandSetInner notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public TierBandSetInner addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier Band Set details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public TierBandSetInner tierBand(List<@Valid TierBandInner> tierBand) {
-    this.tierBand = tierBand;
-    return this;
-  }
-
-  public TierBandSetInner addTierBandItem(TierBandInner tierBandItem) {
-    if (this.tierBand == null) {
-      this.tierBand = new ArrayList<>();
-    }
-    this.tierBand.add(tierBandItem);
-    return this;
-  }
-
-  /**
-   * Tier Band Details
-   * @return tierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBand", description = "Tier Band Details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBand")
-  public List<@Valid TierBandInner> getTierBand() {
-    return tierBand;
-  }
-
-  public void setTierBand(List<@Valid TierBandInner> tierBand) {
-    this.tierBand = tierBand;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TierBandSetInner tierBandSetInner = (TierBandSetInner) o;
-    return Objects.equals(this.tierBandMethod, tierBandSetInner.tierBandMethod) &&
-        Objects.equals(this.calculationMethod, tierBandSetInner.calculationMethod) &&
-        Objects.equals(this.destination, tierBandSetInner.destination) &&
-        Objects.equals(this.notes, tierBandSetInner.notes) &&
-        Objects.equals(this.tierBand, tierBandSetInner.tierBand);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, calculationMethod, destination, notes, tierBand);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class TierBandSetInner {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
-    sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/TierBandSetInner1.java
@@ -19,10 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
@@ -39,294 +37,197 @@ import jakarta.validation.constraints.Size;
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class TierBandSetInner1 {
 
-  /**
-   * The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance
-   */
-  public enum TierBandMethodEnum {
-    TIERED("Tiered"),
-    
-    WHOLE("Whole");
+    private TierBandMethod2 tierBandMethod;
 
-    private String value;
+    private CalculationMethod calculationMethod;
 
-    TierBandMethodEnum(String value) {
-      this.value = value;
+    private Destination1 destination;
+
+    @Valid
+    private List<@Size(min = 1, max = 2000) String> notes;
+
+    @Valid
+    private List<@Valid TierBandInner1> tierBand = new ArrayList<>();
+
+    public TierBandSetInner1() {
+        super();
     }
 
-    @JsonValue
-    public String getValue() {
-      return value;
+    /**
+     * Constructor with only required parameters
+     */
+    public TierBandSetInner1(TierBandMethod2 tierBandMethod, List<@Valid TierBandInner1> tierBand) {
+        this.tierBandMethod = tierBandMethod;
+        this.tierBand = tierBand;
+    }
+
+    public TierBandSetInner1 tierBandMethod(TierBandMethod2 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+        return this;
+    }
+
+    /**
+     * Get tierBandMethod
+     *
+     * @return tierBandMethod
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "TierBandMethod", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBandMethod")
+    public TierBandMethod2 getTierBandMethod() {
+        return tierBandMethod;
+    }
+
+    public void setTierBandMethod(TierBandMethod2 tierBandMethod) {
+        this.tierBandMethod = tierBandMethod;
+    }
+
+    public TierBandSetInner1 calculationMethod(CalculationMethod calculationMethod) {
+        this.calculationMethod = calculationMethod;
+        return this;
+    }
+
+    /**
+     * Get calculationMethod
+     *
+     * @return calculationMethod
+     */
+    @Valid
+    @Schema(name = "CalculationMethod", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CalculationMethod")
+    public CalculationMethod getCalculationMethod() {
+        return calculationMethod;
+    }
+
+    public void setCalculationMethod(CalculationMethod calculationMethod) {
+        this.calculationMethod = calculationMethod;
+    }
+
+    public TierBandSetInner1 destination(Destination1 destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    /**
+     * Get destination
+     *
+     * @return destination
+     */
+    @Valid
+    @Schema(name = "Destination", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Destination")
+    public Destination1 getDestination() {
+        return destination;
+    }
+
+    public void setDestination(Destination1 destination) {
+        this.destination = destination;
+    }
+
+    public TierBandSetInner1 notes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+        return this;
+    }
+
+    public TierBandSetInner1 addNotesItem(String notesItem) {
+        if (this.notes == null) {
+            this.notes = new ArrayList<>();
+        }
+        this.notes.add(notesItem);
+        return this;
+    }
+
+    /**
+     * Optional additional notes to supplement the Tier Band Set details
+     *
+     * @return notes
+     */
+
+    @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Notes")
+    public List<@Size(min = 1, max = 2000) String> getNotes() {
+        return notes;
+    }
+
+    public void setNotes(List<@Size(min = 1, max = 2000) String> notes) {
+        this.notes = notes;
+    }
+
+    public TierBandSetInner1 tierBand(List<@Valid TierBandInner1> tierBand) {
+        this.tierBand = tierBand;
+        return this;
+    }
+
+    public TierBandSetInner1 addTierBandItem(TierBandInner1 tierBandItem) {
+        if (this.tierBand == null) {
+            this.tierBand = new ArrayList<>();
+        }
+        this.tierBand.add(tierBandItem);
+        return this;
+    }
+
+    /**
+     * Tier Band Details
+     *
+     * @return tierBand
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "TierBand", description = "Tier Band Details", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("TierBand")
+    public List<@Valid TierBandInner1> getTierBand() {
+        return tierBand;
+    }
+
+    public void setTierBand(List<@Valid TierBandInner1> tierBand) {
+        this.tierBand = tierBand;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TierBandSetInner1 tierBandSetInner1 = (TierBandSetInner1) o;
+        return Objects.equals(this.tierBandMethod, tierBandSetInner1.tierBandMethod) &&
+                Objects.equals(this.calculationMethod, tierBandSetInner1.calculationMethod) &&
+                Objects.equals(this.destination, tierBandSetInner1.destination) &&
+                Objects.equals(this.notes, tierBandSetInner1.notes) &&
+                Objects.equals(this.tierBand, tierBandSetInner1.tierBand);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tierBandMethod, calculationMethod, destination, notes, tierBand);
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+        StringBuilder sb = new StringBuilder();
+        sb.append("class TierBandSetInner1 {\n");
+        sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
+        sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
+        sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
+        sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
+        sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
+        sb.append("}");
+        return sb.toString();
     }
 
-    @JsonCreator
-    public static TierBandMethodEnum fromValue(String value) {
-      for (TierBandMethodEnum b : TierBandMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
         }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        return o.toString().replace("\n", "\n    ");
     }
-  }
-
-  private TierBandMethodEnum tierBandMethod;
-
-  /**
-   * Methods of calculating interest
-   */
-  public enum CalculationMethodEnum {
-    COMPOUND("Compound"),
-    
-    SIMPLEINTEREST("SimpleInterest");
-
-    private String value;
-
-    CalculationMethodEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static CalculationMethodEnum fromValue(String value) {
-      for (CalculationMethodEnum b : CalculationMethodEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private CalculationMethodEnum calculationMethod;
-
-  /**
-   * Describes whether accrued interest is payable only to the PCA or to another bank account
-   */
-  public enum DestinationEnum {
-    PAYAWAY("PayAway"),
-    
-    SELFCREDIT("SelfCredit");
-
-    private String value;
-
-    DestinationEnum(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static DestinationEnum fromValue(String value) {
-      for (DestinationEnum b : DestinationEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
-  private DestinationEnum destination;
-
-  @Valid
-  private List<@Size(min = 1, max = 2000)String> notes;
-
-  @Valid
-  private List<@Valid TierBandInner1> tierBand = new ArrayList<>();
-
-  public TierBandSetInner1() {
-    super();
-  }
-
-  /**
-   * Constructor with only required parameters
-   */
-  public TierBandSetInner1(TierBandMethodEnum tierBandMethod, List<@Valid TierBandInner1> tierBand) {
-    this.tierBandMethod = tierBandMethod;
-    this.tierBand = tierBand;
-  }
-
-  public TierBandSetInner1 tierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-    return this;
-  }
-
-  /**
-   * The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance
-   * @return tierBandMethod
-  */
-  @NotNull 
-  @Schema(name = "TierBandMethod", description = "The methodology of how credit interest is charged. It can be:-  1. Banded Interest rates are banded. i.e. Increasing rate on whole balance as balance increases.  2. Tiered Interest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.  3. Whole The same interest rate is applied irrespective of the PCA balance", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBandMethod")
-  public TierBandMethodEnum getTierBandMethod() {
-    return tierBandMethod;
-  }
-
-  public void setTierBandMethod(TierBandMethodEnum tierBandMethod) {
-    this.tierBandMethod = tierBandMethod;
-  }
-
-  public TierBandSetInner1 calculationMethod(CalculationMethodEnum calculationMethod) {
-    this.calculationMethod = calculationMethod;
-    return this;
-  }
-
-  /**
-   * Methods of calculating interest
-   * @return calculationMethod
-  */
-  
-  @Schema(name = "CalculationMethod", description = "Methods of calculating interest", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("CalculationMethod")
-  public CalculationMethodEnum getCalculationMethod() {
-    return calculationMethod;
-  }
-
-  public void setCalculationMethod(CalculationMethodEnum calculationMethod) {
-    this.calculationMethod = calculationMethod;
-  }
-
-  public TierBandSetInner1 destination(DestinationEnum destination) {
-    this.destination = destination;
-    return this;
-  }
-
-  /**
-   * Describes whether accrued interest is payable only to the PCA or to another bank account
-   * @return destination
-  */
-  
-  @Schema(name = "Destination", description = "Describes whether accrued interest is payable only to the PCA or to another bank account", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Destination")
-  public DestinationEnum getDestination() {
-    return destination;
-  }
-
-  public void setDestination(DestinationEnum destination) {
-    this.destination = destination;
-  }
-
-  public TierBandSetInner1 notes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-    return this;
-  }
-
-  public TierBandSetInner1 addNotesItem(String notesItem) {
-    if (this.notes == null) {
-      this.notes = new ArrayList<>();
-    }
-    this.notes.add(notesItem);
-    return this;
-  }
-
-  /**
-   * Optional additional notes to supplement the Tier Band Set details
-   * @return notes
-  */
-  
-  @Schema(name = "Notes", description = "Optional additional notes to supplement the Tier Band Set details", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("Notes")
-  public List<@Size(min = 1, max = 2000)String> getNotes() {
-    return notes;
-  }
-
-  public void setNotes(List<@Size(min = 1, max = 2000)String> notes) {
-    this.notes = notes;
-  }
-
-  public TierBandSetInner1 tierBand(List<@Valid TierBandInner1> tierBand) {
-    this.tierBand = tierBand;
-    return this;
-  }
-
-  public TierBandSetInner1 addTierBandItem(TierBandInner1 tierBandItem) {
-    if (this.tierBand == null) {
-      this.tierBand = new ArrayList<>();
-    }
-    this.tierBand.add(tierBandItem);
-    return this;
-  }
-
-  /**
-   * Tier Band Details
-   * @return tierBand
-  */
-  @NotNull @Valid @Size(min = 1) 
-  @Schema(name = "TierBand", description = "Tier Band Details", requiredMode = Schema.RequiredMode.REQUIRED)
-  @JsonProperty("TierBand")
-  public List<@Valid TierBandInner1> getTierBand() {
-    return tierBand;
-  }
-
-  public void setTierBand(List<@Valid TierBandInner1> tierBand) {
-    this.tierBand = tierBand;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    TierBandSetInner1 tierBandSetInner1 = (TierBandSetInner1) o;
-    return Objects.equals(this.tierBandMethod, tierBandSetInner1.tierBandMethod) &&
-        Objects.equals(this.calculationMethod, tierBandSetInner1.calculationMethod) &&
-        Objects.equals(this.destination, tierBandSetInner1.destination) &&
-        Objects.equals(this.notes, tierBandSetInner1.notes) &&
-        Objects.equals(this.tierBand, tierBandSetInner1.tierBand);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tierBandMethod, calculationMethod, destination, notes, tierBand);
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("class TierBandSetInner1 {\n");
-    sb.append("    tierBandMethod: ").append(toIndentedString(tierBandMethod)).append("\n");
-    sb.append("    calculationMethod: ").append(toIndentedString(calculationMethod)).append("\n");
-    sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
-    sb.append("    notes: ").append(toIndentedString(notes)).append("\n");
-    sb.append("    tierBand: ").append(toIndentedString(tierBand)).append("\n");
-    sb.append("}");
-    return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces
-   * (except the first line).
-   */
-  private String toIndentedString(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return o.toString().replace("\n", "\n    ");
-  }
 }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalPermissions1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBExternalPermissions1Code.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package uk.org.openbanking.datamodel.account;
+package uk.org.openbanking.datamodel.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
@@ -76,7 +76,10 @@ public class EqualityBigDecimalUtilTest {
     @ParameterizedTest(name = "OBObject {0}")
     @MethodSource("argumentsProviderTrue")
     public <T> void equalsShouldReturnTrue(String obObject, T obObjectTo, T toOBObject) {
-        assertThat(obObjectTo.equals(toOBObject)).isTrue();
+        assertThat(obObjectTo.equals(toOBObject))
+                .overridingErrorMessage(obObject + " requires equals method generated code updated to use EqualityVerificationUtil.BigDecimalUtil.isEqual method")
+                .isTrue();
+
     }
 
     private static Stream<Arguments> argumentsProviderFalse() {


### PR DESCRIPTION
Re-generating the accounts data model with the updated code-gen config, the main change is to fix config to reuse types and to have inner enums pulled out as top level types.

Adding config to use the custom OBRisk2 rather than use the default code-gen output which uses type Object.

Reformatting code to use FR formatting settings.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1243