### PR TITLE
1251: Prepare next SAPIG release of 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Bump parent version to release version

Version: https://github.com/SecureApiGateway/SecureApiGateway/issues/1251