### PR TITLE
900: CodeQL configuration changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         java-version: '17'
+        distribution: 'zulu'
         cache: 'maven'
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
Fixing setup-java action to specify distribution, this is now a required configuration in v4 of the action.

Using the Azul Zulu distribution as this is matches our runtime distribution (specified in the FR base images).

https://github.com/SecureApiGateway/SecureApiGateway/issues/900