### PR TITLE
1364: Update parent version to 2.3.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.2-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Using the latest version of the parent pom to pick up the latest dependency updates.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1364