### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run_release-template:
     name: Release - Build, Deploy & Create Release
-    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@1389-standard-steps-for-workflows
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@main
     secrets: inherit
     with:
       componentName: secure-api-gateway-ob-uk-common

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release - Build, Deploy & Create Release
+run-name: "${{ inputs.releaseVersion }}: Release - Build, Deploy & Create Release"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,55 +1,22 @@
-name: create-release
-run-name: Create release '${{ inputs.release_version_number }}'
-# What it does:
-# - Call release-prepare workflow
-# - Call release-publish-java workflow
-# - Call release-publish-draft-and-pr
+name: Release - Build, Deploy & Create Release
 on:
   workflow_dispatch:
     inputs:
-      notes:
-        description: "Release notes"
+      releaseNotes:
+        description: "Release Notes - Issues Included in Release"
         required: false
         type: string
-        default: ''
-      release_version_number:
-        description: "Provide release version number"
+      releaseVersion:
+        description: "The version to be Released (#.#.#.#)"
         required: true
         type: string
-
 jobs:
-
-  release_prepare: # prepare for a release in scm, creates the tag and release branch with the proper release versions
-    name: Call release prepare
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-prepare.yml@master
+  run_release-template:
+    name: Release - Build, Deploy & Create Release
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@1389-standard-steps-for-workflows
+    secrets: inherit
     with:
-      release_version_number: ${{ inputs.release_version_number }}
-    secrets:
-      GPG_PRIVATE_KEY_BOT: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
-      GPG_KEY_PASSPHRASE_BOT: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
-      GIT_COMMIT_USERNAME_BOT: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-      GIT_COMMIT_AUTHOR_EMAIL_BOT: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-      release_github_token: ${{ secrets.RELEASE_PAT }}
-
-
-  release_java:
-    name: Call publish java
-    needs: release_prepare
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-java.yml@master
-    with:
-      release_version_number: ${{ inputs.release_version_number }}
-      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
-    secrets:
-      FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-      FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-
-  release_publish:
-    name: Call publish
-    needs: [release_prepare, release_java]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish.yml@master
-    with:
-      release_version_number: ${{ inputs.release_version_number }}
-      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
-      release_notes: ${{ inputs.notes }}
-    secrets:
-      release_github_token: ${{ secrets.RELEASE_PAT }}
+      componentName: secure-api-gateway-ob-uk-common
+      dockerTag: $(echo ${{ github.sha }} | cut -c1-7)
+      releaseNotes: ${{ inputs.releaseNotes }}
+      releaseVersion: ${{ inputs.releaseVersion }}


### PR DESCRIPTION
Amend release workflow to use reusable CI repo workflow

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389