### PR TITLE
1440: Add shared types to v4 common pkg

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -234,23 +234,26 @@
                                          Documentation: https://github.com/OpenAPITools/openapi-generator/blob/master/docs/customization.md
                                          -->
                                     <importMappings>
-                                        Links=uk.org.openbanking.datamodel.v3.common.Links,
-                                        Meta=uk.org.openbanking.datamodel.v3.common.Meta,
-                                        OBRisk1=uk.org.openbanking.datamodel.v3.common.OBRisk1,
+                                        <!-- v3 common types to reuse -->
                                         OBSupplementaryData1=uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1,
-                                        OBError1=uk.org.openbanking.datamodel.v3.error.OBError1,
-                                        OBErrorResponse1=uk.org.openbanking.datamodel.v3.error.OBErrorResponse1,
+
+                                        <!-- v4 common types to reuse -->
+                                        Links=uk.org.openbanking.datamodel.v4.common.Links,
+                                        Meta=uk.org.openbanking.datamodel.v4.common.Meta,
+                                        OBRisk1=uk.org.openbanking.datamodel.v4.common.OBRisk1,
+                                        OBError1=uk.org.openbanking.datamodel.v4.error.OBError1,
+                                        OBErrorResponse1=uk.org.openbanking.datamodel.v4.error.OBErrorResponse1,
                                         OBCashAccount3=uk.org.openbanking.datamodel.common.OBCashAccount3,
-                                        OBExternalRequestStatus1Code=uk.org.openbanking.datamodel.v3.common.OBExternalRequestStatus1Code,
-                                        OBActiveOrHistoricCurrencyAndAmount=uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount,
-                                        OBPostalAddress6=uk.org.openbanking.datamodel.v3.common.OBPostalAddress6,
-                                        OBChargeBearerType1Code=uk.org.openbanking.datamodel.v3.common.OBChargeBearerType1Code,
-                                        OBCashAccountCreditor3=uk.org.openbanking.datamodel.v3.common.OBCashAccountCreditor3,
-                                        OBBranchAndFinancialInstitutionIdentification6=uk.org.openbanking.datamodel.v3.common.OBBranchAndFinancialInstitutionIdentification6,
-                                        OBExternalStatus2Code=uk.org.openbanking.datamodel.common.OBExternalStatus2Code,
-                                        OBReadRefundAccount=uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount,
-                                        OBAddressTypeCode=uk.org.openbanking.datamodel.v3.common.OBAddressTypeCode,
-                                        OBExternalPermissions1Code=uk.org.openbanking.datamodel.v3.common.OBExternalPermissions1Code
+                                        OBExternalRequestStatus1Code=uk.org.openbanking.datamodel.v4.common.OBExternalRequestStatus1Code,
+                                        OBActiveOrHistoricCurrencyAndAmount=uk.org.openbanking.datamodel.v4.common.OBActiveOrHistoricCurrencyAndAmount,
+                                        OBPostalAddress7=uk.org.openbanking.datamodel.v4.common.OBPostalAddress7,
+                                        OBChargeBearerType1Code=uk.org.openbanking.datamodel.v4.common.OBChargeBearerType1Code,
+                                        OBCashAccountCreditor3=uk.org.openbanking.datamodel.v4.common.OBCashAccountCreditor3,
+                                        OBBranchAndFinancialInstitutionIdentification6=uk.org.openbanking.datamodel.v4.common.OBBranchAndFinancialInstitutionIdentification6,
+                                        OBExternalStatus2Code=uk.org.openbanking.datamodel.v4.common.OBExternalStatus2Code,
+                                        OBReadRefundAccount=uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount,
+                                        OBAddressTypeCode=uk.org.openbanking.datamodel.v4.common.OBAddressTypeCode,
+                                        OBExternalPermissions1Code=uk.org.openbanking.datamodel.v4.common.OBExternalPermissions1Code
                                     </importMappings>
                                     <configOptions>
                                         <useSpringBoot3>true</useSpringBoot3>

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Links.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Links.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Links relevant to the payload
+ */
+
+@Schema(name = "Links", description = "Links relevant to the payload")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class Links {
+
+    private URI self;
+
+    private URI first;
+
+    private URI prev;
+
+    private URI next;
+
+    private URI last;
+
+    public Links() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public Links(URI self) {
+        this.self = self;
+    }
+
+    public Links self(URI self) {
+        this.self = self;
+        return this;
+    }
+
+    /**
+     * Get self
+     *
+     * @return self
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Self", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Self")
+    public URI getSelf() {
+        return self;
+    }
+
+    public void setSelf(URI self) {
+        this.self = self;
+    }
+
+    public Links first(URI first) {
+        this.first = first;
+        return this;
+    }
+
+    /**
+     * Get first
+     *
+     * @return first
+     */
+    @Valid
+    @Schema(name = "First", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("First")
+    public URI getFirst() {
+        return first;
+    }
+
+    public void setFirst(URI first) {
+        this.first = first;
+    }
+
+    public Links prev(URI prev) {
+        this.prev = prev;
+        return this;
+    }
+
+    /**
+     * Get prev
+     *
+     * @return prev
+     */
+    @Valid
+    @Schema(name = "Prev", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Prev")
+    public URI getPrev() {
+        return prev;
+    }
+
+    public void setPrev(URI prev) {
+        this.prev = prev;
+    }
+
+    public Links next(URI next) {
+        this.next = next;
+        return this;
+    }
+
+    /**
+     * Get next
+     *
+     * @return next
+     */
+    @Valid
+    @Schema(name = "Next", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Next")
+    public URI getNext() {
+        return next;
+    }
+
+    public void setNext(URI next) {
+        this.next = next;
+    }
+
+    public Links last(URI last) {
+        this.last = last;
+        return this;
+    }
+
+    /**
+     * Get last
+     *
+     * @return last
+     */
+    @Valid
+    @Schema(name = "Last", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Last")
+    public URI getLast() {
+        return last;
+    }
+
+    public void setLast(URI last) {
+        this.last = last;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Links links = (Links) o;
+        return Objects.equals(this.self, links.self) &&
+                Objects.equals(this.first, links.first) &&
+                Objects.equals(this.prev, links.prev) &&
+                Objects.equals(this.next, links.next) &&
+                Objects.equals(this.last, links.last);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(self, first, prev, next, last);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Links {\n");
+        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("    first: ").append(toIndentedString(first)).append("\n");
+        sb.append("    prev: ").append(toIndentedString(prev)).append("\n");
+        sb.append("    next: ").append(toIndentedString(next)).append("\n");
+        sb.append("    last: ").append(toIndentedString(last)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Meta.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Meta.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.Objects;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+
+/**
+ * Meta Data relevant to the payload
+ */
+
+@Schema(name = "Meta", description = "Meta Data relevant to the payload")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class Meta {
+
+    private Integer totalPages;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime firstAvailableDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime lastAvailableDateTime;
+
+    public Meta totalPages(Integer totalPages) {
+        this.totalPages = totalPages;
+        return this;
+    }
+
+    /**
+     * Get totalPages
+     *
+     * @return totalPages
+     */
+
+    @Schema(name = "TotalPages", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TotalPages")
+    public Integer getTotalPages() {
+        return totalPages;
+    }
+
+    public void setTotalPages(Integer totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    public Meta firstAvailableDateTime(DateTime firstAvailableDateTime) {
+        this.firstAvailableDateTime = firstAvailableDateTime;
+        return this;
+    }
+
+    /**
+     * All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return firstAvailableDateTime
+     */
+    @Valid
+    @Schema(name = "FirstAvailableDateTime", description = "All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("FirstAvailableDateTime")
+    public DateTime getFirstAvailableDateTime() {
+        return firstAvailableDateTime;
+    }
+
+    public void setFirstAvailableDateTime(DateTime firstAvailableDateTime) {
+        this.firstAvailableDateTime = firstAvailableDateTime;
+    }
+
+    public Meta lastAvailableDateTime(DateTime lastAvailableDateTime) {
+        this.lastAvailableDateTime = lastAvailableDateTime;
+        return this;
+    }
+
+    /**
+     * All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return lastAvailableDateTime
+     */
+    @Valid
+    @Schema(name = "LastAvailableDateTime", description = "All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LastAvailableDateTime")
+    public DateTime getLastAvailableDateTime() {
+        return lastAvailableDateTime;
+    }
+
+    public void setLastAvailableDateTime(DateTime lastAvailableDateTime) {
+        this.lastAvailableDateTime = lastAvailableDateTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Meta meta = (Meta) o;
+        return Objects.equals(this.totalPages, meta.totalPages) &&
+                Objects.equals(this.firstAvailableDateTime, meta.firstAvailableDateTime) &&
+                Objects.equals(this.lastAvailableDateTime, meta.lastAvailableDateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(totalPages, firstAvailableDateTime, lastAvailableDateTime);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Meta {\n");
+        sb.append("    totalPages: ").append(toIndentedString(totalPages)).append("\n");
+        sb.append("    firstAvailableDateTime: ").append(toIndentedString(firstAvailableDateTime)).append("\n");
+        sb.append("    lastAvailableDateTime: ").append(toIndentedString(lastAvailableDateTime)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBActiveOrHistoricCurrencyAndAmount.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Amount of money associated with the charge type.
+ */
+
+@Schema(name = "OBActiveOrHistoricCurrencyAndAmount", description = "Amount of money associated with the charge type.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBActiveOrHistoricCurrencyAndAmount {
+
+    private String amount;
+
+    private String currency;
+
+    public OBActiveOrHistoricCurrencyAndAmount() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBActiveOrHistoricCurrencyAndAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount amount(String amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBActiveOrHistoricCurrencyAndAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBActiveOrHistoricCurrencyAndAmount obActiveOrHistoricCurrencyAndAmount = (OBActiveOrHistoricCurrencyAndAmount) o;
+        return Objects.equals(this.amount, obActiveOrHistoricCurrencyAndAmount.amount) &&
+                Objects.equals(this.currency, obActiveOrHistoricCurrencyAndAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBActiveOrHistoricCurrencyAndAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressTypeCode.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Identifies the nature of the postal address.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBAddressTypeCode {
+
+    BUSINESS("Business"),
+
+    CORRESPONDENCE("Correspondence"),
+
+    DELIVERYTO("DeliveryTo"),
+
+    MAILTO("MailTo"),
+
+    POBOX("POBox"),
+
+    POSTAL("Postal"),
+
+    RESIDENTIAL("Residential"),
+
+    STATEMENT("Statement");
+
+    private String value;
+
+    OBAddressTypeCode(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBAddressTypeCode fromValue(String value) {
+        for (OBAddressTypeCode b : OBAddressTypeCode.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBCashAccountCreditor3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBCashAccountCreditor3.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.payment.OBProxy1;
+
+/**
+ * OBCashAccountCreditor3
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBCashAccountCreditor3 {
+
+    private String schemeName;
+
+    private String identification;
+
+    private String name;
+
+    private String secondaryIdentification;
+
+    private String LEI;
+
+    private OBProxy1 proxy;
+
+    public OBCashAccountCreditor3() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBCashAccountCreditor3(String schemeName, String identification, String name) {
+        this.schemeName = schemeName;
+        this.identification = identification;
+        this.name = name;
+    }
+
+    public OBCashAccountCreditor3 schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
+    }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBCashAccountCreditor3 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBCashAccountCreditor3 name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @NotNull
+    @Schema(name = "Name", description = "Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBCashAccountCreditor3 secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * Secondary identification of the account, as assigned by the account servicing institution. This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(max = 34)
+    @Schema(name = "SecondaryIdentification", description = "Secondary identification of the account, as assigned by the account servicing institution. This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    public OBCashAccountCreditor3 LEI(String LEI) {
+        this.LEI = LEI;
+        return this;
+    }
+
+    /**
+     * Legal entity identification as an alternate identification for a party. Legal Entity Identifier is a code allocated to a party as described in ISO 17442 \"Financial Services - Legal Entity Identifier (LEI)\".
+     *
+     * @return LEI
+     */
+    @Pattern(regexp = "^[0-9]{4}[0]{2}[A-Z0-9]{12}[0-9]{2}")
+    @Size(min = 1, max = 20)
+    @Schema(name = "LEI", description = "Legal entity identification as an alternate identification for a party. Legal Entity Identifier is a code allocated to a party as described in ISO 17442 \"Financial Services - Legal Entity Identifier (LEI)\".", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("LEI")
+    public String getLEI() {
+        return LEI;
+    }
+
+    public void setLEI(String LEI) {
+        this.LEI = LEI;
+    }
+
+    public OBCashAccountCreditor3 proxy(OBProxy1 proxy) {
+        this.proxy = proxy;
+        return this;
+    }
+
+    /**
+     * Get proxy
+     *
+     * @return proxy
+     */
+    @Valid
+    @Schema(name = "Proxy", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Proxy")
+    public OBProxy1 getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(OBProxy1 proxy) {
+        this.proxy = proxy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBCashAccountCreditor3 obCashAccountCreditor3 = (OBCashAccountCreditor3) o;
+        return Objects.equals(this.schemeName, obCashAccountCreditor3.schemeName) &&
+                Objects.equals(this.identification, obCashAccountCreditor3.identification) &&
+                Objects.equals(this.name, obCashAccountCreditor3.name) &&
+                Objects.equals(this.secondaryIdentification, obCashAccountCreditor3.secondaryIdentification) &&
+                Objects.equals(this.LEI, obCashAccountCreditor3.LEI) &&
+                Objects.equals(this.proxy, obCashAccountCreditor3.proxy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification, LEI, proxy);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBCashAccountCreditor3 {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("    LEI: ").append(toIndentedString(LEI)).append("\n");
+        sb.append("    proxy: ").append(toIndentedString(proxy)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBError1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBError1.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBError1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBError1 {
+
+    private String errorCode;
+
+    private String message;
+
+    private String path;
+
+    private String url;
+
+    public OBError1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBError1(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public OBError1 errorCode(String errorCode) {
+        this.errorCode = errorCode;
+        return this;
+    }
+
+    /**
+     * Low level textual error code, for all enum values see `OBInternalErrorResponseError1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+     *
+     * @return errorCode
+     */
+    @NotNull
+    @Size(min = 4, max = 4)
+    @Schema(name = "ErrorCode", example = "U001", description = "Low level textual error code, for all enum values see `OBInternalErrorResponseError1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ErrorCode")
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public OBError1 message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+     * A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBL doesn't standardise this field
+     *
+     * @return message
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Message", description = "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future' OBL doesn't standardise this field", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Message")
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public OBError1 path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency
+     *
+     * @return path
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Path", description = "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Path")
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public OBError1 url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    /**
+     * URL to help remediate the problem, or provide more information, or to API Reference, or help etc
+     *
+     * @return url
+     */
+
+    @Schema(name = "Url", description = "URL to help remediate the problem, or provide more information, or to API Reference, or help etc", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Url")
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBError1 obError1 = (OBError1) o;
+        return Objects.equals(this.errorCode, obError1.errorCode) &&
+                Objects.equals(this.message, obError1.message) &&
+                Objects.equals(this.path, obError1.path) &&
+                Objects.equals(this.url, obError1.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(errorCode, message, path, url);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBError1 {\n");
+        sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("    url: ").append(toIndentedString(url)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBErrorResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBErrorResponse1.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * An array of detail error codes, and messages, and URLs to documentation to help remediation.
+ */
+
+@Schema(name = "OBErrorResponse1", description = "An array of detail error codes, and messages, and URLs to documentation to help remediation.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBErrorResponse1 {
+
+    private String id;
+
+    private String code;
+
+    private String message;
+
+    @Valid
+    private List<@Valid OBError1> errors = new ArrayList<>();
+
+    public OBErrorResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBErrorResponse1(List<@Valid OBError1> errors) {
+        this.errors = errors;
+    }
+
+    public OBErrorResponse1 id(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors.
+     *
+     * @return id
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "Id", description = "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Id")
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public OBErrorResponse1 code(String code) {
+        this.code = code;
+        return this;
+    }
+
+    /**
+     * Deprecated <br>High level textual error code, to help categorise the errors.
+     *
+     * @return code
+     */
+    @Size(min = 1, max = 40)
+    @Schema(name = "Code", example = "400 BadRequest", description = "Deprecated <br>High level textual error code, to help categorise the errors.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Code")
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public OBErrorResponse1 message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+     * Deprecated <br>Brief Error message
+     *
+     * @return message
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Message", example = "There is something wrong with the request parameters provided", description = "Deprecated <br>Brief Error message", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Message")
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public OBErrorResponse1 errors(List<@Valid OBError1> errors) {
+        this.errors = errors;
+        return this;
+    }
+
+    public OBErrorResponse1 addErrorsItem(OBError1 errorsItem) {
+        if (this.errors == null) {
+            this.errors = new ArrayList<>();
+        }
+        this.errors.add(errorsItem);
+        return this;
+    }
+
+    /**
+     * Get errors
+     *
+     * @return errors
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "Errors", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Errors")
+    public List<@Valid OBError1> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<@Valid OBError1> errors) {
+        this.errors = errors;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBErrorResponse1 obErrorResponse1 = (OBErrorResponse1) o;
+        return Objects.equals(this.id, obErrorResponse1.id) &&
+                Objects.equals(this.code, obErrorResponse1.code) &&
+                Objects.equals(this.message, obErrorResponse1.message) &&
+                Objects.equals(this.errors, obErrorResponse1.errors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, code, message, errors);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBErrorResponse1 {\n");
+        sb.append("    id: ").append(toIndentedString(id)).append("\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    errors: ").append(toIndentedString(errors)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBPostalAddress7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBPostalAddress7.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.payment.OBAddressType2Code;
+
+/**
+ * Information that locates and identifies a specific address, as defined by postal services.
+ */
+
+@Schema(name = "OBPostalAddress7", description = "Information that locates and identifies a specific address, as defined by postal services.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBPostalAddress7 {
+
+    private OBAddressType2Code addressType;
+
+    private String department;
+
+    private String subDepartment;
+
+    private String streetName;
+
+    private String buildingNumber;
+
+    private String buildingName;
+
+    private String floor;
+
+    private String unitNumber;
+
+    private String room;
+
+    private String postBox;
+
+    private String townLocationName;
+
+    private String districtName;
+
+    private String careOf;
+
+    private String postCode;
+
+    private String townName;
+
+    private String countrySubDivision;
+
+    private String country;
+
+    @Valid
+    private List<@Size(min = 1, max = 70) String> addressLine;
+
+    public OBPostalAddress7 addressType(OBAddressType2Code addressType) {
+        this.addressType = addressType;
+        return this;
+    }
+
+    /**
+     * Get addressType
+     *
+     * @return addressType
+     */
+    @Valid
+    @Schema(name = "AddressType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressType")
+    public OBAddressType2Code getAddressType() {
+        return addressType;
+    }
+
+    public void setAddressType(OBAddressType2Code addressType) {
+        this.addressType = addressType;
+    }
+
+    public OBPostalAddress7 department(String department) {
+        this.department = department;
+        return this;
+    }
+
+    /**
+     * Identification of a division of a large organisation or building.
+     *
+     * @return department
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Department", description = "Identification of a division of a large organisation or building.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Department")
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public OBPostalAddress7 subDepartment(String subDepartment) {
+        this.subDepartment = subDepartment;
+        return this;
+    }
+
+    /**
+     * Identification of a sub-division of a large organisation or building.
+     *
+     * @return subDepartment
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "SubDepartment", description = "Identification of a sub-division of a large organisation or building.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SubDepartment")
+    public String getSubDepartment() {
+        return subDepartment;
+    }
+
+    public void setSubDepartment(String subDepartment) {
+        this.subDepartment = subDepartment;
+    }
+
+    public OBPostalAddress7 streetName(String streetName) {
+        this.streetName = streetName;
+        return this;
+    }
+
+    /**
+     * Name of a street or thoroughfare.
+     *
+     * @return streetName
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "StreetName", description = "Name of a street or thoroughfare.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StreetName")
+    public String getStreetName() {
+        return streetName;
+    }
+
+    public void setStreetName(String streetName) {
+        this.streetName = streetName;
+    }
+
+    public OBPostalAddress7 buildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+        return this;
+    }
+
+    /**
+     * Number that identifies the position of a building on a street.
+     *
+     * @return buildingNumber
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "BuildingNumber", description = "Number that identifies the position of a building on a street.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BuildingNumber")
+    public String getBuildingNumber() {
+        return buildingNumber;
+    }
+
+    public void setBuildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+    }
+
+    public OBPostalAddress7 buildingName(String buildingName) {
+        this.buildingName = buildingName;
+        return this;
+    }
+
+    /**
+     * Name of a referenced building.
+     *
+     * @return buildingName
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "BuildingName", description = "Name of a referenced building.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BuildingName")
+    public String getBuildingName() {
+        return buildingName;
+    }
+
+    public void setBuildingName(String buildingName) {
+        this.buildingName = buildingName;
+    }
+
+    public OBPostalAddress7 floor(String floor) {
+        this.floor = floor;
+        return this;
+    }
+
+    /**
+     * Number that identifies the level within a building
+     *
+     * @return floor
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Floor", description = "Number that identifies the level within a building", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Floor")
+    public String getFloor() {
+        return floor;
+    }
+
+    public void setFloor(String floor) {
+        this.floor = floor;
+    }
+
+    public OBPostalAddress7 unitNumber(String unitNumber) {
+        this.unitNumber = unitNumber;
+        return this;
+    }
+
+    /**
+     * Number that identifies the unit of a specific address .
+     *
+     * @return unitNumber
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "UnitNumber", description = "Number that identifies the unit of a specific address .", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("UnitNumber")
+    public String getUnitNumber() {
+        return unitNumber;
+    }
+
+    public void setUnitNumber(String unitNumber) {
+        this.unitNumber = unitNumber;
+    }
+
+    public OBPostalAddress7 room(String room) {
+        this.room = room;
+        return this;
+    }
+
+    /**
+     * Information that locates and identifies a room to form part of an address
+     *
+     * @return room
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "Room", description = "Information that locates and identifies a room to form part of an address", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Room")
+    public String getRoom() {
+        return room;
+    }
+
+    public void setRoom(String room) {
+        this.room = room;
+    }
+
+    public OBPostalAddress7 postBox(String postBox) {
+        this.postBox = postBox;
+        return this;
+    }
+
+    /**
+     * Information that locates and identifies a box in a post office assigned to a person or organization, where letters for them are kept until called for.
+     *
+     * @return postBox
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "PostBox", description = "Information that locates and identifies a box in a post office assigned to a person or organization, where letters for them are kept until called for.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostBox")
+    public String getPostBox() {
+        return postBox;
+    }
+
+    public void setPostBox(String postBox) {
+        this.postBox = postBox;
+    }
+
+    public OBPostalAddress7 townLocationName(String townLocationName) {
+        this.townLocationName = townLocationName;
+        return this;
+    }
+
+    /**
+     * Name of a built-up area, with defined boundaries, and a local government.
+     *
+     * @return townLocationName
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "TownLocationName", description = "Name of a built-up area, with defined boundaries, and a local government.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TownLocationName")
+    public String getTownLocationName() {
+        return townLocationName;
+    }
+
+    public void setTownLocationName(String townLocationName) {
+        this.townLocationName = townLocationName;
+    }
+
+    public OBPostalAddress7 districtName(String districtName) {
+        this.districtName = districtName;
+        return this;
+    }
+
+    /**
+     * Number that of the regional area, known as a district, which forms part of an address
+     *
+     * @return districtName
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "DistrictName", description = "Number that of the regional area, known as a district, which forms part of an address", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DistrictName")
+    public String getDistrictName() {
+        return districtName;
+    }
+
+    public void setDistrictName(String districtName) {
+        this.districtName = districtName;
+    }
+
+    public OBPostalAddress7 careOf(String careOf) {
+        this.careOf = careOf;
+        return this;
+    }
+
+    /**
+     * The 'care of' address is used whenever sending mail to a person or organisation who does not actually live or work at the address. They will receive the mail for the individual.
+     *
+     * @return careOf
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "CareOf", description = "The 'care of' address is used whenever sending mail to a person or organisation who does not actually live or work at the address. They will receive the mail for the individual.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CareOf")
+    public String getCareOf() {
+        return careOf;
+    }
+
+    public void setCareOf(String careOf) {
+        this.careOf = careOf;
+    }
+
+    public OBPostalAddress7 postCode(String postCode) {
+        this.postCode = postCode;
+        return this;
+    }
+
+    /**
+     * Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.
+     *
+     * @return postCode
+     */
+    @Size(min = 1, max = 16)
+    @Schema(name = "PostCode", description = "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PostCode")
+    public String getPostCode() {
+        return postCode;
+    }
+
+    public void setPostCode(String postCode) {
+        this.postCode = postCode;
+    }
+
+    public OBPostalAddress7 townName(String townName) {
+        this.townName = townName;
+        return this;
+    }
+
+    /**
+     * Name of a built-up area, with defined boundaries, and a local government.
+     *
+     * @return townName
+     */
+    @Size(min = 1, max = 140)
+    @Schema(name = "TownName", description = "Name of a built-up area, with defined boundaries, and a local government.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("TownName")
+    public String getTownName() {
+        return townName;
+    }
+
+    public void setTownName(String townName) {
+        this.townName = townName;
+    }
+
+    public OBPostalAddress7 countrySubDivision(String countrySubDivision) {
+        this.countrySubDivision = countrySubDivision;
+        return this;
+    }
+
+    /**
+     * Identifies a subdivision of a country such as state, region, county.
+     *
+     * @return countrySubDivision
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "CountrySubDivision", description = "Identifies a subdivision of a country such as state, region, county.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CountrySubDivision")
+    public String getCountrySubDivision() {
+        return countrySubDivision;
+    }
+
+    public void setCountrySubDivision(String countrySubDivision) {
+        this.countrySubDivision = countrySubDivision;
+    }
+
+    public OBPostalAddress7 country(String country) {
+        this.country = country;
+        return this;
+    }
+
+    /**
+     * Nation with its own government.
+     *
+     * @return country
+     */
+    @Pattern(regexp = "^[A-Z]{2,2}$")
+    @Schema(name = "Country", description = "Nation with its own government.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Country")
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public OBPostalAddress7 addressLine(List<@Size(min = 1, max = 70) String> addressLine) {
+        this.addressLine = addressLine;
+        return this;
+    }
+
+    public OBPostalAddress7 addAddressLineItem(String addressLineItem) {
+        if (this.addressLine == null) {
+            this.addressLine = new ArrayList<>();
+        }
+        this.addressLine.add(addressLineItem);
+        return this;
+    }
+
+    /**
+     * Get addressLine
+     *
+     * @return addressLine
+     */
+    @Size(min = 0, max = 7)
+    @Schema(name = "AddressLine", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("AddressLine")
+    public List<@Size(min = 1, max = 70) String> getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine(List<@Size(min = 1, max = 70) String> addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBPostalAddress7 obPostalAddress7 = (OBPostalAddress7) o;
+        return Objects.equals(this.addressType, obPostalAddress7.addressType) &&
+                Objects.equals(this.department, obPostalAddress7.department) &&
+                Objects.equals(this.subDepartment, obPostalAddress7.subDepartment) &&
+                Objects.equals(this.streetName, obPostalAddress7.streetName) &&
+                Objects.equals(this.buildingNumber, obPostalAddress7.buildingNumber) &&
+                Objects.equals(this.buildingName, obPostalAddress7.buildingName) &&
+                Objects.equals(this.floor, obPostalAddress7.floor) &&
+                Objects.equals(this.unitNumber, obPostalAddress7.unitNumber) &&
+                Objects.equals(this.room, obPostalAddress7.room) &&
+                Objects.equals(this.postBox, obPostalAddress7.postBox) &&
+                Objects.equals(this.townLocationName, obPostalAddress7.townLocationName) &&
+                Objects.equals(this.districtName, obPostalAddress7.districtName) &&
+                Objects.equals(this.careOf, obPostalAddress7.careOf) &&
+                Objects.equals(this.postCode, obPostalAddress7.postCode) &&
+                Objects.equals(this.townName, obPostalAddress7.townName) &&
+                Objects.equals(this.countrySubDivision, obPostalAddress7.countrySubDivision) &&
+                Objects.equals(this.country, obPostalAddress7.country) &&
+                Objects.equals(this.addressLine, obPostalAddress7.addressLine);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addressType, department, subDepartment, streetName, buildingNumber, buildingName, floor, unitNumber, room, postBox, townLocationName, districtName, careOf, postCode, townName, countrySubDivision, country, addressLine);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBPostalAddress7 {\n");
+        sb.append("    addressType: ").append(toIndentedString(addressType)).append("\n");
+        sb.append("    department: ").append(toIndentedString(department)).append("\n");
+        sb.append("    subDepartment: ").append(toIndentedString(subDepartment)).append("\n");
+        sb.append("    streetName: ").append(toIndentedString(streetName)).append("\n");
+        sb.append("    buildingNumber: ").append(toIndentedString(buildingNumber)).append("\n");
+        sb.append("    buildingName: ").append(toIndentedString(buildingName)).append("\n");
+        sb.append("    floor: ").append(toIndentedString(floor)).append("\n");
+        sb.append("    unitNumber: ").append(toIndentedString(unitNumber)).append("\n");
+        sb.append("    room: ").append(toIndentedString(room)).append("\n");
+        sb.append("    postBox: ").append(toIndentedString(postBox)).append("\n");
+        sb.append("    townLocationName: ").append(toIndentedString(townLocationName)).append("\n");
+        sb.append("    districtName: ").append(toIndentedString(districtName)).append("\n");
+        sb.append("    careOf: ").append(toIndentedString(careOf)).append("\n");
+        sb.append("    postCode: ").append(toIndentedString(postCode)).append("\n");
+        sb.append("    townName: ").append(toIndentedString(townName)).append("\n");
+        sb.append("    countrySubDivision: ").append(toIndentedString(countrySubDivision)).append("\n");
+        sb.append("    country: ").append(toIndentedString(country)).append("\n");
+        sb.append("    addressLine: ").append(toIndentedString(addressLine)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBReadRefundAccount.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Specifies to share the refund account details with PISP
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBReadRefundAccount {
+
+    NO("No"),
+
+    YES("Yes");
+
+    private String value;
+
+    OBReadRefundAccount(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBReadRefundAccount fromValue(String value) {
+        for (OBReadRefundAccount b : OBReadRefundAccount.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.payment.ExternalCategoryPurpose1Code;
+import uk.org.openbanking.datamodel.v4.payment.ExternalPurpose1Code;
+import uk.org.openbanking.datamodel.v4.payment.OBInternalExtendedAccountType1Code;
+
+/**
+ * The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments.
+ */
+
+@Schema(name = "OBRisk1", description = "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBRisk1 {
+
+    private OBRisk1PaymentContextCode paymentContextCode;
+
+    private String merchantCategoryCode;
+
+    private String merchantCustomerIdentification;
+
+    private Boolean contractPresentIndicator;
+
+    private Boolean beneficiaryPrepopulatedIndicator;
+
+    private ExternalPurpose1Code paymentPurposeCode;
+
+    private ExternalCategoryPurpose1Code categoryPurposeCode;
+
+    private OBInternalExtendedAccountType1Code beneficiaryAccountType;
+
+    private OBPostalAddress7 deliveryAddress;
+
+    public OBRisk1 paymentContextCode(OBRisk1PaymentContextCode paymentContextCode) {
+        this.paymentContextCode = paymentContextCode;
+        return this;
+    }
+
+    /**
+     * Get paymentContextCode
+     *
+     * @return paymentContextCode
+     */
+    @Valid
+    @Schema(name = "PaymentContextCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PaymentContextCode")
+    public OBRisk1PaymentContextCode getPaymentContextCode() {
+        return paymentContextCode;
+    }
+
+    public void setPaymentContextCode(OBRisk1PaymentContextCode paymentContextCode) {
+        this.paymentContextCode = paymentContextCode;
+    }
+
+    public OBRisk1 merchantCategoryCode(String merchantCategoryCode) {
+        this.merchantCategoryCode = merchantCategoryCode;
+        return this;
+    }
+
+    /**
+     * Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.
+     *
+     * @return merchantCategoryCode
+     */
+    @Size(min = 3, max = 4)
+    @Schema(name = "MerchantCategoryCode", description = "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantCategoryCode")
+    public String getMerchantCategoryCode() {
+        return merchantCategoryCode;
+    }
+
+    public void setMerchantCategoryCode(String merchantCategoryCode) {
+        this.merchantCategoryCode = merchantCategoryCode;
+    }
+
+    public OBRisk1 merchantCustomerIdentification(String merchantCustomerIdentification) {
+        this.merchantCustomerIdentification = merchantCustomerIdentification;
+        return this;
+    }
+
+    /**
+     * The unique customer identifier of the PSU with the merchant.
+     *
+     * @return merchantCustomerIdentification
+     */
+    @Size(min = 1, max = 70)
+    @Schema(name = "MerchantCustomerIdentification", description = "The unique customer identifier of the PSU with the merchant.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("MerchantCustomerIdentification")
+    public String getMerchantCustomerIdentification() {
+        return merchantCustomerIdentification;
+    }
+
+    public void setMerchantCustomerIdentification(String merchantCustomerIdentification) {
+        this.merchantCustomerIdentification = merchantCustomerIdentification;
+    }
+
+    public OBRisk1 contractPresentIndicator(Boolean contractPresentIndicator) {
+        this.contractPresentIndicator = contractPresentIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if Payee has a contractual relationship with the PISP.
+     *
+     * @return contractPresentIndicator
+     */
+
+    @Schema(name = "ContractPresentIndicator", description = "Indicates if Payee has a contractual relationship with the PISP.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ContractPresentIndicator")
+    public Boolean getContractPresentIndicator() {
+        return contractPresentIndicator;
+    }
+
+    public void setContractPresentIndicator(Boolean contractPresentIndicator) {
+        this.contractPresentIndicator = contractPresentIndicator;
+    }
+
+    public OBRisk1 beneficiaryPrepopulatedIndicator(Boolean beneficiaryPrepopulatedIndicator) {
+        this.beneficiaryPrepopulatedIndicator = beneficiaryPrepopulatedIndicator;
+        return this;
+    }
+
+    /**
+     * Indicates if PISP has immutably prepopulated payment details in for the PSU.
+     *
+     * @return beneficiaryPrepopulatedIndicator
+     */
+
+    @Schema(name = "BeneficiaryPrepopulatedIndicator", description = "Indicates if PISP has immutably prepopulated payment details in for the PSU.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryPrepopulatedIndicator")
+    public Boolean getBeneficiaryPrepopulatedIndicator() {
+        return beneficiaryPrepopulatedIndicator;
+    }
+
+    public void setBeneficiaryPrepopulatedIndicator(Boolean beneficiaryPrepopulatedIndicator) {
+        this.beneficiaryPrepopulatedIndicator = beneficiaryPrepopulatedIndicator;
+    }
+
+    public OBRisk1 paymentPurposeCode(ExternalPurpose1Code paymentPurposeCode) {
+        this.paymentPurposeCode = paymentPurposeCode;
+        return this;
+    }
+
+    /**
+     * Get paymentPurposeCode
+     *
+     * @return paymentPurposeCode
+     */
+    @Valid
+    @Schema(name = "PaymentPurposeCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("PaymentPurposeCode")
+    public ExternalPurpose1Code getPaymentPurposeCode() {
+        return paymentPurposeCode;
+    }
+
+    public void setPaymentPurposeCode(ExternalPurpose1Code paymentPurposeCode) {
+        this.paymentPurposeCode = paymentPurposeCode;
+    }
+
+    public OBRisk1 categoryPurposeCode(ExternalCategoryPurpose1Code categoryPurposeCode) {
+        this.categoryPurposeCode = categoryPurposeCode;
+        return this;
+    }
+
+    /**
+     * Get categoryPurposeCode
+     *
+     * @return categoryPurposeCode
+     */
+    @Valid
+    @Schema(name = "CategoryPurposeCode", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CategoryPurposeCode")
+    public ExternalCategoryPurpose1Code getCategoryPurposeCode() {
+        return categoryPurposeCode;
+    }
+
+    public void setCategoryPurposeCode(ExternalCategoryPurpose1Code categoryPurposeCode) {
+        this.categoryPurposeCode = categoryPurposeCode;
+    }
+
+    public OBRisk1 beneficiaryAccountType(OBInternalExtendedAccountType1Code beneficiaryAccountType) {
+        this.beneficiaryAccountType = beneficiaryAccountType;
+        return this;
+    }
+
+    /**
+     * Get beneficiaryAccountType
+     *
+     * @return beneficiaryAccountType
+     */
+    @Valid
+    @Schema(name = "BeneficiaryAccountType", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("BeneficiaryAccountType")
+    public OBInternalExtendedAccountType1Code getBeneficiaryAccountType() {
+        return beneficiaryAccountType;
+    }
+
+    public void setBeneficiaryAccountType(OBInternalExtendedAccountType1Code beneficiaryAccountType) {
+        this.beneficiaryAccountType = beneficiaryAccountType;
+    }
+
+    public OBRisk1 deliveryAddress(OBPostalAddress7 deliveryAddress) {
+        this.deliveryAddress = deliveryAddress;
+        return this;
+    }
+
+    /**
+     * Get deliveryAddress
+     *
+     * @return deliveryAddress
+     */
+    @Valid
+    @Schema(name = "DeliveryAddress", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("DeliveryAddress")
+    public OBPostalAddress7 getDeliveryAddress() {
+        return deliveryAddress;
+    }
+
+    public void setDeliveryAddress(OBPostalAddress7 deliveryAddress) {
+        this.deliveryAddress = deliveryAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBRisk1 obRisk1 = (OBRisk1) o;
+        return Objects.equals(this.paymentContextCode, obRisk1.paymentContextCode) &&
+                Objects.equals(this.merchantCategoryCode, obRisk1.merchantCategoryCode) &&
+                Objects.equals(this.merchantCustomerIdentification, obRisk1.merchantCustomerIdentification) &&
+                Objects.equals(this.contractPresentIndicator, obRisk1.contractPresentIndicator) &&
+                Objects.equals(this.beneficiaryPrepopulatedIndicator, obRisk1.beneficiaryPrepopulatedIndicator) &&
+                Objects.equals(this.paymentPurposeCode, obRisk1.paymentPurposeCode) &&
+                Objects.equals(this.categoryPurposeCode, obRisk1.categoryPurposeCode) &&
+                Objects.equals(this.beneficiaryAccountType, obRisk1.beneficiaryAccountType) &&
+                Objects.equals(this.deliveryAddress, obRisk1.deliveryAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paymentContextCode, merchantCategoryCode, merchantCustomerIdentification, contractPresentIndicator, beneficiaryPrepopulatedIndicator, paymentPurposeCode, categoryPurposeCode, beneficiaryAccountType, deliveryAddress);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBRisk1 {\n");
+        sb.append("    paymentContextCode: ").append(toIndentedString(paymentContextCode)).append("\n");
+        sb.append("    merchantCategoryCode: ").append(toIndentedString(merchantCategoryCode)).append("\n");
+        sb.append("    merchantCustomerIdentification: ").append(toIndentedString(merchantCustomerIdentification)).append("\n");
+        sb.append("    contractPresentIndicator: ").append(toIndentedString(contractPresentIndicator)).append("\n");
+        sb.append("    beneficiaryPrepopulatedIndicator: ").append(toIndentedString(beneficiaryPrepopulatedIndicator)).append("\n");
+        sb.append("    paymentPurposeCode: ").append(toIndentedString(paymentPurposeCode)).append("\n");
+        sb.append("    categoryPurposeCode: ").append(toIndentedString(categoryPurposeCode)).append("\n");
+        sb.append("    beneficiaryAccountType: ").append(toIndentedString(beneficiaryAccountType)).append("\n");
+        sb.append("    deliveryAddress: ").append(toIndentedString(deliveryAddress)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1PaymentContextCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1PaymentContextCode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Specifies the payment context, `OBInternalPaymentContext1Code`
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBRisk1PaymentContextCode {
+
+    BILLINGGOODSANDSERVICESINADVANCE("BillingGoodsAndServicesInAdvance"),
+
+    BILLINGGOODSANDSERVICESINARREARS("BillingGoodsAndServicesInArrears"),
+
+    ECOMMERCEMERCHANTINITIATEDPAYMENT("EcommerceMerchantInitiatedPayment"),
+
+    FACETOFACEPOINTOFSALE("FaceToFacePointOfSale"),
+
+    TRANSFERTOSELF("TransferToSelf"),
+
+    TRANSFERTOTHIRDPARTY("TransferToThirdParty");
+
+    private String value;
+
+    OBRisk1PaymentContextCode(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBRisk1PaymentContextCode fromValue(String value) {
+        for (OBRisk1PaymentContextCode b : OBRisk1PaymentContextCode.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBBranchAndFinancialInstitutionIdentification60.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBStructuredRegulatoryReporting3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBStructuredRegulatoryReporting3.java
@@ -29,7 +29,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v4.common.OBActiveOrHistoricCurrencyAndAmount;
 
 /**
  * Set of elements used to provide details on the regulatory reporting information.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBUltimateCreditor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBUltimateCreditor1.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Ultimate party to which an amount of money is due.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBUltimateDebtor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBUltimateDebtor1.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Ultimate party that owes an amount of money to the (ultimate) creditor.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomestic2

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiation.java
@@ -28,6 +28,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAgent.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Financial institution servicing an account for the creditor.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticConsent4

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticConsent4Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticConsentResponse5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticConsentResponse5Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.v4.common.OBActiveOrHistoricCurrencyAndAmount;
 
 /**
  * Set of elements used to provide details of a charge for the payment initiation.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteDomesticResponse5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticScheduled2

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2DataInitiation.java
@@ -29,6 +29,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticScheduledConsent4

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticScheduledConsent4Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4DataInitiation.java
@@ -31,6 +31,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticScheduledConsentResponse5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticScheduledConsentResponse5Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteDomesticScheduledResponse5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticStandingOrder3

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticStandingOrderConsent5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticStandingOrderConsent5Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteDomesticStandingOrderConsentResponse6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteDomesticStandingOrderConsentResponse6Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteDomesticStandingOrderResponse6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteFileConsentResponse4

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteFileResponse3

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteFundsConfirmationResponse1

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternational3

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationCreditor.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Party to which an amount of money is due.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalConsent5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalConsent5Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalConsentResponse6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalConsentResponse6Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteInternationalResponse5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAgent.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundCreditor.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Set of elements used to identify a person or an organisation.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalScheduled3

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalScheduledConsent5

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalScheduledConsent5Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiationCreditorAgent.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Financial institution servicing an account for the creditor.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalScheduledConsentResponse6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalScheduledConsentResponse6Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Party to which an amount of money is due.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteInternationalScheduledResponse6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalStandingOrder4

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalStandingOrderConsent6

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6Data.java
@@ -24,7 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalStandingOrderConsent6Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7.java
@@ -23,9 +23,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
-import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.OBRisk1;
 
 /**
  * OBWriteInternationalStandingOrderConsentResponse7

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
@@ -30,7 +30,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v3.common.OBReadRefundAccount;
+import uk.org.openbanking.datamodel.v4.common.OBReadRefundAccount;
 
 /**
  * OBWriteInternationalStandingOrderConsentResponse7Data

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7.java
@@ -23,8 +23,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWriteInternationalStandingOrderResponse7

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * Set of elements used to identify a person or an organisation.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1.java
@@ -25,8 +25,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import uk.org.openbanking.datamodel.v3.common.Links;
-import uk.org.openbanking.datamodel.v3.common.Meta;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
 
 /**
  * OBWritePaymentDetailsResponse1


### PR DESCRIPTION
Re-generating the shared types used by the payments schemas, into pkg: uk.org.openbanking.datamodel.v4.common

Shared types which have changed:
- OBRisk1
- OBCashAccountCreditor3
- OBPostalAddress7 (replaces OBPostalAddress6)

Continuing to use: uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1 as it is a custom type defined by us to represent how to add additional free form json data to extend particular types. This type has its own JSON serializer which produces the output required by the OB schema.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440