### PR TITLE
1440: Fix all consent responses to use OBPaymentConsentStatus type

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -174,6 +174,8 @@
                                     <inlineSchemaNameMappings>
                                         OBWriteInternational3_Data_Initiation_ExchangeRateInformation_RateType=OBExchangeRateType,
                                         OBWriteDomesticConsentResponse5_Data_Status=OBPaymentConsentStatus,
+                                        OBWriteDomesticScheduledConsentResponse5_Data_Status=OBPaymentConsentStatus,
+                                        OBWriteInternationalStandingOrderConsentResponse7_Data_Status=OBPaymentConsentStatus,
                                         OBDomesticVRPControlParameters_PeriodicLimits_inner_PeriodAlignment=OBPeriodAlignment,
                                         OBDomesticVRPControlParameters_PeriodicLimits_inner_PeriodType=OBPeriodType,
                                     </inlineSchemaNameMappings>
@@ -218,7 +220,6 @@
                                         OBReadRefundAccount=OBReadRefundAccount,
                                         OBAddressTypeCode=OBAddressTypeCode,
                                         OBExternalPaymentContext1Code=OBExternalPaymentContext1Code,
-                                        OBWriteInternationalStandingOrderConsentResponse7_Data_Status=OBPaymentConsentStatus,
                                         OBDomesticVRPRequest_Data_PSUInteractionType=OBVRPInteractionTypes,
                                         OBDomesticVRPConsentResponse_Data_DebtorAccount=OBCashAccountDebtorWithName,
                                         OBDomesticVRPConsentResponse_Data_ReadRefundAccount=OBReadRefundAccount,

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -45,7 +45,7 @@ public class OBWriteDomesticScheduledConsentResponse5Data {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private DateTime creationDateTime;
 
-    private OBWriteDomesticScheduledConsentResponse5DataStatus status;
+    private OBPaymentConsentStatus status;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private DateTime statusUpdateDateTime;
@@ -84,7 +84,7 @@ public class OBWriteDomesticScheduledConsentResponse5Data {
     /**
      * Constructor with only required parameters
      */
-    public OBWriteDomesticScheduledConsentResponse5Data(String consentId, DateTime creationDateTime, OBWriteDomesticScheduledConsentResponse5DataStatus status, DateTime statusUpdateDateTime, OBWriteDomesticScheduledConsent4DataPermission permission, OBWriteDomesticScheduledConsent4DataInitiation initiation) {
+    public OBWriteDomesticScheduledConsentResponse5Data(String consentId, DateTime creationDateTime, OBPaymentConsentStatus status, DateTime statusUpdateDateTime, OBWriteDomesticScheduledConsent4DataPermission permission, OBWriteDomesticScheduledConsent4DataInitiation initiation) {
         this.consentId = consentId;
         this.creationDateTime = creationDateTime;
         this.status = status;
@@ -137,7 +137,7 @@ public class OBWriteDomesticScheduledConsentResponse5Data {
         this.creationDateTime = creationDateTime;
     }
 
-    public OBWriteDomesticScheduledConsentResponse5Data status(OBWriteDomesticScheduledConsentResponse5DataStatus status) {
+    public OBWriteDomesticScheduledConsentResponse5Data status(OBPaymentConsentStatus status) {
         this.status = status;
         return this;
     }
@@ -151,11 +151,11 @@ public class OBWriteDomesticScheduledConsentResponse5Data {
     @Valid
     @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("Status")
-    public OBWriteDomesticScheduledConsentResponse5DataStatus getStatus() {
+    public OBPaymentConsentStatus getStatus() {
         return status;
     }
 
-    public void setStatus(OBWriteDomesticScheduledConsentResponse5DataStatus status) {
+    public void setStatus(OBPaymentConsentStatus status) {
         this.status = status;
     }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -45,7 +45,7 @@ public class OBWriteDomesticStandingOrderConsentResponse6Data {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private DateTime creationDateTime;
 
-    private OBWriteDomesticScheduledConsentResponse5DataStatus status;
+    private OBPaymentConsentStatus status;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private DateTime statusUpdateDateTime;
@@ -78,7 +78,7 @@ public class OBWriteDomesticStandingOrderConsentResponse6Data {
     /**
      * Constructor with only required parameters
      */
-    public OBWriteDomesticStandingOrderConsentResponse6Data(String consentId, DateTime creationDateTime, OBWriteDomesticScheduledConsentResponse5DataStatus status, DateTime statusUpdateDateTime, OBWriteDomesticScheduledConsent4DataPermission permission, OBWriteDomesticStandingOrderConsentResponse6DataInitiation initiation) {
+    public OBWriteDomesticStandingOrderConsentResponse6Data(String consentId, DateTime creationDateTime, OBPaymentConsentStatus status, DateTime statusUpdateDateTime, OBWriteDomesticScheduledConsent4DataPermission permission, OBWriteDomesticStandingOrderConsentResponse6DataInitiation initiation) {
         this.consentId = consentId;
         this.creationDateTime = creationDateTime;
         this.status = status;
@@ -131,7 +131,7 @@ public class OBWriteDomesticStandingOrderConsentResponse6Data {
         this.creationDateTime = creationDateTime;
     }
 
-    public OBWriteDomesticStandingOrderConsentResponse6Data status(OBWriteDomesticScheduledConsentResponse5DataStatus status) {
+    public OBWriteDomesticStandingOrderConsentResponse6Data status(OBPaymentConsentStatus status) {
         this.status = status;
         return this;
     }
@@ -145,11 +145,11 @@ public class OBWriteDomesticStandingOrderConsentResponse6Data {
     @Valid
     @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("Status")
-    public OBWriteDomesticScheduledConsentResponse5DataStatus getStatus() {
+    public OBPaymentConsentStatus getStatus() {
         return status;
     }
 
-    public void setStatus(OBWriteDomesticScheduledConsentResponse5DataStatus status) {
+    public void setStatus(OBPaymentConsentStatus status) {
         this.status = status;
     }
 


### PR DESCRIPTION
Code generation for Domestic Scheduled Payments and Standing Orders has been fixed to use the shared OBPaymentConsentStatus type.

All Consent Response types status field are now using OBPaymentConsentStatus.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440