### PR TITLE
1440: Add v4 confirmation of funds data model

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -160,12 +160,12 @@
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/payment-initiation-openapi.yaml</inputSpec>-->
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi-3.1.9r7.yaml</inputSpec>-->
                                     <inputSpec>
-                                        ${project.basedir}/src/main/resources/specification/4.0.0/account-info-openapi.yaml
+                                        ${project.basedir}/src/main/resources/specification/4.0.0/confirmation-funds-openapi.yaml
                                     </inputSpec>
                                     <output>${project.build.directory}/generated-sources/swagger</output>
                                     <generatorName>spring</generatorName>
                                     <!-- Change the package here as per the chosen spec above -->
-                                    <modelPackage>uk.org.openbanking.datamodel.v4.account</modelPackage>
+                                    <modelPackage>uk.org.openbanking.datamodel.v4.fund</modelPackage>
                                     <generateApis>false</generateApis>
                                     <!-- Override the default name for inline schemas
                                          This should be used when we want to give complex inner schema names a more
@@ -179,7 +179,8 @@
                                         OBDomesticVRPControlParameters_PeriodicLimits_inner_PeriodAlignment=OBPeriodAlignment,
                                         OBDomesticVRPControlParameters_PeriodicLimits_inner_PeriodType=OBPeriodType,
                                         OBReadConsent1_Data_Permissions_inner=OBInternalPermissions1Code,
-                                        OBReadConsentResponse1_Data_Status=OBReadConsentStatus
+                                        OBReadConsentResponse1_Data_Status=OBReadConsentStatus,
+                                        OBFundsConfirmationConsentResponse1_Data_Status=OBFundsConfirmationConsentStatus
                                     </inlineSchemaNameMappings>
                                     <!-- RESOLVE_INLINE_ENUMS needs to be enabled to move enums which are specified as
                                          inline types in the schema to top level generated types, this then allows us to

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OBFundsConfirmation1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmation1 {
+
+    private OBFundsConfirmation1Data data;
+
+    public OBFundsConfirmation1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmation1(OBFundsConfirmation1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmation1 data(OBFundsConfirmation1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBFundsConfirmation1Data getData() {
+        return data;
+    }
+
+    public void setData(OBFundsConfirmation1Data data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmation1 obFundsConfirmation1 = (OBFundsConfirmation1) o;
+        return Objects.equals(this.data, obFundsConfirmation1.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmation1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1Data.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBFundsConfirmation1Data
+ */
+
+@JsonTypeName("OBFundsConfirmation1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmation1Data {
+
+    private String consentId;
+
+    private String reference;
+
+    private OBFundsConfirmation1DataInstructedAmount instructedAmount;
+
+    public OBFundsConfirmation1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmation1Data(String consentId, String reference, OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.consentId = consentId;
+        this.reference = reference;
+        this.instructedAmount = instructedAmount;
+    }
+
+    public OBFundsConfirmation1Data consentId(String consentId) {
+        this.consentId = consentId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+     *
+     * @return consentId
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "ConsentId", description = "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ConsentId")
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public OBFundsConfirmation1Data reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
+     *
+     * @return reference
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBFundsConfirmation1Data instructedAmount(OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBFundsConfirmation1DataInstructedAmount getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmation1Data obFundsConfirmation1Data = (OBFundsConfirmation1Data) o;
+        return Objects.equals(this.consentId, obFundsConfirmation1Data.consentId) &&
+                Objects.equals(this.reference, obFundsConfirmation1Data.reference) &&
+                Objects.equals(this.instructedAmount, obFundsConfirmation1Data.instructedAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(consentId, reference, instructedAmount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmation1Data {\n");
+        sb.append("    consentId: ").append(toIndentedString(consentId)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1DataInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1DataInstructedAmount.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency.
+ */
+
+@Schema(name = "OBFundsConfirmation1_Data_InstructedAmount", description = "Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency.")
+@JsonTypeName("OBFundsConfirmation1_Data_InstructedAmount")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmation1DataInstructedAmount {
+
+    private String amount;
+
+    private String currency;
+
+    public OBFundsConfirmation1DataInstructedAmount() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmation1DataInstructedAmount(String amount, String currency) {
+        this.amount = amount;
+        this.currency = currency;
+    }
+
+    public OBFundsConfirmation1DataInstructedAmount amount(String amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    /**
+     * A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+     *
+     * @return amount
+     */
+    @NotNull
+    @Pattern(regexp = "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$")
+    @Schema(name = "Amount", description = "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Amount")
+    public String getAmount() {
+        return amount;
+    }
+
+    public void setAmount(String amount) {
+        this.amount = amount;
+    }
+
+    public OBFundsConfirmation1DataInstructedAmount currency(String currency) {
+        this.currency = currency;
+        return this;
+    }
+
+    /**
+     * A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".
+     *
+     * @return currency
+     */
+    @NotNull
+    @Pattern(regexp = "^[A-Z]{3,3}$")
+    @Schema(name = "Currency", description = "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmation1DataInstructedAmount obFundsConfirmation1DataInstructedAmount = (OBFundsConfirmation1DataInstructedAmount) o;
+        return Objects.equals(this.amount, obFundsConfirmation1DataInstructedAmount.amount) &&
+                Objects.equals(this.currency, obFundsConfirmation1DataInstructedAmount.currency);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(amount, currency);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmation1DataInstructedAmount {\n");
+        sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+        sb.append("    currency: ").append(toIndentedString(currency)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OBFundsConfirmationConsent1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationConsent1 {
+
+    private OBFundsConfirmationConsent1Data data;
+
+    public OBFundsConfirmationConsent1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationConsent1(OBFundsConfirmationConsent1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmationConsent1 data(OBFundsConfirmationConsent1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBFundsConfirmationConsent1Data getData() {
+        return data;
+    }
+
+    public void setData(OBFundsConfirmationConsent1Data data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationConsent1 obFundsConfirmationConsent1 = (OBFundsConfirmationConsent1) o;
+        return Objects.equals(this.data, obFundsConfirmationConsent1.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationConsent1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1Data.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OBFundsConfirmationConsent1Data
+ */
+
+@JsonTypeName("OBFundsConfirmationConsent1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationConsent1Data {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime expirationDateTime;
+
+    private OBFundsConfirmationConsent1DataDebtorAccount debtorAccount;
+
+    public OBFundsConfirmationConsent1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationConsent1Data(OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.debtorAccount = debtorAccount;
+    }
+
+    public OBFundsConfirmationConsent1Data expirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+        return this;
+    }
+
+    /**
+     * Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return expirationDateTime
+     */
+    @Valid
+    @Schema(name = "ExpirationDateTime", description = "Specified date and time the funds confirmation authorisation will expire.  If this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ExpirationDateTime")
+    public DateTime getExpirationDateTime() {
+        return expirationDateTime;
+    }
+
+    public void setExpirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public OBFundsConfirmationConsent1Data debtorAccount(OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.debtorAccount = debtorAccount;
+        return this;
+    }
+
+    /**
+     * Get debtorAccount
+     *
+     * @return debtorAccount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("DebtorAccount")
+    public OBFundsConfirmationConsent1DataDebtorAccount getDebtorAccount() {
+        return debtorAccount;
+    }
+
+    public void setDebtorAccount(OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.debtorAccount = debtorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationConsent1Data obFundsConfirmationConsent1Data = (OBFundsConfirmationConsent1Data) o;
+        return Objects.equals(this.expirationDateTime, obFundsConfirmationConsent1Data.expirationDateTime) &&
+                Objects.equals(this.debtorAccount, obFundsConfirmationConsent1Data.debtorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expirationDateTime, debtorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationConsent1Data {\n");
+        sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
+        sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
+ */
+
+@Schema(name = "OBFundsConfirmationConsent1_Data_DebtorAccount", description = "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.")
+@JsonTypeName("OBFundsConfirmationConsent1_Data_DebtorAccount")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationConsent1DataDebtorAccount {
+
+    private String schemeName;
+
+    private String identification;
+
+    private String name;
+
+    private String secondaryIdentification;
+
+    private OBProxy1 proxy;
+
+    public OBFundsConfirmationConsent1DataDebtorAccount() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationConsent1DataDebtorAccount(String schemeName, String identification) {
+        this.schemeName = schemeName;
+        this.identification = identification;
+    }
+
+    public OBFundsConfirmationConsent1DataDebtorAccount schemeName(String schemeName) {
+        this.schemeName = schemeName;
+        return this;
+    }
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list.
+     *
+     * @return schemeName
+     */
+    @NotNull
+    @Schema(name = "SchemeName", description = "Name of the identification scheme, in a coded form as published in an external list.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("SchemeName")
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public OBFundsConfirmationConsent1DataDebtorAccount identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification assigned by an institution to identify an account. This identification is known by the account owner.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 256)
+    @Schema(name = "Identification", description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBFundsConfirmationConsent1DataDebtorAccount name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+     *
+     * @return name
+     */
+    @Size(min = 1, max = 350)
+    @Schema(name = "Name", description = "Name of the account, as assigned by the account servicing institution. Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Name")
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public OBFundsConfirmationConsent1DataDebtorAccount secondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+        return this;
+    }
+
+    /**
+     * This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+     *
+     * @return secondaryIdentification
+     */
+    @Size(min = 1, max = 34)
+    @Schema(name = "SecondaryIdentification", description = "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("SecondaryIdentification")
+    public String getSecondaryIdentification() {
+        return secondaryIdentification;
+    }
+
+    public void setSecondaryIdentification(String secondaryIdentification) {
+        this.secondaryIdentification = secondaryIdentification;
+    }
+
+    public OBFundsConfirmationConsent1DataDebtorAccount proxy(OBProxy1 proxy) {
+        this.proxy = proxy;
+        return this;
+    }
+
+    /**
+     * Get proxy
+     *
+     * @return proxy
+     */
+    @Valid
+    @Schema(name = "Proxy", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Proxy")
+    public OBProxy1 getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(OBProxy1 proxy) {
+        this.proxy = proxy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationConsent1DataDebtorAccount obFundsConfirmationConsent1DataDebtorAccount = (OBFundsConfirmationConsent1DataDebtorAccount) o;
+        return Objects.equals(this.schemeName, obFundsConfirmationConsent1DataDebtorAccount.schemeName) &&
+                Objects.equals(this.identification, obFundsConfirmationConsent1DataDebtorAccount.identification) &&
+                Objects.equals(this.name, obFundsConfirmationConsent1DataDebtorAccount.name) &&
+                Objects.equals(this.secondaryIdentification, obFundsConfirmationConsent1DataDebtorAccount.secondaryIdentification) &&
+                Objects.equals(this.proxy, obFundsConfirmationConsent1DataDebtorAccount.proxy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemeName, identification, name, secondaryIdentification, proxy);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationConsent1DataDebtorAccount {\n");
+        sb.append("    schemeName: ").append(toIndentedString(schemeName)).append("\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
+        sb.append("    secondaryIdentification: ").append(toIndentedString(secondaryIdentification)).append("\n");
+        sb.append("    proxy: ").append(toIndentedString(proxy)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+
+/**
+ * OBFundsConfirmationConsentResponse1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationConsentResponse1 {
+
+    private OBFundsConfirmationConsentResponse1Data data;
+
+    private Links links;
+
+    private Meta meta;
+
+    public OBFundsConfirmationConsentResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationConsentResponse1(OBFundsConfirmationConsentResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmationConsentResponse1 data(OBFundsConfirmationConsentResponse1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBFundsConfirmationConsentResponse1Data getData() {
+        return data;
+    }
+
+    public void setData(OBFundsConfirmationConsentResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmationConsentResponse1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBFundsConfirmationConsentResponse1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationConsentResponse1 obFundsConfirmationConsentResponse1 = (OBFundsConfirmationConsentResponse1) o;
+        return Objects.equals(this.data, obFundsConfirmationConsentResponse1.data) &&
+                Objects.equals(this.links, obFundsConfirmationConsentResponse1.links) &&
+                Objects.equals(this.meta, obFundsConfirmationConsentResponse1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationConsentResponse1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1Data.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBFundsConfirmationConsentResponse1Data
+ */
+
+@JsonTypeName("OBFundsConfirmationConsentResponse1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationConsentResponse1Data {
+
+    private String consentId;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
+
+    private OBFundsConfirmationConsentStatus status;
+
+    @Valid
+    private List<@Valid OBStatusReason> statusReason;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime statusUpdateDateTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime expirationDateTime;
+
+    private OBFundsConfirmationConsent1DataDebtorAccount debtorAccount;
+
+    public OBFundsConfirmationConsentResponse1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationConsentResponse1Data(String consentId, DateTime creationDateTime, OBFundsConfirmationConsentStatus status, DateTime statusUpdateDateTime, OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.consentId = consentId;
+        this.creationDateTime = creationDateTime;
+        this.status = status;
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        this.debtorAccount = debtorAccount;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data consentId(String consentId) {
+        this.consentId = consentId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned to identify the funds confirmation consent resource.
+     *
+     * @return consentId
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "ConsentId", description = "Unique identification as assigned to identify the funds confirmation consent resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ConsentId")
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data status(OBFundsConfirmationConsentStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return status
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Status")
+    public OBFundsConfirmationConsentStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OBFundsConfirmationConsentStatus status) {
+        this.status = status;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data statusReason(List<@Valid OBStatusReason> statusReason) {
+        this.statusReason = statusReason;
+        return this;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data addStatusReasonItem(OBStatusReason statusReasonItem) {
+        if (this.statusReason == null) {
+            this.statusReason = new ArrayList<>();
+        }
+        this.statusReason.add(statusReasonItem);
+        return this;
+    }
+
+    /**
+     * Get statusReason
+     *
+     * @return statusReason
+     */
+    @Valid
+    @Schema(name = "StatusReason", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusReason")
+    public List<@Valid OBStatusReason> getStatusReason() {
+        return statusReason;
+    }
+
+    public void setStatusReason(List<@Valid OBStatusReason> statusReason) {
+        this.statusReason = statusReason;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data statusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return statusUpdateDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "StatusUpdateDateTime", description = "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("StatusUpdateDateTime")
+    public DateTime getStatusUpdateDateTime() {
+        return statusUpdateDateTime;
+    }
+
+    public void setStatusUpdateDateTime(DateTime statusUpdateDateTime) {
+        this.statusUpdateDateTime = statusUpdateDateTime;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data expirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+        return this;
+    }
+
+    /**
+     * Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return expirationDateTime
+     */
+    @Valid
+    @Schema(name = "ExpirationDateTime", description = "Specified date and time the funds confirmation authorisation will expire. If this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ExpirationDateTime")
+    public DateTime getExpirationDateTime() {
+        return expirationDateTime;
+    }
+
+    public void setExpirationDateTime(DateTime expirationDateTime) {
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public OBFundsConfirmationConsentResponse1Data debtorAccount(OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.debtorAccount = debtorAccount;
+        return this;
+    }
+
+    /**
+     * Get debtorAccount
+     *
+     * @return debtorAccount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "DebtorAccount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("DebtorAccount")
+    public OBFundsConfirmationConsent1DataDebtorAccount getDebtorAccount() {
+        return debtorAccount;
+    }
+
+    public void setDebtorAccount(OBFundsConfirmationConsent1DataDebtorAccount debtorAccount) {
+        this.debtorAccount = debtorAccount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationConsentResponse1Data obFundsConfirmationConsentResponse1Data = (OBFundsConfirmationConsentResponse1Data) o;
+        return Objects.equals(this.consentId, obFundsConfirmationConsentResponse1Data.consentId) &&
+                Objects.equals(this.creationDateTime, obFundsConfirmationConsentResponse1Data.creationDateTime) &&
+                Objects.equals(this.status, obFundsConfirmationConsentResponse1Data.status) &&
+                Objects.equals(this.statusReason, obFundsConfirmationConsentResponse1Data.statusReason) &&
+                Objects.equals(this.statusUpdateDateTime, obFundsConfirmationConsentResponse1Data.statusUpdateDateTime) &&
+                Objects.equals(this.expirationDateTime, obFundsConfirmationConsentResponse1Data.expirationDateTime) &&
+                Objects.equals(this.debtorAccount, obFundsConfirmationConsentResponse1Data.debtorAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(consentId, creationDateTime, status, statusReason, statusUpdateDateTime, expirationDateTime, debtorAccount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationConsentResponse1Data {\n");
+        sb.append("    consentId: ").append(toIndentedString(consentId)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
+        sb.append("    statusReason: ").append(toIndentedString(statusReason)).append("\n");
+        sb.append("    statusUpdateDateTime: ").append(toIndentedString(statusUpdateDateTime)).append("\n");
+        sb.append("    expirationDateTime: ").append(toIndentedString(expirationDateTime)).append("\n");
+        sb.append("    debtorAccount: ").append(toIndentedString(debtorAccount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentStatus.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import jakarta.annotation.Generated;
+
+/**
+ * Specifies the status of consent resource in code form.
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public enum OBFundsConfirmationConsentStatus {
+
+    AWAU("AWAU"),
+
+    RJCT("RJCT"),
+
+    AUTH("AUTH");
+
+    private String value;
+
+    OBFundsConfirmationConsentStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBFundsConfirmationConsentStatus fromValue(String value) {
+        for (OBFundsConfirmationConsentStatus b : OBFundsConfirmationConsentStatus.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+
+/**
+ * OBFundsConfirmationResponse1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationResponse1 {
+
+    private OBFundsConfirmationResponse1Data data;
+
+    private Links links;
+
+    private Meta meta;
+
+    public OBFundsConfirmationResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationResponse1(OBFundsConfirmationResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmationResponse1 data(OBFundsConfirmationResponse1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBFundsConfirmationResponse1Data getData() {
+        return data;
+    }
+
+    public void setData(OBFundsConfirmationResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBFundsConfirmationResponse1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBFundsConfirmationResponse1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationResponse1 obFundsConfirmationResponse1 = (OBFundsConfirmationResponse1) o;
+        return Objects.equals(this.data, obFundsConfirmationResponse1.data) &&
+                Objects.equals(this.links, obFundsConfirmationResponse1.links) &&
+                Objects.equals(this.meta, obFundsConfirmationResponse1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationResponse1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1Data.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBFundsConfirmationResponse1Data
+ */
+
+@JsonTypeName("OBFundsConfirmationResponse1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBFundsConfirmationResponse1Data {
+
+    private String fundsConfirmationId;
+
+    private String consentId;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private DateTime creationDateTime;
+
+    private Boolean fundsAvailable;
+
+    private String reference;
+
+    private OBFundsConfirmation1DataInstructedAmount instructedAmount;
+
+    public OBFundsConfirmationResponse1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBFundsConfirmationResponse1Data(String fundsConfirmationId, String consentId, DateTime creationDateTime, Boolean fundsAvailable, String reference, OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.fundsConfirmationId = fundsConfirmationId;
+        this.consentId = consentId;
+        this.creationDateTime = creationDateTime;
+        this.fundsAvailable = fundsAvailable;
+        this.reference = reference;
+        this.instructedAmount = instructedAmount;
+    }
+
+    public OBFundsConfirmationResponse1Data fundsConfirmationId(String fundsConfirmationId) {
+        this.fundsConfirmationId = fundsConfirmationId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource.
+     *
+     * @return fundsConfirmationId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "FundsConfirmationId", description = "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FundsConfirmationId")
+    public String getFundsConfirmationId() {
+        return fundsConfirmationId;
+    }
+
+    public void setFundsConfirmationId(String fundsConfirmationId) {
+        this.fundsConfirmationId = fundsConfirmationId;
+    }
+
+    public OBFundsConfirmationResponse1Data consentId(String consentId) {
+        this.consentId = consentId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+     *
+     * @return consentId
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "ConsentId", description = "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("ConsentId")
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public OBFundsConfirmationResponse1Data creationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+        return this;
+    }
+
+    /**
+     * Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00
+     *
+     * @return creationDateTime
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "CreationDateTime", description = "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format.  All date-time fields in responses must include the timezone. An example is below: 2017-04-05T10:43:07+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("CreationDateTime")
+    public DateTime getCreationDateTime() {
+        return creationDateTime;
+    }
+
+    public void setCreationDateTime(DateTime creationDateTime) {
+        this.creationDateTime = creationDateTime;
+    }
+
+    public OBFundsConfirmationResponse1Data fundsAvailable(Boolean fundsAvailable) {
+        this.fundsAvailable = fundsAvailable;
+        return this;
+    }
+
+    /**
+     * Flag to indicate the result of a confirmation of funds check.
+     *
+     * @return fundsAvailable
+     */
+    @NotNull
+    @Schema(name = "FundsAvailable", description = "Flag to indicate the result of a confirmation of funds check.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("FundsAvailable")
+    public Boolean getFundsAvailable() {
+        return fundsAvailable;
+    }
+
+    public void setFundsAvailable(Boolean fundsAvailable) {
+        this.fundsAvailable = fundsAvailable;
+    }
+
+    public OBFundsConfirmationResponse1Data reference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    /**
+     * Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
+     *
+     * @return reference
+     */
+    @NotNull
+    @Size(min = 1, max = 35)
+    @Schema(name = "Reference", description = "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Reference")
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public OBFundsConfirmationResponse1Data instructedAmount(OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+        return this;
+    }
+
+    /**
+     * Get instructedAmount
+     *
+     * @return instructedAmount
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "InstructedAmount", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("InstructedAmount")
+    public OBFundsConfirmation1DataInstructedAmount getInstructedAmount() {
+        return instructedAmount;
+    }
+
+    public void setInstructedAmount(OBFundsConfirmation1DataInstructedAmount instructedAmount) {
+        this.instructedAmount = instructedAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBFundsConfirmationResponse1Data obFundsConfirmationResponse1Data = (OBFundsConfirmationResponse1Data) o;
+        return Objects.equals(this.fundsConfirmationId, obFundsConfirmationResponse1Data.fundsConfirmationId) &&
+                Objects.equals(this.consentId, obFundsConfirmationResponse1Data.consentId) &&
+                Objects.equals(this.creationDateTime, obFundsConfirmationResponse1Data.creationDateTime) &&
+                Objects.equals(this.fundsAvailable, obFundsConfirmationResponse1Data.fundsAvailable) &&
+                Objects.equals(this.reference, obFundsConfirmationResponse1Data.reference) &&
+                Objects.equals(this.instructedAmount, obFundsConfirmationResponse1Data.instructedAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fundsConfirmationId, consentId, creationDateTime, fundsAvailable, reference, instructedAmount);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBFundsConfirmationResponse1Data {\n");
+        sb.append("    fundsConfirmationId: ").append(toIndentedString(fundsConfirmationId)).append("\n");
+        sb.append("    consentId: ").append(toIndentedString(consentId)).append("\n");
+        sb.append("    creationDateTime: ").append(toIndentedString(creationDateTime)).append("\n");
+        sb.append("    fundsAvailable: ").append(toIndentedString(fundsAvailable)).append("\n");
+        sb.append("    reference: ").append(toIndentedString(reference)).append("\n");
+        sb.append("    instructedAmount: ").append(toIndentedString(instructedAmount)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBProxy1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBProxy1.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import uk.org.openbanking.datamodel.v4.common.ExternalProxyAccountType1Code;
+
+/**
+ * Specifies an alternate assumed name for the identification of the account.
+ */
+
+@Schema(name = "OBProxy1", description = "Specifies an alternate assumed name for the identification of the account.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBProxy1 {
+
+    private String identification;
+
+    private ExternalProxyAccountType1Code code;
+
+    private String type;
+
+    public OBProxy1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBProxy1(String identification, ExternalProxyAccountType1Code code) {
+        this.identification = identification;
+        this.code = code;
+    }
+
+    public OBProxy1 identification(String identification) {
+        this.identification = identification;
+        return this;
+    }
+
+    /**
+     * Identification used to indicate the account identification under another specified name.
+     *
+     * @return identification
+     */
+    @NotNull
+    @Size(min = 1, max = 2048)
+    @Schema(name = "Identification", description = "Identification used to indicate the account identification under another specified name.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Identification")
+    public String getIdentification() {
+        return identification;
+    }
+
+    public void setIdentification(String identification) {
+        this.identification = identification;
+    }
+
+    public OBProxy1 code(ExternalProxyAccountType1Code code) {
+        this.code = code;
+        return this;
+    }
+
+    /**
+     * Get code
+     *
+     * @return code
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Code", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Code")
+    public ExternalProxyAccountType1Code getCode() {
+        return code;
+    }
+
+    public void setCode(ExternalProxyAccountType1Code code) {
+        this.code = code;
+    }
+
+    public OBProxy1 type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Type of the proxy identification.
+     *
+     * @return type
+     */
+    @Size(min = 1, max = 35)
+    @Schema(name = "Type", description = "Type of the proxy identification.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBProxy1 obProxy1 = (OBProxy1) o;
+        return Objects.equals(this.identification, obProxy1.identification) &&
+                Objects.equals(this.code, obProxy1.code) &&
+                Objects.equals(this.type, obProxy1.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identification, code, type);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBProxy1 {\n");
+        sb.append("    identification: ").append(toIndentedString(identification)).append("\n");
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBStatusReason.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.fund;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBStatusReason
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBStatusReason {
+
+    private String statusReasonCode;
+
+    private String statusReasonDescription;
+
+    private String path;
+
+    public OBStatusReason statusReasonCode(String statusReasonCode) {
+        this.statusReasonCode = statusReasonCode;
+        return this;
+    }
+
+    /**
+     * Specifies the status reason in a code form.   For a full description see `OBExternalStatusReason1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+     *
+     * @return statusReasonCode
+     */
+    @Size(min = 1, max = 4)
+    @Schema(name = "StatusReasonCode", example = "ERIN", description = "Specifies the status reason in a code form.   For a full description see `OBExternalStatusReason1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusReasonCode")
+    public String getStatusReasonCode() {
+        return statusReasonCode;
+    }
+
+    public void setStatusReasonCode(String statusReasonCode) {
+        this.statusReasonCode = statusReasonCode;
+    }
+
+    public OBStatusReason statusReasonDescription(String statusReasonDescription) {
+        this.statusReasonDescription = statusReasonDescription;
+        return this;
+    }
+
+    /**
+     * Description supporting the StatusReasonCode.
+     *
+     * @return statusReasonDescription
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "StatusReasonDescription", description = "Description supporting the StatusReasonCode.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("StatusReasonDescription")
+    public String getStatusReasonDescription() {
+        return statusReasonDescription;
+    }
+
+    public void setStatusReasonDescription(String statusReasonDescription) {
+        this.statusReasonDescription = statusReasonDescription;
+    }
+
+    public OBStatusReason path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency
+     *
+     * @return path
+     */
+    @Size(min = 1, max = 500)
+    @Schema(name = "Path", description = "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Path")
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBStatusReason obStatusReason = (OBStatusReason) o;
+        return Objects.equals(this.statusReasonCode, obStatusReason.statusReasonCode) &&
+                Objects.equals(this.statusReasonDescription, obStatusReason.statusReasonDescription) &&
+                Objects.equals(this.path, obStatusReason.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statusReasonCode, statusReasonDescription, path);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBStatusReason {\n");
+        sb.append("    statusReasonCode: ").append(toIndentedString(statusReasonCode)).append("\n");
+        sb.append("    statusReasonDescription: ").append(toIndentedString(statusReasonDescription)).append("\n");
+        sb.append("    path: ").append(toIndentedString(path)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/confirmation-funds-openapi.yaml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/confirmation-funds-openapi.yaml
@@ -207,10 +207,6 @@ components:
           ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
           (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}
           \d{2}:\d{2}:\d{2} (GMT|UTC)$
-        pattern: >-
-          ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
-          (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}
-          \d{2}:\d{2}:\d{2} (GMT|UTC)$
     x-fapi-interaction-id:
       in: header
       name: x-fapi-interaction-id


### PR DESCRIPTION
Code generated from confirmation-funds-openapi.yaml using OB v4 schema into pkg: uk.org.openbanking.datamodel.v4.fund

Adjusted code gen config to create OBFundsConfirmationConsentStatus as a top-level class rather than having it nested.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440