### PR TITLE
1440: Add v4 events data model

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -160,12 +160,12 @@
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/payment-initiation-openapi.yaml</inputSpec>-->
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi-3.1.9r7.yaml</inputSpec>-->
                                     <inputSpec>
-                                        ${project.basedir}/src/main/resources/specification/4.0.0/vrp-openapi.yaml
+                                        ${project.basedir}/src/main/resources/specification/4.0.0/event-notifications-openapi.yaml
                                     </inputSpec>
                                     <output>${project.build.directory}/generated-sources/swagger</output>
                                     <generatorName>spring</generatorName>
                                     <!-- Change the package here as per the chosen spec above -->
-                                    <modelPackage>uk.org.openbanking.datamodel.v4.vrp</modelPackage>
+                                    <modelPackage>uk.org.openbanking.datamodel.v4.event</modelPackage>
                                     <generateApis>false</generateApis>
                                     <!-- Override the default name for inline schemas
                                          This should be used when we want to give complex inner schema names a more

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEvent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEvent1.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Events.
+ */
+
+@Schema(name = "OBEvent1", description = "Events.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEvent1 {
+
+    private OBEventResourceUpdate1 urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate;
+
+    public OBEvent1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEvent1(OBEventResourceUpdate1 urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate) {
+        this.urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate = urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate;
+    }
+
+    public OBEvent1 urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate(OBEventResourceUpdate1 urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate) {
+        this.urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate = urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate;
+        return this;
+    }
+
+    /**
+     * Get urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate
+     *
+     * @return urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "urn:uk:org:openbanking:events:resource-update", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("urn:uk:org:openbanking:events:resource-update")
+    public OBEventResourceUpdate1 getUrnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate() {
+        return urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate;
+    }
+
+    public void setUrnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate(OBEventResourceUpdate1 urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate) {
+        this.urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate = urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEvent1 obEvent1 = (OBEvent1) o;
+        return Objects.equals(this.urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate, obEvent1.urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEvent1 {\n");
+        sb.append("    urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate: ").append(toIndentedString(urnColonUkColonOrgColonOpenbankingColonEventsColonResourceUpdate)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventLink1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventLink1.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Resource links to other available versions of the resource.
+ */
+
+@Schema(name = "OBEventLink1", description = "Resource links to other available versions of the resource.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventLink1 {
+
+    private String version;
+
+    private String link;
+
+    public OBEventLink1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventLink1(String version, String link) {
+        this.version = version;
+        this.link = link;
+    }
+
+    public OBEventLink1 version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Resource version.
+     *
+     * @return version
+     */
+    @NotNull
+    @Size(min = 1, max = 10)
+    @Schema(name = "version", description = "Resource version.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public OBEventLink1 link(String link) {
+        this.link = link;
+        return this;
+    }
+
+    /**
+     * Resource link.
+     *
+     * @return link
+     */
+    @NotNull
+    @Schema(name = "link", description = "Resource link.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("link")
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventLink1 obEventLink1 = (OBEventLink1) o;
+        return Objects.equals(this.version, obEventLink1.version) &&
+                Objects.equals(this.link, obEventLink1.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, link);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventLink1 {\n");
+        sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("    link: ").append(toIndentedString(link)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventNotification1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventNotification1.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.net.URI;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * The resource-update event.
+ */
+
+@Schema(name = "OBEventNotification1", description = "The resource-update event.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventNotification1 {
+
+    private String iss;
+
+    private Integer iat;
+
+    private String jti;
+
+    private String aud;
+
+    private URI sub;
+
+    private String txn;
+
+    private Integer toe;
+
+    private OBEvent1 events;
+
+    public OBEventNotification1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventNotification1(String iss, Integer iat, String jti, String aud, URI sub, String txn, Integer toe, OBEvent1 events) {
+        this.iss = iss;
+        this.iat = iat;
+        this.jti = jti;
+        this.aud = aud;
+        this.sub = sub;
+        this.txn = txn;
+        this.toe = toe;
+        this.events = events;
+    }
+
+    public OBEventNotification1 iss(String iss) {
+        this.iss = iss;
+        return this;
+    }
+
+    /**
+     * Issuer.
+     *
+     * @return iss
+     */
+    @NotNull
+    @Schema(name = "iss", description = "Issuer.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("iss")
+    public String getIss() {
+        return iss;
+    }
+
+    public void setIss(String iss) {
+        this.iss = iss;
+    }
+
+    public OBEventNotification1 iat(Integer iat) {
+        this.iat = iat;
+        return this;
+    }
+
+    /**
+     * Issued At.
+     * minimum: 0
+     *
+     * @return iat
+     */
+    @NotNull
+    @Min(0)
+    @Schema(name = "iat", description = "Issued At. ", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("iat")
+    public Integer getIat() {
+        return iat;
+    }
+
+    public void setIat(Integer iat) {
+        this.iat = iat;
+    }
+
+    public OBEventNotification1 jti(String jti) {
+        this.jti = jti;
+        return this;
+    }
+
+    /**
+     * JWT ID.
+     *
+     * @return jti
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "jti", description = "JWT ID.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("jti")
+    public String getJti() {
+        return jti;
+    }
+
+    public void setJti(String jti) {
+        this.jti = jti;
+    }
+
+    public OBEventNotification1 aud(String aud) {
+        this.aud = aud;
+        return this;
+    }
+
+    /**
+     * Audience.
+     *
+     * @return aud
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "aud", description = "Audience.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("aud")
+    public String getAud() {
+        return aud;
+    }
+
+    public void setAud(String aud) {
+        this.aud = aud;
+    }
+
+    public OBEventNotification1 sub(URI sub) {
+        this.sub = sub;
+        return this;
+    }
+
+    /**
+     * Subject
+     *
+     * @return sub
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "sub", description = "Subject", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("sub")
+    public URI getSub() {
+        return sub;
+    }
+
+    public void setSub(URI sub) {
+        this.sub = sub;
+    }
+
+    public OBEventNotification1 txn(String txn) {
+        this.txn = txn;
+        return this;
+    }
+
+    /**
+     * Transaction Identifier.
+     *
+     * @return txn
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "txn", description = "Transaction Identifier.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("txn")
+    public String getTxn() {
+        return txn;
+    }
+
+    public void setTxn(String txn) {
+        this.txn = txn;
+    }
+
+    public OBEventNotification1 toe(Integer toe) {
+        this.toe = toe;
+        return this;
+    }
+
+    /**
+     * Time of Event.
+     * minimum: 0
+     *
+     * @return toe
+     */
+    @NotNull
+    @Min(0)
+    @Schema(name = "toe", description = "Time of Event.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("toe")
+    public Integer getToe() {
+        return toe;
+    }
+
+    public void setToe(Integer toe) {
+        this.toe = toe;
+    }
+
+    public OBEventNotification1 events(OBEvent1 events) {
+        this.events = events;
+        return this;
+    }
+
+    /**
+     * Get events
+     *
+     * @return events
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "events", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("events")
+    public OBEvent1 getEvents() {
+        return events;
+    }
+
+    public void setEvents(OBEvent1 events) {
+        this.events = events;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventNotification1 obEventNotification1 = (OBEventNotification1) o;
+        return Objects.equals(this.iss, obEventNotification1.iss) &&
+                Objects.equals(this.iat, obEventNotification1.iat) &&
+                Objects.equals(this.jti, obEventNotification1.jti) &&
+                Objects.equals(this.aud, obEventNotification1.aud) &&
+                Objects.equals(this.sub, obEventNotification1.sub) &&
+                Objects.equals(this.txn, obEventNotification1.txn) &&
+                Objects.equals(this.toe, obEventNotification1.toe) &&
+                Objects.equals(this.events, obEventNotification1.events);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(iss, iat, jti, aud, sub, txn, toe, events);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventNotification1 {\n");
+        sb.append("    iss: ").append(toIndentedString(iss)).append("\n");
+        sb.append("    iat: ").append(toIndentedString(iat)).append("\n");
+        sb.append("    jti: ").append(toIndentedString(jti)).append("\n");
+        sb.append("    aud: ").append(toIndentedString(aud)).append("\n");
+        sb.append("    sub: ").append(toIndentedString(sub)).append("\n");
+        sb.append("    txn: ").append(toIndentedString(txn)).append("\n");
+        sb.append("    toe: ").append(toIndentedString(toe)).append("\n");
+        sb.append("    events: ").append(toIndentedString(events)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBEventPolling1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventPolling1 {
+
+    private Integer maxEvents;
+
+    private Boolean returnImmediately;
+
+    @Valid
+    private List<@Size(min = 1, max = 128) String> ack;
+
+    @Valid
+    private Map<String, OBEventPolling1SetErrsValue> setErrs = new HashMap<>();
+
+    public OBEventPolling1 maxEvents(Integer maxEvents) {
+        this.maxEvents = maxEvents;
+        return this;
+    }
+
+    /**
+     * Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available
+     *
+     * @return maxEvents
+     */
+
+    @Schema(name = "maxEvents", description = "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("maxEvents")
+    public Integer getMaxEvents() {
+        return maxEvents;
+    }
+
+    public void setMaxEvents(Integer maxEvents) {
+        this.maxEvents = maxEvents;
+    }
+
+    public OBEventPolling1 returnImmediately(Boolean returnImmediately) {
+        this.returnImmediately = returnImmediately;
+        return this;
+    }
+
+    /**
+     * Indicates whether an ASPSP should return a response immediately or provide a long poll
+     *
+     * @return returnImmediately
+     */
+
+    @Schema(name = "returnImmediately", description = "Indicates whether an ASPSP should return a response immediately or provide a long poll", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("returnImmediately")
+    public Boolean getReturnImmediately() {
+        return returnImmediately;
+    }
+
+    public void setReturnImmediately(Boolean returnImmediately) {
+        this.returnImmediately = returnImmediately;
+    }
+
+    public OBEventPolling1 ack(List<@Size(min = 1, max = 128) String> ack) {
+        this.ack = ack;
+        return this;
+    }
+
+    public OBEventPolling1 addAckItem(String ackItem) {
+        if (this.ack == null) {
+            this.ack = new ArrayList<>();
+        }
+        this.ack.add(ackItem);
+        return this;
+    }
+
+    /**
+     * Get ack
+     *
+     * @return ack
+     */
+
+    @Schema(name = "ack", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("ack")
+    public List<@Size(min = 1, max = 128) String> getAck() {
+        return ack;
+    }
+
+    public void setAck(List<@Size(min = 1, max = 128) String> ack) {
+        this.ack = ack;
+    }
+
+    public OBEventPolling1 setErrs(Map<String, OBEventPolling1SetErrsValue> setErrs) {
+        this.setErrs = setErrs;
+        return this;
+    }
+
+    public OBEventPolling1 putSetErrsItem(String key, OBEventPolling1SetErrsValue setErrsItem) {
+        if (this.setErrs == null) {
+            this.setErrs = new HashMap<>();
+        }
+        this.setErrs.put(key, setErrsItem);
+        return this;
+    }
+
+    /**
+     * An object that encapsulates all negative acknowledgements transmitted by the TPP
+     *
+     * @return setErrs
+     */
+    @Valid
+    @Schema(name = "setErrs", description = "An object that encapsulates all negative acknowledgements transmitted by the TPP", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("setErrs")
+    public Map<String, OBEventPolling1SetErrsValue> getSetErrs() {
+        return setErrs;
+    }
+
+    public void setSetErrs(Map<String, OBEventPolling1SetErrsValue> setErrs) {
+        this.setErrs = setErrs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventPolling1 obEventPolling1 = (OBEventPolling1) o;
+        return Objects.equals(this.maxEvents, obEventPolling1.maxEvents) &&
+                Objects.equals(this.returnImmediately, obEventPolling1.returnImmediately) &&
+                Objects.equals(this.ack, obEventPolling1.ack) &&
+                Objects.equals(this.setErrs, obEventPolling1.setErrs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(maxEvents, returnImmediately, ack, setErrs);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventPolling1 {\n");
+        sb.append("    maxEvents: ").append(toIndentedString(maxEvents)).append("\n");
+        sb.append("    returnImmediately: ").append(toIndentedString(returnImmediately)).append("\n");
+        sb.append("    ack: ").append(toIndentedString(ack)).append("\n");
+        sb.append("    setErrs: ").append(toIndentedString(setErrs)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1SetErrsValue.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1SetErrsValue.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBEventPolling1SetErrsValue
+ */
+
+@JsonTypeName("OBEventPolling1_setErrs_value")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventPolling1SetErrsValue {
+
+    private String err;
+
+    private String description;
+
+    public OBEventPolling1SetErrsValue() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventPolling1SetErrsValue(String err, String description) {
+        this.err = err;
+        this.description = description;
+    }
+
+    public OBEventPolling1SetErrsValue err(String err) {
+        this.err = err;
+        return this;
+    }
+
+    /**
+     * A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes
+     *
+     * @return err
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "err", description = "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here  https://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("err")
+    public String getErr() {
+        return err;
+    }
+
+    public void setErr(String err) {
+        this.err = err;
+    }
+
+    public OBEventPolling1SetErrsValue description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * A human-readable string that provides additional diagnostic information
+     *
+     * @return description
+     */
+    @NotNull
+    @Size(min = 1, max = 256)
+    @Schema(name = "description", description = "A human-readable string that provides additional diagnostic information", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventPolling1SetErrsValue obEventPolling1SetErrsValue = (OBEventPolling1SetErrsValue) o;
+        return Objects.equals(this.err, obEventPolling1SetErrsValue.err) &&
+                Objects.equals(this.description, obEventPolling1SetErrsValue.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(err, description);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventPolling1SetErrsValue {\n");
+        sb.append("    err: ").append(toIndentedString(err)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPollingResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPollingResponse1.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OBEventPollingResponse1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventPollingResponse1 {
+
+    private Boolean moreAvailable;
+
+    @Valid
+    private Map<String, String> sets = new HashMap<>();
+
+    public OBEventPollingResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventPollingResponse1(Boolean moreAvailable, Map<String, String> sets) {
+        this.moreAvailable = moreAvailable;
+        this.sets = sets;
+    }
+
+    public OBEventPollingResponse1 moreAvailable(Boolean moreAvailable) {
+        this.moreAvailable = moreAvailable;
+        return this;
+    }
+
+    /**
+     * A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned.
+     *
+     * @return moreAvailable
+     */
+    @NotNull
+    @Schema(name = "moreAvailable", description = "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("moreAvailable")
+    public Boolean getMoreAvailable() {
+        return moreAvailable;
+    }
+
+    public void setMoreAvailable(Boolean moreAvailable) {
+        this.moreAvailable = moreAvailable;
+    }
+
+    public OBEventPollingResponse1 sets(Map<String, String> sets) {
+        this.sets = sets;
+        return this;
+    }
+
+    public OBEventPollingResponse1 putSetsItem(String key, String setsItem) {
+        if (this.sets == null) {
+            this.sets = new HashMap<>();
+        }
+        this.sets.put(key, setsItem);
+        return this;
+    }
+
+    /**
+     * A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.
+     *
+     * @return sets
+     */
+    @NotNull
+    @Schema(name = "sets", description = "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("sets")
+    public Map<String, String> getSets() {
+        return sets;
+    }
+
+    public void setSets(Map<String, String> sets) {
+        this.sets = sets;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventPollingResponse1 obEventPollingResponse1 = (OBEventPollingResponse1) o;
+        return Objects.equals(this.moreAvailable, obEventPollingResponse1.moreAvailable) &&
+                Objects.equals(this.sets, obEventPollingResponse1.sets);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(moreAvailable, sets);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventPollingResponse1 {\n");
+        sb.append("    moreAvailable: ").append(toIndentedString(moreAvailable)).append("\n");
+        sb.append("    sets: ").append(toIndentedString(sets)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventResourceUpdate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventResourceUpdate1.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Resource-Update Event.
+ */
+
+@Schema(name = "OBEventResourceUpdate1", description = "Resource-Update Event.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventResourceUpdate1 {
+
+    private OBEventSubject1 subject;
+
+    public OBEventResourceUpdate1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventResourceUpdate1(OBEventSubject1 subject) {
+        this.subject = subject;
+    }
+
+    public OBEventResourceUpdate1 subject(OBEventSubject1 subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    /**
+     * Get subject
+     *
+     * @return subject
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "subject", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("subject")
+    public OBEventSubject1 getSubject() {
+        return subject;
+    }
+
+    public void setSubject(OBEventSubject1 subject) {
+        this.subject = subject;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventResourceUpdate1 obEventResourceUpdate1 = (OBEventResourceUpdate1) o;
+        return Objects.equals(this.subject, obEventResourceUpdate1.subject);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subject);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventResourceUpdate1 {\n");
+        sb.append("    subject: ").append(toIndentedString(subject)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubject1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubject1.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * The resource-update event.
+ */
+
+@Schema(name = "OBEventSubject1", description = "The resource-update event.")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubject1 {
+
+    private String subjectType;
+
+    private String httpColonOpenbankingOrgUkRid;
+
+    private String httpColonOpenbankingOrgUkRty;
+
+    @Valid
+    private List<@Valid OBEventLink1> httpColonOpenbankingOrgUkRlk = new ArrayList<>();
+
+    public OBEventSubject1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubject1(String subjectType, String httpColonOpenbankingOrgUkRid, String httpColonOpenbankingOrgUkRty, List<@Valid OBEventLink1> httpColonOpenbankingOrgUkRlk) {
+        this.subjectType = subjectType;
+        this.httpColonOpenbankingOrgUkRid = httpColonOpenbankingOrgUkRid;
+        this.httpColonOpenbankingOrgUkRty = httpColonOpenbankingOrgUkRty;
+        this.httpColonOpenbankingOrgUkRlk = httpColonOpenbankingOrgUkRlk;
+    }
+
+    public OBEventSubject1 subjectType(String subjectType) {
+        this.subjectType = subjectType;
+        return this;
+    }
+
+    /**
+     * Subject type for the updated resource.
+     *
+     * @return subjectType
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "subject_type", description = "Subject type for the updated resource. ", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("subject_type")
+    public String getSubjectType() {
+        return subjectType;
+    }
+
+    public void setSubjectType(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    public OBEventSubject1 httpColonOpenbankingOrgUkRid(String httpColonOpenbankingOrgUkRid) {
+        this.httpColonOpenbankingOrgUkRid = httpColonOpenbankingOrgUkRid;
+        return this;
+    }
+
+    /**
+     * Resource Id for the updated resource.
+     *
+     * @return httpColonOpenbankingOrgUkRid
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "http://openbanking.org.uk/rid", description = "Resource Id for the updated resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("http://openbanking.org.uk/rid")
+    public String getHttpColonOpenbankingOrgUkRid() {
+        return httpColonOpenbankingOrgUkRid;
+    }
+
+    public void setHttpColonOpenbankingOrgUkRid(String httpColonOpenbankingOrgUkRid) {
+        this.httpColonOpenbankingOrgUkRid = httpColonOpenbankingOrgUkRid;
+    }
+
+    public OBEventSubject1 httpColonOpenbankingOrgUkRty(String httpColonOpenbankingOrgUkRty) {
+        this.httpColonOpenbankingOrgUkRty = httpColonOpenbankingOrgUkRty;
+        return this;
+    }
+
+    /**
+     * Resource Type for the updated resource.
+     *
+     * @return httpColonOpenbankingOrgUkRty
+     */
+    @NotNull
+    @Size(min = 1, max = 128)
+    @Schema(name = "http://openbanking.org.uk/rty", description = "Resource Type for the updated resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("http://openbanking.org.uk/rty")
+    public String getHttpColonOpenbankingOrgUkRty() {
+        return httpColonOpenbankingOrgUkRty;
+    }
+
+    public void setHttpColonOpenbankingOrgUkRty(String httpColonOpenbankingOrgUkRty) {
+        this.httpColonOpenbankingOrgUkRty = httpColonOpenbankingOrgUkRty;
+    }
+
+    public OBEventSubject1 httpColonOpenbankingOrgUkRlk(List<@Valid OBEventLink1> httpColonOpenbankingOrgUkRlk) {
+        this.httpColonOpenbankingOrgUkRlk = httpColonOpenbankingOrgUkRlk;
+        return this;
+    }
+
+    public OBEventSubject1 addHttpColonOpenbankingOrgUkRlkItem(OBEventLink1 httpColonOpenbankingOrgUkRlkItem) {
+        if (this.httpColonOpenbankingOrgUkRlk == null) {
+            this.httpColonOpenbankingOrgUkRlk = new ArrayList<>();
+        }
+        this.httpColonOpenbankingOrgUkRlk.add(httpColonOpenbankingOrgUkRlkItem);
+        return this;
+    }
+
+    /**
+     * Resource links to other available versions of the resource.
+     *
+     * @return httpColonOpenbankingOrgUkRlk
+     */
+    @NotNull
+    @Valid
+    @Size(min = 1)
+    @Schema(name = "http://openbanking.org.uk/rlk", description = "Resource links to other available versions of the resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("http://openbanking.org.uk/rlk")
+    public List<@Valid OBEventLink1> getHttpColonOpenbankingOrgUkRlk() {
+        return httpColonOpenbankingOrgUkRlk;
+    }
+
+    public void setHttpColonOpenbankingOrgUkRlk(List<@Valid OBEventLink1> httpColonOpenbankingOrgUkRlk) {
+        this.httpColonOpenbankingOrgUkRlk = httpColonOpenbankingOrgUkRlk;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubject1 obEventSubject1 = (OBEventSubject1) o;
+        return Objects.equals(this.subjectType, obEventSubject1.subjectType) &&
+                Objects.equals(this.httpColonOpenbankingOrgUkRid, obEventSubject1.httpColonOpenbankingOrgUkRid) &&
+                Objects.equals(this.httpColonOpenbankingOrgUkRty, obEventSubject1.httpColonOpenbankingOrgUkRty) &&
+                Objects.equals(this.httpColonOpenbankingOrgUkRlk, obEventSubject1.httpColonOpenbankingOrgUkRlk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subjectType, httpColonOpenbankingOrgUkRid, httpColonOpenbankingOrgUkRty, httpColonOpenbankingOrgUkRlk);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubject1 {\n");
+        sb.append("    subjectType: ").append(toIndentedString(subjectType)).append("\n");
+        sb.append("    httpColonOpenbankingOrgUkRid: ").append(toIndentedString(httpColonOpenbankingOrgUkRid)).append("\n");
+        sb.append("    httpColonOpenbankingOrgUkRty: ").append(toIndentedString(httpColonOpenbankingOrgUkRty)).append("\n");
+        sb.append("    httpColonOpenbankingOrgUkRlk: ").append(toIndentedString(httpColonOpenbankingOrgUkRlk)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * OBEventSubscription1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscription1 {
+
+    private OBEventSubscription1Data data;
+
+    public OBEventSubscription1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscription1(OBEventSubscription1Data data) {
+        this.data = data;
+    }
+
+    public OBEventSubscription1 data(OBEventSubscription1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBEventSubscription1Data getData() {
+        return data;
+    }
+
+    public void setData(OBEventSubscription1Data data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscription1 obEventSubscription1 = (OBEventSubscription1) o;
+        return Objects.equals(this.data, obEventSubscription1.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscription1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1Data.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBEventSubscription1Data
+ */
+
+@JsonTypeName("OBEventSubscription1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscription1Data {
+
+    private URI callbackUrl;
+
+    private String version;
+
+    @Valid
+    private List<String> eventTypes;
+
+    public OBEventSubscription1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscription1Data(String version) {
+        this.version = version;
+    }
+
+    public OBEventSubscription1Data callbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+        return this;
+    }
+
+    /**
+     * Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.
+     *
+     * @return callbackUrl
+     */
+    @Valid
+    @Schema(name = "CallbackUrl", description = "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CallbackUrl")
+    public URI getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public void setCallbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public OBEventSubscription1Data version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Version for the event notification.
+     *
+     * @return version
+     */
+    @NotNull
+    @Size(min = 1, max = 10)
+    @Schema(name = "Version", description = "Version for the event notification.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public OBEventSubscription1Data eventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+        return this;
+    }
+
+    public OBEventSubscription1Data addEventTypesItem(String eventTypesItem) {
+        if (this.eventTypes == null) {
+            this.eventTypes = new ArrayList<>();
+        }
+        this.eventTypes.add(eventTypesItem);
+        return this;
+    }
+
+    /**
+     * Get eventTypes
+     *
+     * @return eventTypes
+     */
+
+    @Schema(name = "EventTypes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EventTypes")
+    public List<String> getEventTypes() {
+        return eventTypes;
+    }
+
+    public void setEventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscription1Data obEventSubscription1Data = (OBEventSubscription1Data) o;
+        return Objects.equals(this.callbackUrl, obEventSubscription1Data.callbackUrl) &&
+                Objects.equals(this.version, obEventSubscription1Data.version) &&
+                Objects.equals(this.eventTypes, obEventSubscription1Data.eventTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(callbackUrl, version, eventTypes);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscription1Data {\n");
+        sb.append("    callbackUrl: ").append(toIndentedString(callbackUrl)).append("\n");
+        sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("    eventTypes: ").append(toIndentedString(eventTypes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+
+/**
+ * OBEventSubscriptionResponse1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscriptionResponse1 {
+
+    private OBEventSubscriptionResponse1Data data;
+
+    private Links links;
+
+    private Meta meta;
+
+    public OBEventSubscriptionResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscriptionResponse1(OBEventSubscriptionResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBEventSubscriptionResponse1 data(OBEventSubscriptionResponse1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBEventSubscriptionResponse1Data getData() {
+        return data;
+    }
+
+    public void setData(OBEventSubscriptionResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBEventSubscriptionResponse1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBEventSubscriptionResponse1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscriptionResponse1 obEventSubscriptionResponse1 = (OBEventSubscriptionResponse1) o;
+        return Objects.equals(this.data, obEventSubscriptionResponse1.data) &&
+                Objects.equals(this.links, obEventSubscriptionResponse1.links) &&
+                Objects.equals(this.meta, obEventSubscriptionResponse1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscriptionResponse1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1Data.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBEventSubscriptionResponse1Data
+ */
+
+@JsonTypeName("OBEventSubscriptionResponse1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscriptionResponse1Data {
+
+    private String eventSubscriptionId;
+
+    private URI callbackUrl;
+
+    private String version;
+
+    @Valid
+    private List<String> eventTypes;
+
+    public OBEventSubscriptionResponse1Data() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscriptionResponse1Data(String eventSubscriptionId, String version) {
+        this.eventSubscriptionId = eventSubscriptionId;
+        this.version = version;
+    }
+
+    public OBEventSubscriptionResponse1Data eventSubscriptionId(String eventSubscriptionId) {
+        this.eventSubscriptionId = eventSubscriptionId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource.
+     *
+     * @return eventSubscriptionId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "EventSubscriptionId", description = "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("EventSubscriptionId")
+    public String getEventSubscriptionId() {
+        return eventSubscriptionId;
+    }
+
+    public void setEventSubscriptionId(String eventSubscriptionId) {
+        this.eventSubscriptionId = eventSubscriptionId;
+    }
+
+    public OBEventSubscriptionResponse1Data callbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+        return this;
+    }
+
+    /**
+     * Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.
+     *
+     * @return callbackUrl
+     */
+    @Valid
+    @Schema(name = "CallbackUrl", description = "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CallbackUrl")
+    public URI getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public void setCallbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public OBEventSubscriptionResponse1Data version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Version for the event notification.
+     *
+     * @return version
+     */
+    @NotNull
+    @Size(min = 1, max = 10)
+    @Schema(name = "Version", description = "Version for the event notification.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public OBEventSubscriptionResponse1Data eventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+        return this;
+    }
+
+    public OBEventSubscriptionResponse1Data addEventTypesItem(String eventTypesItem) {
+        if (this.eventTypes == null) {
+            this.eventTypes = new ArrayList<>();
+        }
+        this.eventTypes.add(eventTypesItem);
+        return this;
+    }
+
+    /**
+     * Get eventTypes
+     *
+     * @return eventTypes
+     */
+
+    @Schema(name = "EventTypes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EventTypes")
+    public List<String> getEventTypes() {
+        return eventTypes;
+    }
+
+    public void setEventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscriptionResponse1Data obEventSubscriptionResponse1Data = (OBEventSubscriptionResponse1Data) o;
+        return Objects.equals(this.eventSubscriptionId, obEventSubscriptionResponse1Data.eventSubscriptionId) &&
+                Objects.equals(this.callbackUrl, obEventSubscriptionResponse1Data.callbackUrl) &&
+                Objects.equals(this.version, obEventSubscriptionResponse1Data.version) &&
+                Objects.equals(this.eventTypes, obEventSubscriptionResponse1Data.eventTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventSubscriptionId, callbackUrl, version, eventTypes);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscriptionResponse1Data {\n");
+        sb.append("    eventSubscriptionId: ").append(toIndentedString(eventSubscriptionId)).append("\n");
+        sb.append("    callbackUrl: ").append(toIndentedString(callbackUrl)).append("\n");
+        sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("    eventTypes: ").append(toIndentedString(eventTypes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import uk.org.openbanking.datamodel.v4.common.Links;
+import uk.org.openbanking.datamodel.v4.common.Meta;
+
+/**
+ * OBEventSubscriptionsResponse1
+ */
+
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscriptionsResponse1 {
+
+    private OBEventSubscriptionsResponse1Data data;
+
+    private Links links;
+
+    private Meta meta;
+
+    public OBEventSubscriptionsResponse1() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscriptionsResponse1(OBEventSubscriptionsResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBEventSubscriptionsResponse1 data(OBEventSubscriptionsResponse1Data data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * Get data
+     *
+     * @return data
+     */
+    @NotNull
+    @Valid
+    @Schema(name = "Data", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Data")
+    public OBEventSubscriptionsResponse1Data getData() {
+        return data;
+    }
+
+    public void setData(OBEventSubscriptionsResponse1Data data) {
+        this.data = data;
+    }
+
+    public OBEventSubscriptionsResponse1 links(Links links) {
+        this.links = links;
+        return this;
+    }
+
+    /**
+     * Get links
+     *
+     * @return links
+     */
+    @Valid
+    @Schema(name = "Links", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Links")
+    public Links getLinks() {
+        return links;
+    }
+
+    public void setLinks(Links links) {
+        this.links = links;
+    }
+
+    public OBEventSubscriptionsResponse1 meta(Meta meta) {
+        this.meta = meta;
+        return this;
+    }
+
+    /**
+     * Get meta
+     *
+     * @return meta
+     */
+    @Valid
+    @Schema(name = "Meta", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("Meta")
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscriptionsResponse1 obEventSubscriptionsResponse1 = (OBEventSubscriptionsResponse1) o;
+        return Objects.equals(this.data, obEventSubscriptionsResponse1.data) &&
+                Objects.equals(this.links, obEventSubscriptionsResponse1.links) &&
+                Objects.equals(this.meta, obEventSubscriptionsResponse1.meta);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data, links, meta);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscriptionsResponse1 {\n");
+        sb.append("    data: ").append(toIndentedString(data)).append("\n");
+        sb.append("    links: ").append(toIndentedString(links)).append("\n");
+        sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1Data.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+
+/**
+ * OBEventSubscriptionsResponse1Data
+ */
+
+@JsonTypeName("OBEventSubscriptionsResponse1_Data")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscriptionsResponse1Data {
+
+    @Valid
+    private List<@Valid OBEventSubscriptionsResponse1DataEventSubscriptionInner> eventSubscription;
+
+    public OBEventSubscriptionsResponse1Data eventSubscription(List<@Valid OBEventSubscriptionsResponse1DataEventSubscriptionInner> eventSubscription) {
+        this.eventSubscription = eventSubscription;
+        return this;
+    }
+
+    public OBEventSubscriptionsResponse1Data addEventSubscriptionItem(OBEventSubscriptionsResponse1DataEventSubscriptionInner eventSubscriptionItem) {
+        if (this.eventSubscription == null) {
+            this.eventSubscription = new ArrayList<>();
+        }
+        this.eventSubscription.add(eventSubscriptionItem);
+        return this;
+    }
+
+    /**
+     * Get eventSubscription
+     *
+     * @return eventSubscription
+     */
+    @Valid
+    @Schema(name = "EventSubscription", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EventSubscription")
+    public List<@Valid OBEventSubscriptionsResponse1DataEventSubscriptionInner> getEventSubscription() {
+        return eventSubscription;
+    }
+
+    public void setEventSubscription(List<@Valid OBEventSubscriptionsResponse1DataEventSubscriptionInner> eventSubscription) {
+        this.eventSubscription = eventSubscription;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscriptionsResponse1Data obEventSubscriptionsResponse1Data = (OBEventSubscriptionsResponse1Data) o;
+        return Objects.equals(this.eventSubscription, obEventSubscriptionsResponse1Data.eventSubscription);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventSubscription);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscriptionsResponse1Data {\n");
+        sb.append("    eventSubscription: ").append(toIndentedString(eventSubscription)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.v4.event;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * OBEventSubscriptionsResponse1DataEventSubscriptionInner
+ */
+
+@JsonTypeName("OBEventSubscriptionsResponse1_Data_EventSubscription_inner")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
+public class OBEventSubscriptionsResponse1DataEventSubscriptionInner {
+
+    private String eventSubscriptionId;
+
+    private URI callbackUrl;
+
+    private String version;
+
+    @Valid
+    private List<String> eventTypes;
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner() {
+        super();
+    }
+
+    /**
+     * Constructor with only required parameters
+     */
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner(String eventSubscriptionId, String version) {
+        this.eventSubscriptionId = eventSubscriptionId;
+        this.version = version;
+    }
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner eventSubscriptionId(String eventSubscriptionId) {
+        this.eventSubscriptionId = eventSubscriptionId;
+        return this;
+    }
+
+    /**
+     * Unique identification as assigned by the ASPSP to uniquely identify the callback url resource.
+     *
+     * @return eventSubscriptionId
+     */
+    @NotNull
+    @Size(min = 1, max = 40)
+    @Schema(name = "EventSubscriptionId", description = "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("EventSubscriptionId")
+    public String getEventSubscriptionId() {
+        return eventSubscriptionId;
+    }
+
+    public void setEventSubscriptionId(String eventSubscriptionId) {
+        this.eventSubscriptionId = eventSubscriptionId;
+    }
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner callbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+        return this;
+    }
+
+    /**
+     * Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.
+     *
+     * @return callbackUrl
+     */
+    @Valid
+    @Schema(name = "CallbackUrl", description = "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("CallbackUrl")
+    public URI getCallbackUrl() {
+        return callbackUrl;
+    }
+
+    public void setCallbackUrl(URI callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * Version for the event notification.
+     *
+     * @return version
+     */
+    @NotNull
+    @Size(min = 1, max = 10)
+    @Schema(name = "Version", description = "Version for the event notification.", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("Version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner eventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+        return this;
+    }
+
+    public OBEventSubscriptionsResponse1DataEventSubscriptionInner addEventTypesItem(String eventTypesItem) {
+        if (this.eventTypes == null) {
+            this.eventTypes = new ArrayList<>();
+        }
+        this.eventTypes.add(eventTypesItem);
+        return this;
+    }
+
+    /**
+     * Get eventTypes
+     *
+     * @return eventTypes
+     */
+
+    @Schema(name = "EventTypes", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @JsonProperty("EventTypes")
+    public List<String> getEventTypes() {
+        return eventTypes;
+    }
+
+    public void setEventTypes(List<String> eventTypes) {
+        this.eventTypes = eventTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OBEventSubscriptionsResponse1DataEventSubscriptionInner obEventSubscriptionsResponse1DataEventSubscriptionInner = (OBEventSubscriptionsResponse1DataEventSubscriptionInner) o;
+        return Objects.equals(this.eventSubscriptionId, obEventSubscriptionsResponse1DataEventSubscriptionInner.eventSubscriptionId) &&
+                Objects.equals(this.callbackUrl, obEventSubscriptionsResponse1DataEventSubscriptionInner.callbackUrl) &&
+                Objects.equals(this.version, obEventSubscriptionsResponse1DataEventSubscriptionInner.version) &&
+                Objects.equals(this.eventTypes, obEventSubscriptionsResponse1DataEventSubscriptionInner.eventTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventSubscriptionId, callbackUrl, version, eventTypes);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OBEventSubscriptionsResponse1DataEventSubscriptionInner {\n");
+        sb.append("    eventSubscriptionId: ").append(toIndentedString(eventSubscriptionId)).append("\n");
+        sb.append("    callbackUrl: ").append(toIndentedString(callbackUrl)).append("\n");
+        sb.append("    version: ").append(toIndentedString(version)).append("\n");
+        sb.append("    eventTypes: ").append(toIndentedString(eventTypes)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+


### PR DESCRIPTION
Code generated from event-openapi.yaml and event-notifications-openapi.yaml using OB v4 schema into pkg: uk.org.openbanking.datamodel.v4.event

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440