### PR TITLE
1440: Rename OBDomesticVRPConsentResponseDataStatus to OBDomesticVRPConsentStatus

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -160,12 +160,12 @@
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/payment-initiation-openapi.yaml</inputSpec>-->
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi-3.1.9r7.yaml</inputSpec>-->
                                     <inputSpec>
-                                        ${project.basedir}/src/main/resources/specification/4.0.0/event-notifications-openapi.yaml
+                                        ${project.basedir}/src/main/resources/specification/4.0.0/vrp-openapi.yaml
                                     </inputSpec>
                                     <output>${project.build.directory}/generated-sources/swagger</output>
                                     <generatorName>spring</generatorName>
                                     <!-- Change the package here as per the chosen spec above -->
-                                    <modelPackage>uk.org.openbanking.datamodel.v4.event</modelPackage>
+                                    <modelPackage>uk.org.openbanking.datamodel.v4.vrp</modelPackage>
                                     <generateApis>false</generateApis>
                                     <!-- Override the default name for inline schemas
                                          This should be used when we want to give complex inner schema names a more
@@ -180,7 +180,8 @@
                                         OBDomesticVRPControlParameters_PeriodicLimits_inner_PeriodType=OBPeriodType,
                                         OBReadConsent1_Data_Permissions_inner=OBInternalPermissions1Code,
                                         OBReadConsentResponse1_Data_Status=OBReadConsentStatus,
-                                        OBFundsConfirmationConsentResponse1_Data_Status=OBFundsConfirmationConsentStatus
+                                        OBFundsConfirmationConsentResponse1_Data_Status=OBFundsConfirmationConsentStatus,
+                                        OBDomesticVRPConsentResponse_Data_Status=OBDomesticVRPConsentStatus
                                     </inlineSchemaNameMappings>
                                     <!-- RESOLVE_INLINE_ENUMS needs to be enabled to move enums which are specified as
                                          inline types in the schema to top level generated types, this then allows us to

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponseData.java
@@ -47,7 +47,7 @@ public class OBDomesticVRPConsentResponseData {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private DateTime creationDateTime;
 
-    private OBDomesticVRPConsentResponseDataStatus status;
+    private OBDomesticVRPConsentStatus status;
 
     @Valid
     private List<@Valid OBStatusReason> statusReason;
@@ -68,7 +68,7 @@ public class OBDomesticVRPConsentResponseData {
     /**
      * Constructor with only required parameters
      */
-    public OBDomesticVRPConsentResponseData(String consentId, DateTime creationDateTime, OBDomesticVRPConsentResponseDataStatus status, DateTime statusUpdateDateTime, OBDomesticVRPControlParameters controlParameters, OBDomesticVRPInitiation initiation) {
+    public OBDomesticVRPConsentResponseData(String consentId, DateTime creationDateTime, OBDomesticVRPConsentStatus status, DateTime statusUpdateDateTime, OBDomesticVRPControlParameters controlParameters, OBDomesticVRPInitiation initiation) {
         this.consentId = consentId;
         this.creationDateTime = creationDateTime;
         this.status = status;
@@ -142,7 +142,7 @@ public class OBDomesticVRPConsentResponseData {
         this.creationDateTime = creationDateTime;
     }
 
-    public OBDomesticVRPConsentResponseData status(OBDomesticVRPConsentResponseDataStatus status) {
+    public OBDomesticVRPConsentResponseData status(OBDomesticVRPConsentStatus status) {
         this.status = status;
         return this;
     }
@@ -156,11 +156,11 @@ public class OBDomesticVRPConsentResponseData {
     @Valid
     @Schema(name = "Status", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("Status")
-    public OBDomesticVRPConsentResponseDataStatus getStatus() {
+    public OBDomesticVRPConsentStatus getStatus() {
         return status;
     }
 
-    public void setStatus(OBDomesticVRPConsentResponseDataStatus status) {
+    public void setStatus(OBDomesticVRPConsentStatus status) {
         this.status = status;
     }
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentStatus.java
@@ -25,7 +25,7 @@ import jakarta.annotation.Generated;
  */
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
-public enum OBDomesticVRPConsentResponseDataStatus {
+public enum OBDomesticVRPConsentStatus {
 
     AWAU("AWAU"),
 
@@ -37,7 +37,7 @@ public enum OBDomesticVRPConsentResponseDataStatus {
 
     private String value;
 
-    OBDomesticVRPConsentResponseDataStatus(String value) {
+    OBDomesticVRPConsentStatus(String value) {
         this.value = value;
     }
 
@@ -52,8 +52,8 @@ public enum OBDomesticVRPConsentResponseDataStatus {
     }
 
     @JsonCreator
-    public static OBDomesticVRPConsentResponseDataStatus fromValue(String value) {
-        for (OBDomesticVRPConsentResponseDataStatus b : OBDomesticVRPConsentResponseDataStatus.values()) {
+    public static OBDomesticVRPConsentStatus fromValue(String value) {
+        for (OBDomesticVRPConsentStatus b : OBDomesticVRPConsentStatus.values()) {
             if (b.value.equals(value)) {
                 return b;
             }

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParameters.java
@@ -29,8 +29,8 @@ import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import uk.org.openbanking.datamodel.v4.common.OBActiveOrHistoricCurrencyAndAmount;
 import uk.org.openbanking.datamodel.v3.common.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.v4.common.OBActiveOrHistoricCurrencyAndAmount;
 
 /**
  * OBDomesticVRPControlParameters


### PR DESCRIPTION
The new status name provides consistency with the status names for other schemas.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440