### PR TITLE
1440: Add code generator options for generating APIs

### DIFF
--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -275,6 +275,8 @@
                                         <dateLibrary>joda</dateLibrary>
                                         <openApiNullable>false</openApiNullable>
                                         <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                                        <interfaceOnly>true</interfaceOnly>
+                                        <skipDefaultInterface>true</skipDefaultInterface>
                                     </configOptions>
                                     <globalProperties>
                                         <verbose>true</verbose>


### PR DESCRIPTION
Configure the code generator to only produce an interface for the API with no default methods.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440