### PR TITLE
1440: Add OB v4 Domestic Standing Orders support to the FR data model

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalCreditorReferenceTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalCreditorReferenceTypeCode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+
+import java.util.stream.Stream;
+
+public enum FRExternalCreditorReferenceTypeCode {
+
+    DISP("DISP"),
+    FXDR("FXDR"),
+    PUOR("PUOR"),
+    RPIN("RPIN"),
+    RADM("RADM"),
+    SCOR("SCOR");
+
+    private final String value;
+
+    FRExternalCreditorReferenceTypeCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRExternalCreditorReferenceTypeCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(type -> type.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalDocumentTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalDocumentTypeCode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+
+import java.util.stream.Stream;
+
+public enum FRExternalDocumentTypeCode {
+
+    CINV("CINV"),
+    CNFA("CNFA"),
+    CONT("CONT"),
+    CREN("CREN"),
+    DEBN("DEBN"),
+    DISP("DISP"),
+    DNFA("DNFA"),
+    HIRI("HIRI"),
+    INVS("INVS"),
+    MSIN("MSIN"),
+    PROF("PROF"),
+    PUOR("PUOR"),
+    QUOT("QUOT"),
+    SBIN("SBIN"),
+    SPRR("SPRR"),
+    TISH("TISH");
+
+    private final String value;
+
+    FRExternalDocumentTypeCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRExternalDocumentTypeCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(type -> type.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
@@ -15,13 +15,13 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
@@ -38,46 +38,23 @@ import java.util.stream.Stream;
 @Builder
 public class FRPostalAddress {
 
-    private AddressTypeCode addressType;
+    private String addressType;
     private String department;
     private String subDepartment;
     private String streetName;
     private String buildingNumber;
+    private String buildingName;
+    private String floor;
+    private String unitNumber;
+    private String room;
+    private String postBox;
+    private String townLocationName;
+    private String districtName;
+    private String careOf;
     private String postCode;
     private String townName;
     private String countrySubDivision;
     private String country;
     private List<String> addressLine;
 
-    public enum AddressTypeCode {
-        BUSINESS("Business"),
-        CORRESPONDENCE("Correspondence"),
-        DELIVERYTO("DeliveryTo"),
-        MAILTO("MailTo"),
-        POBOX("POBox"),
-        POSTAL("Postal"),
-        RESIDENTIAL("Residential"),
-        STATEMENT("Statement");
-
-        private String value;
-
-        AddressTypeCode(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public String toString() {
-            return value;
-        }
-
-        public static AddressTypeCode fromValue(String value) {
-            return Stream.of(values())
-                    .filter(type -> type.getValue().equals(value))
-                    .findFirst()
-                    .orElse(null);
-        }
-    }
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReferredDocumentInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReferredDocumentInformation.java
@@ -13,21 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.payment;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
 
 import java.util.List;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
+import org.joda.time.DateTime;
 
-/**
- * Test data factory for {@link FRRemittanceInformation}
- */
-public class FRRemittanceInformationTestDataFactory {
+public class FRReferredDocumentInformation {
 
-    public static FRRemittanceInformation aValidFRRemittanceInformation() {
-        return FRRemittanceInformation.builder()
-                .reference("123456")
-                .unstructured(List.of("INV.001"))
-                .build();
-    }
+    private FRExternalDocumentTypeCode code;
+    private String issuer;
+    private String number;
+    private DateTime relatedDate;
+    private List<String> lineDetails;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructured.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructured.java
@@ -15,31 +15,23 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
+import java.util.List;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
-    private String identification;
-    private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+public class FRRemittanceInformationStructured {
+    private List<@Valid FRReferredDocumentInformation> referredDocumentInformation;
+    private Integer referredDocumentAmount;
+    private FRRemittanceInformationStructuredCreditorReferenceInformation creditorReferenceInformation;
+    private String invoicer;
+    private String invoicee;
+    private String taxRemittance;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructuredCreditorReferenceInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructuredCreditorReferenceInformation.java
@@ -15,31 +15,17 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
-    private String identification;
-    private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+public class FRRemittanceInformationStructuredCreditorReferenceInformation {
+    private FRExternalCreditorReferenceTypeCode code;
+    private String issuer;
+    private String reference;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtils.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtils.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.payment;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter;
 
 import java.util.List;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
+public class ConversionUtils {
 
-/**
- * Test data factory for {@link FRRemittanceInformation}
- */
-public class FRRemittanceInformationTestDataFactory {
-
-    public static FRRemittanceInformation aValidFRRemittanceInformation() {
-        return FRRemittanceInformation.builder()
-                .reference("123456")
-                .unstructured(List.of("INV.001"))
-                .build();
+    private ConversionUtils() {
     }
+
+    public static String convertListToSingleString(List<String> values) {
+        if (values != null && !values.isEmpty()) {
+            return values.get(0);
+        }
+        return null;
+    }
+
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRemittanceInformationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRRemittanceInformationConverter.java
@@ -15,6 +15,10 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.ConversionUtils.convertListToSingleString;
+
+import java.util.List;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
 
 import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
@@ -25,35 +29,35 @@ public class FRRemittanceInformationConverter {
 
     public static FRRemittanceInformation toFRRemittanceInformation(OBWriteDomestic2DataInitiationRemittanceInformation remittanceInformation) {
         return remittanceInformation == null ? null : FRRemittanceInformation.builder()
-                .unstructured(remittanceInformation.getUnstructured())
+                .unstructured(List.of(remittanceInformation.getUnstructured()))
                 .reference(remittanceInformation.getReference())
                 .build();
     }
 
     public static FRRemittanceInformation toFRRemittanceInformation(OBDomesticVRPInitiationRemittanceInformation remittanceInformation) {
         return remittanceInformation == null ? null : FRRemittanceInformation.builder()
-                .unstructured(remittanceInformation.getUnstructured())
+                .unstructured(List.of(remittanceInformation.getUnstructured()))
                 .reference(remittanceInformation.getReference())
                 .build();
     }
 
     public static FRRemittanceInformation toFRRemittanceInformation(OBVRPRemittanceInformation remittanceInformation) {
         return remittanceInformation == null ? null : FRRemittanceInformation.builder()
-                .unstructured(remittanceInformation.getUnstructured())
+                .unstructured(List.of(remittanceInformation.getUnstructured()))
                 .reference(remittanceInformation.getReference())
                 .build();
     }
 
     public static OBWriteDomestic2DataInitiationRemittanceInformation toOBWriteDomestic2DataInitiationRemittanceInformation(FRRemittanceInformation remittanceInformation) {
         return remittanceInformation == null ? null : new OBWriteDomestic2DataInitiationRemittanceInformation()
-                .unstructured(remittanceInformation.getUnstructured())
+                .unstructured(convertListToSingleString(remittanceInformation.getUnstructured()))
                 .reference(remittanceInformation.getReference());
     }
 
     public static OBVRPRemittanceInformation toOBVRPRemittanceInformation(FRRemittanceInformation remittanceInformation){
         return remittanceInformation == null ? null : new OBVRPRemittanceInformation()
                 .reference(remittanceInformation.getReference())
-                .unstructured(remittanceInformation.getUnstructured());
+                .unstructured(convertListToSingleString(remittanceInformation.getUnstructured()));
     }
 
     public static OBDomesticVRPInitiationRemittanceInformation toOBDomesticVRPInitiationRemittanceInformation(
@@ -61,6 +65,9 @@ public class FRRemittanceInformationConverter {
     ) {
         return remittanceInformation == null ? null : new OBDomesticVRPInitiationRemittanceInformation()
                 .reference(remittanceInformation.getReference())
-                .unstructured(remittanceInformation.getUnstructured());
+                // Convert the unstructured field to a single element, in v3 only a single value is allowed whereas v4 permits a list
+                .unstructured(convertListToSingleString(remittanceInformation.getUnstructured()));
     }
+
+
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/mapper/FRModelMapper.java
@@ -15,11 +15,24 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.mapper;
 
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.ConversionUtils.convertListToSingleString;
+
+import java.util.List;
+
+import org.modelmapper.Converter;
 import org.modelmapper.ModelMapper;
 
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPaymentRisk;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPostalAddress;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter;
 
+import uk.org.openbanking.datamodel.v3.common.OBPostalAddress6;
 import uk.org.openbanking.datamodel.v3.common.OBRisk1;
+import uk.org.openbanking.datamodel.v3.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
+import uk.org.openbanking.datamodel.v3.vrp.OBDomesticVRPInitiationRemittanceInformation;
+import uk.org.openbanking.datamodel.v3.vrp.OBVRPRemittanceInformation;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
 
 /**
  * This is used to wrap a singleton model mapper so config can be set in one place without requiring DI/Spring in a common lib.
@@ -28,6 +41,10 @@ import uk.org.openbanking.datamodel.v3.common.OBRisk1;
 public class FRModelMapper {
 
     private static final ModelMapper modelMapper = new ModelMapper();
+
+    private static final Converter<String, List<String>> STRING_TO_LIST_CONVERTER = context -> context.getSource() == null ? null : List.of(context.getSource());
+    private static final Converter<List<String>, String> LIST_TO_SINGLE_STRING_CONVERTER = context -> convertListToSingleString(context.getSource());
+
     static {
         // Set project wide config here
         modelMapper.getConfiguration().setSkipNullEnabled(true);
@@ -35,6 +52,43 @@ public class FRModelMapper {
         // Custom mapping to handle OBRisk1 typo contractPresentInidicator property
         modelMapper.createTypeMap(OBRisk1.class, FRPaymentRisk.class).addMapping(OBRisk1::getContractPresentInidicator, FRPaymentRisk::setContractPresentIndicator);
         modelMapper.createTypeMap(FRPaymentRisk.class, OBRisk1.class).addMapping(FRPaymentRisk::getContractPresentIndicator, OBRisk1::setContractPresentInidicator);
+
+        modelMapper.createTypeMap(FRRemittanceInformation.class, OBWriteDomestic2DataInitiationRemittanceInformation.class)
+                   .addMappings(mapper -> mapper.using(LIST_TO_SINGLE_STRING_CONVERTER)
+                                                .map(FRRemittanceInformation::getUnstructured,
+                                                     OBWriteDomestic2DataInitiationRemittanceInformation::setUnstructured));
+
+        modelMapper.createTypeMap(OBWriteDomestic2DataInitiationRemittanceInformation.class, FRRemittanceInformation.class)
+                .addMappings(mapper -> mapper.using(STRING_TO_LIST_CONVERTER)
+                                             .map(OBWriteDomestic2DataInitiationRemittanceInformation::getUnstructured,
+                                                  FRRemittanceInformation::setUnstructured));
+
+        modelMapper.createTypeMap(FRRemittanceInformation.class, OBDomesticVRPInitiationRemittanceInformation.class)
+                   .addMappings(mapper -> mapper.using(LIST_TO_SINGLE_STRING_CONVERTER)
+                                                .map(FRRemittanceInformation::getUnstructured,
+                                                     OBDomesticVRPInitiationRemittanceInformation::setUnstructured));
+
+        modelMapper.createTypeMap(OBDomesticVRPInitiationRemittanceInformation.class, FRRemittanceInformation.class)
+                .addMappings(mapper -> mapper.using(STRING_TO_LIST_CONVERTER)
+                                             .map(OBDomesticVRPInitiationRemittanceInformation::getUnstructured,
+                                                  FRRemittanceInformation::setUnstructured));
+
+        modelMapper.createTypeMap(FRRemittanceInformation.class, OBVRPRemittanceInformation.class)
+                   .addMappings(mapper -> mapper.using(LIST_TO_SINGLE_STRING_CONVERTER)
+                                                .map(FRRemittanceInformation::getUnstructured,
+                                                     OBVRPRemittanceInformation::setUnstructured));
+
+        modelMapper.createTypeMap(OBVRPRemittanceInformation.class, FRRemittanceInformation.class)
+                .addMappings(mapper -> mapper.using(STRING_TO_LIST_CONVERTER)
+                                             .map(OBVRPRemittanceInformation::getUnstructured,
+                                                  FRRemittanceInformation::setUnstructured));
+
+        // Register converters which map between address types
+        modelMapper.addConverter(context -> FRPostalAddressConverter.toOBPostalAddress6(context.getSource()), FRPostalAddress.class, OBPostalAddress6.class);
+        modelMapper.addConverter(context -> FRPostalAddressConverter.toFRPostalAddress(context.getSource()), OBPostalAddress6.class, FRPostalAddress.class);
+        modelMapper.addConverter(context -> FRPostalAddressConverter.toOBPostalAddress7(context.getSource()), FRPostalAddress.class, OBPostalAddress7.class);
+        modelMapper.addConverter(context -> FRPostalAddressConverter.toFRPostalAddress(context.getSource()), OBPostalAddress7.class, FRPostalAddress.class);
+
     }
 
     /**

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalCategoryPurposeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalCategoryPurposeCode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
+
+import java.util.stream.Stream;
+
+public enum FRExternalCategoryPurposeCode {
+    BONU("BONU"),
+    CASH("CASH"),
+    CBLK("CBLK"),
+    CCRD("CCRD"),
+    CGWV("CGWV"),
+    CIPC("CIPC"),
+    CONC("CONC"),
+    CORT("CORT"),
+    DCRD("DCRD"),
+    DIVI("DIVI"),
+    DVPM("DVPM"),
+    EPAY("EPAY"),
+    FCDT("FCDT"),
+    FCIN("FCIN"),
+    FCOL("FCOL"),
+    GOVT("GOVT"),
+    GP2P("GP2P"),
+    HEDG("HEDG"),
+    ICCP("ICCP"),
+    IDCP("IDCP"),
+    INTC("INTC"),
+    INTE("INTE"),
+    LBOX("LBOX"),
+    LOAN("LOAN"),
+    MP2B("MP2B"),
+    MP2P("MP2P"),
+    OTHR("OTHR"),
+    PENS("PENS"),
+    RPRE("RPRE"),
+    RRCT("RRCT"),
+    RVPM("RVPM"),
+    SALA("SALA"),
+    SECU("SECU"),
+    SSBE("SSBE"),
+    SUPP("SUPP"),
+    SWEP("SWEP"),
+    TAXS("TAXS"),
+    TOPG("TOPG"),
+    TRAD("TRAD"),
+    TREA("TREA"),
+    VATX("VATX"),
+    VOST("VOST"),
+    WHLD("WHLD"),
+    ZABA("ZABA");
+
+    private final String value;
+
+    FRExternalCategoryPurposeCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRExternalCategoryPurposeCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(code -> code.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalMandateClassificationCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalMandateClassificationCode.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
+
+import java.util.stream.Stream;
+
+public enum FRExternalMandateClassificationCode {
+
+    FIXE("FIXE"),
+    USGB("USGB"),
+    VARI("VARI");
+
+    private final String value;
+
+    FRExternalMandateClassificationCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRExternalMandateClassificationCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(code -> code.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalProxyAccountTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalProxyAccountTypeCode.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
+
+import java.util.stream.Stream;
+
+public enum FRExternalProxyAccountTypeCode {
+
+    TELE("TELE"),
+    EMAL("EMAL"),
+    DNAM("DNAM"),
+    CINC("CINC"),
+    COTX("COTX"),
+    COID("COID"),
+    CUST("CUST"),
+    DRLC("DRLC"),
+    EIDN("EIDN"),
+    EWAL("EWAL"),
+    PVTX("PVTX"),
+    LEIC("LEIC"),
+    MBNO("MBNO"),
+    NIDN("NIDN"),
+    CCPT("CCPT"),
+    SHID("SHID"),
+    SOSE("SOSE"),
+    TOKN("TOKN"),
+    UBIL("UBIL"),
+    VIPN("VIPN"),
+    BIID("BIID");
+
+    private final String value;
+
+    FRExternalProxyAccountTypeCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRExternalProxyAccountTypeCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(code -> code.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRMandateRelatedInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRMandateRelatedInformation.java
@@ -13,32 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
-import java.util.List;
+import org.joda.time.DateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
- * to make it easier to introduce new versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be
- * populated. For this reason it is a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRRemittanceInformation {
+public class FRMandateRelatedInformation {
 
-    private String reference;
+    private String mandateIdentification;
+    private FRExternalMandateClassificationCode classification;
+    private FRExternalCategoryPurposeCode categoryPurposeCode;
+    private DateTime firstPaymentDateTime;
+    private DateTime recurringPaymentDateTime;
+    private DateTime finalPaymentDateTime;
+    private FRStandingOrderFrequency frequency;
+    private String reason;
 
-    private List<FRRemittanceInformationStructured> structured;
-    private List<String> unstructured;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRProxy.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRProxy.java
@@ -13,33 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
-
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.org.openbanking.datamodel.v4.common.ExternalProxyAccountType1Code;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
+public class FRProxy {
+
     private String identification;
-    private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+    private ExternalProxyAccountType1Code code;
+    private String type;
+
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryAuthority.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryAuthority.java
@@ -13,33 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
-
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
-    private String identification;
+public class FRRegulatoryAuthority {
     private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+    private String countryCode;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReporting.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReporting.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
 import java.util.List;
 
@@ -22,23 +22,12 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
- * to make it easier to introduce new versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be
- * populated. For this reason it is a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRRemittanceInformation {
-
-    private String reference;
-
-    private List<FRRemittanceInformationStructured> structured;
-    private List<String> unstructured;
+public class FRRegulatoryReporting {
+    private FRRegulatoryReportingDebitCreditReportingIndicator debitCreditReportingIndicator;
+    private FRRegulatoryAuthority authority;
+    private List<FRStructuredRegulatoryReporting> details;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReportingDebitCreditReportingIndicator.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReportingDebitCreditReportingIndicator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
+
+import java.util.stream.Stream;
+
+
+public enum FRRegulatoryReportingDebitCreditReportingIndicator {
+
+    CRED("CRED"),
+    DEBT("DEBT"),
+    BOTH("BOTH");
+
+    private final String value;
+
+    FRRegulatoryReportingDebitCreditReportingIndicator(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRRegulatoryReportingDebitCreditReportingIndicator fromValue(String value) {
+        return Stream.of(values())
+                .filter(code -> code.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequency.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequency.java
@@ -13,32 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
-
-import java.util.List;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
- * to make it easier to introduce new versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be
- * populated. For this reason it is a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRRemittanceInformation {
+public class FRStandingOrderFrequency {
 
-    private String reference;
+    private FRStandingOrderFrequencyCode type;
+    private Integer countPerPeriod;
+    private String pointInTime;
 
-    private List<FRRemittanceInformationStructured> structured;
-    private List<String> unstructured;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequencyCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequencyCode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
+
+import java.util.stream.Stream;
+
+public enum FRStandingOrderFrequencyCode {
+    ADHO("ADHO"),
+    YEAR("YEAR"),
+    DAIL("DAIL"),
+    FRTN("FRTN"),
+    INDA("INDA"),
+    MNTH("MNTH"),
+    QURT("QURT"),
+    MIAN("MIAN"),
+    WEEK("WEEK");
+
+    private final String value;
+
+    FRStandingOrderFrequencyCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static FRStandingOrderFrequencyCode fromValue(String value) {
+        return Stream.of(values())
+                .filter(code -> code.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStructuredRegulatoryReporting.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStructuredRegulatoryReporting.java
@@ -13,32 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
 import java.util.List;
+
+import org.joda.time.DateTime;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
- * to make it easier to introduce new versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be
- * populated. For this reason it is a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRRemittanceInformation {
+public class FRStructuredRegulatoryReporting {
 
-    private String reference;
+    private String type;
+    private DateTime date;
+    private String country;
+    private FRAmount amount;
+    private List<String> information;
 
-    private List<FRRemittanceInformationStructured> structured;
-    private List<String> unstructured;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateCreditor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateCreditor.java
@@ -13,33 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPostalAddress;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
-    private String identification;
+public class FRUltimateCreditor {
+
     private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+    private String identification;
+    private String LEI;
+    private String schemeName;
+    private FRPostalAddress postalAddress;
+
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateDebtor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateDebtor.java
@@ -13,33 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.sapi.gateway.ob.uk.common.datamodel.common;
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
-import com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment.FRProxy;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPostalAddress;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order to make it easier to introduce new
- * versions of the Read/Write API.
- *
- * <p>
- * Note that this object is used across multiple versions of the Read/Write API, meaning that some values won't be populated. For this reason it is
- * a mutable {@link Data} rather than an immutable {@link lombok.Value} one.
- * </p>
- */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FRAccountIdentifier {
-    private String schemeName;
-    private String identification;
+public class FRUltimateDebtor {
     private String name;
-    private String secondaryIdentification;
-    private String accountId;
-    private FRProxy proxy;
+    private String identification;
+    private String LEI;
+    private String schemeName;
+    private FRPostalAddress postalAddress;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
@@ -15,14 +15,19 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.payment;
 
+import java.util.List;
+
+import org.joda.time.DateTime;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAccountIdentifier;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRAmount;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRRemittanceInformation;
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRSupplementaryData;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.joda.time.DateTime;
 
 /**
  * Represents an equivalent object in the OB data model. It is stored within mongo (instead of the OB object), in order
@@ -51,4 +56,11 @@ public class FRWriteDomesticStandingOrderDataInitiation implements FRDomesticDat
     private FRAccountIdentifier debtorAccount;
     private FRAccountIdentifier creditorAccount;
     private FRSupplementaryData supplementaryData;
+
+    // v4 fields
+    private FRRemittanceInformation remittanceInformation;
+    private FRMandateRelatedInformation mandateRelatedInformation;
+    private FRUltimateDebtor ultimateDebtor;
+    private FRUltimateCreditor ultimateCreditor;
+    private List<FRStructuredRegulatoryReporting> regulatoryReporting;
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtilsTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.ConversionUtils.convertListToSingleString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class ConversionUtilsTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldConvertNullListOrEmptyListToNullValue(List<String> values) {
+        assertThat(convertListToSingleString(values)).isNull();
+    }
+
+    @Test
+    public void shouldConvertListOfSize1() {
+        assertThat(convertListToSingleString(List.of("singleValue"))).isEqualTo("singleValue");
+    }
+
+    @Test
+    public void shouldConvertListWithMultipleValuesToFirstElement() {
+        assertThat(convertListToSingleString(List.of("firstValue", "secondValue"))).isEqualTo("firstValue");
+        assertThat(convertListToSingleString(List.of("blah", "DSfsd", "fgdf44"))).isEqualTo("blah");
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRPostalAddressConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/common/FRPostalAddressConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common;
+
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter.toAddressType;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter.toOBAddressType2Code;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter.toOBAddressTypeCode;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter.toOBPostalAddress6;
+import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.common.FRPostalAddressConverter.toOBPostalAddress7;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPostalAddress;
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport.FRPostalAddressTestDataFactory;
+
+import uk.org.openbanking.datamodel.v3.common.OBAddressTypeCode;
+import uk.org.openbanking.datamodel.v3.common.OBPostalAddress6;
+import uk.org.openbanking.datamodel.v4.common.OBAddressType2Code;
+import uk.org.openbanking.datamodel.v4.common.OBPostalAddress7;
+
+class FRPostalAddressConverterTest {
+
+    @Test
+    public void testConvertingOBPostalAddress6() {
+        final FRPostalAddress frPostalAddress = FRPostalAddressTestDataFactory.aValidFRPostalAddress();
+        final OBPostalAddress6 obPostalAddress6 = toOBPostalAddress6(frPostalAddress);
+        assertEquals(frPostalAddress, FRPostalAddressConverter.toFRPostalAddress(obPostalAddress6));
+    }
+
+    @Test
+    public void testConvertingOBPostalAddress7() {
+        final FRPostalAddress frPostalAddress = FRPostalAddressTestDataFactory.aValidFRPostalAddress7();
+        final OBPostalAddress7 obPostalAddress6 = toOBPostalAddress7(frPostalAddress);
+        assertEquals(frPostalAddress, FRPostalAddressConverter.toFRPostalAddress(obPostalAddress6));
+    }
+
+    @Test
+    public void testAddressTypeTranslations() {
+        // Verify converting from v3 to v4
+        for (OBAddressTypeCode obAddressTypeCode : OBAddressTypeCode.values()) {
+            final String addressType = toAddressType(obAddressTypeCode);
+            final OBAddressType2Code addressType2Code = toOBAddressType2Code(addressType);
+            assertEquals(obAddressTypeCode, toOBAddressTypeCode(toAddressType(addressType2Code)));
+        }
+        // Verify converting v4 to v3
+        for (OBAddressType2Code obAddressType2Code : OBAddressType2Code.values()) {
+            final String addressType = toAddressType(obAddressType2Code);
+            final OBAddressTypeCode addressTypeCode = toOBAddressTypeCode(addressType);
+            assertEquals(obAddressType2Code, toOBAddressType2Code(toAddressType(addressTypeCode)));
+        }
+    }
+
+}

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
@@ -15,7 +15,12 @@
  */
 package com.forgerock.sapi.gateway.ob.uk.common.datamodel.testsupport;
 
+import java.util.List;
+
 import com.forgerock.sapi.gateway.ob.uk.common.datamodel.common.FRPostalAddress;
+
+import uk.org.openbanking.datamodel.v4.common.OBAddressType2Code;
+import uk.org.openbanking.datamodel.v4.common.OBAddressTypeCode;
 
 /**
  * Test data factory for {@link FRPostalAddress}.
@@ -27,13 +32,34 @@ public class FRPostalAddressTestDataFactory {
      */
     public static FRPostalAddress aValidFRPostalAddress() {
         return FRPostalAddress.builder()
-                .addressType(FRPostalAddress.AddressTypeCode.RESIDENTIAL)
+                .addressType(OBAddressTypeCode.RESIDENTIAL.getValue())
                 .buildingNumber("21")
                 .streetName("Jagger Road")
                 .townName("Stroud")
                 .postCode("GL5 3AA")
                 .countrySubDivision("Gloucestershire")
                 .country("UK")
+                .build();
+    }
+
+    public static FRPostalAddress aValidFRPostalAddress7() {
+        return FRPostalAddress.builder()
+                .addressType(OBAddressType2Code.HOME.getValue())
+                .buildingNumber("21")
+                .streetName("Jagger Road")
+                .townName("Stroud")
+                .postCode("GL5 3AA")
+                .countrySubDivision("Gloucestershire")
+                .country("UK")
+                .room("1")
+                .careOf("Dave")
+                .floor("Ground")
+                .districtName("Somewhere")
+                .townLocationName("Outskirts")
+                .postBox("POBOX123")
+                .unitNumber("42")
+                .buildingName("The Lodge")
+                .addressLine(List.of("Extra Address Line1", "Extra Address Line2"))
                 .build();
     }
 }


### PR DESCRIPTION
## Standing Order specific changes
FRWriteDomesticStandingOrderDataInitiation has been updated to include the new fields added in v4.

Several top level v3 fields move into new subtype FRMandateRelatedInformation. The fields are duplicated to allow v3 and v4 data to be decoded from the database into the same object.

## Changes applicable to all payments
### FRPostalAddress
FRPostalAddress has been updated to include the new fields added in OBPostalAddress7. 

The addressType field has changed from an enum to a String, this allows us to support the new 4-letter code address types.
 
The FRPostalAddressConverter has been updated to support converting v3 addressType values to v4 and vice versa, this means that existing addresses stored in the database can be translated to v3 or v4 as required.

### FRRemittanceInformation
This has been updated to change unstructured field from String to List<String>. Spring Data will automatically handle the type conversion when returning existing data from the database. 

A new structured field of type FRRemittanceInformationStructured has been added.

### Additional new types
- FRProxy type added to existing FRAccountIdentifier
- FRUltimateCreditor
- FRUltimateDebtor
- FRRegulatoryReporting

https://github.com/SecureApiGateway/SecureApiGateway/issues/1440