### PR TITLE
1602: Build and Deploy SAPIG 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                 <version>${flatten-maven-plugin.version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <flattenMode>bom</flattenMode>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
When using mode `bom` the parent section was being removed, meaning no parent dependency which was throwing an error

Changed to `resolveCiFriendliesOnly` which locally only updates the variables like we want

Issue: https://github.com/SecureApiGateway/secure-api-gateway-ci/pull/122