### PR TITLE
1604: Revert Hardcoded Pom.xml for Common and RCS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Bump parent to 4.0.1-SNAPSHOT

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1604