### PR TITLE
1654: Bump FAPI parent year and individual licenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-ob-uk-common</artifactId>

--- a/secure-api-gateway-ob-uk-common-bom/pom.xml
+++ b/secure-api-gateway-ob-uk-common-bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-datamodel/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountBeneficiary.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountBeneficiary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountRisk.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountRisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountServicer.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountServicer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountStatusCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountStatusCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountWithBalance.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRAccountWithBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalanceData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCashBalanceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditDebitIndicator.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditDebitIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditLine.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCreditLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCurrencyExchange.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRCurrencyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRDirectDebitData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRDirectDebitData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalPermissionsCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalPermissionsCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalRequestStatusCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRExternalRequestStatusCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRFinancialAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRFinancialAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRLinks.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMandateRelatedInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMandateRelatedInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMeta.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FROfferData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FROfferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRPartyData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRPartyData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadConsentResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadDataResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadDataResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRReadResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRScheduledPaymentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRScheduledPaymentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStandingOrderData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStandingOrderData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStatementData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRStatementData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRTransactionData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRTransactionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAccountIdentifier.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAccountIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAmount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRCharge.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRCharge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRChargeBearerType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRChargeBearerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataSCASupportData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRDataSCASupportData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalCreditorReferenceTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalCreditorReferenceTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalDocumentTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalDocumentTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalExtendedAccountTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalExtendedAccountTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPaymentContextCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPaymentContextCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPurposeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRExternalPurposeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialAgent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialCreditor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRFinancialCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRInstructionPriority.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRInstructionPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRLocalAmount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRLocalAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPaymentRisk.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPaymentRisk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPermission.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRPostalAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReferredDocumentInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRReferredDocumentInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructured.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructuredCreditorReferenceInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRemittanceInformationStructuredCreditorReferenceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRResponseDataRefund.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRResponseDataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRisk1PaymentContextCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRRisk1PaymentContextCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSubmissionStatus.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSubmissionStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSupplementaryData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRSupplementaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRTotalValue.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/common/FRTotalValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtils.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRAccountBeneficiaryConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRAccountBeneficiaryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRAccountServicerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRAccountServicerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCashBalanceConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCashBalanceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCreditDebitIndicatorConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCreditDebitIndicatorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCurrencyExchangeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCurrencyExchangeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRDirectDebitConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRDirectDebitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRExternalPermissionsCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRExternalPermissionsCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRExternalRequestStatusCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRExternalRequestStatusCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRFinancialAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRFinancialAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FROfferConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FROfferConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRPartyConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRPartyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRReadConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRReadConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRStatementConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRStatementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRTransactionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRTransactionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRAccountIdentifierConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRAccountIdentifierConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRAmountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRChargeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRChargeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRExternalExtendedAccountTypeCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRExternalExtendedAccountTypeCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRFinancialInstrumentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRFinancialInstrumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRLinksConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRLinksConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRMetaConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRMetaConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FROBExternalPaymentContext1CodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FROBExternalPaymentContext1CodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRPostalAddressConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRPostalAddressConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRemittanceInformationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRemittanceInformationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRResponseDataRefundConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRResponseDataRefundConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRisk1DeliveryAddressConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRisk1DeliveryAddressConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRiskConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRiskConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRSubmissionStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRSubmissionStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRSupplementaryDataConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRSupplementaryDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/event/FREventPollingConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/event/FREventPollingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/event/FREventSubscriptionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/event/FREventSubscriptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/mapper/FRModelMapper.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/mapper/FRModelMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRChargeBearerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRChargeBearerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRDataAuthorisationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRDataAuthorisationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRDataSCASupportDataConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRDataSCASupportDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRExchangeRateConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRExchangeRateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRInstructionPriorityConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRInstructionPriorityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRPermissionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRPermissionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRReadRefundAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRReadRefundAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRScheduledPaymentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRScheduledPaymentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVRPConsentConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVRPConsentConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVrpConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVrpConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRVrpInteractionTypesConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRVrpInteractionTypesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountBeneficiaryConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountBeneficiaryConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountServicerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountServicerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountSubTypeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRAccountSubTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRConsentStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRConsentStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCreditDebitIndicatorConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCreditDebitIndicatorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCurrencyExchangeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCurrencyExchangeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRDirectDebitConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRDirectDebitConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FREntryStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FREntryStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRExternalMandateStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRExternalMandateStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRFinancialAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRFinancialAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FROfferConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FROfferConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRPartyConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRPartyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRReadConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRReadConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRStatementConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRStatementConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRTransactionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRTransactionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRAccountIdentifierConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRAccountIdentifierConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRAmountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRChargeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRChargeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRConsentStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRConsentStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRErrorCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRErrorCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRExternalPurposeCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRExternalPurposeCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRFinancialInstrumentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRFinancialInstrumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRFundsConfirmationConsentStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRFundsConfirmationConsentStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRInternationalConsentStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRInternationalConsentStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRPaymentDetailsStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRPaymentDetailsStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRProxyConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRProxyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRResponseDataRefundConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRResponseDataRefundConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRRiskConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRRiskConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRSubmissionStatusConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRSubmissionStatusConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/event/FREventPollingConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/event/FREventPollingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/event/FREventSubscriptionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/event/FREventSubscriptionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRChargeBearerConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRChargeBearerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRDataAuthorisationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRDataAuthorisationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRDataSCASupportDataConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRDataSCASupportDataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRExchangeRateConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRExchangeRateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRExternalCategoryPurposeCodeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRExternalCategoryPurposeCodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRFrequency6Converter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRFrequency6Converter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRInstructionPriorityConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRInstructionPriorityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRMandateRelatedInformationConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRMandateRelatedInformationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRPermissionConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRPermissionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRReadRefundAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRReadRefundAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRRegulatoryReportingConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRRegulatoryReportingConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRScheduledPaymentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRScheduledPaymentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRUltimateCreditorConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRUltimateCreditorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRUltimateDebtorConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRUltimateDebtorConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalScheduledConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalScheduledConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalScheduledConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalScheduledConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConsentConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConsentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRDomesticVRPConsentConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRDomesticVRPConsentConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRDomesticVrpConverters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRDomesticVrpConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRVrpInteractionTypesConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/vrp/FRVrpInteractionTypesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRAddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfoAddress.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/customerinfo/FRCustomerInfoAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FRCallbackUrlData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FRCallbackUrlData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessage.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessages.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPolling.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPolling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPollingError.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventPollingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventSubscriptionData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/event/FREventSubscriptionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/funds/FRFundsConfirmationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRDomesticDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRDomesticDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalCategoryPurposeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalCategoryPurposeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalMandateClassificationCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalMandateClassificationCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalPaymentPurposeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalPaymentPurposeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalProxyAccountTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRExternalProxyAccountTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFilePayment.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFilePayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFundsConfirmationResponse.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRFundsConfirmationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalResponseDataRefund.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRInternationalResponseDataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRMandateRelatedInformation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRMandateRelatedInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRProxy.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryAuthority.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryAuthority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReporting.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReporting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReportingDebitCreditReportingIndicator.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRRegulatoryReportingDebitCreditReportingIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequency.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequencyCode.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStandingOrderFrequencyCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStructuredRegulatoryReporting.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRStructuredRegulatoryReporting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateCreditor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateDebtor.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRUltimateDebtor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomestic.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomestic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataDomesticStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataFile.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDataFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomestic.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomestic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticScheduledDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteDomesticStandingOrderDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFile.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteFileDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternational.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternational.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduled.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalScheduledDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrder.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/payment/FRWriteInternationalStandingOrderDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/tpp/Tpp.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/tpp/Tpp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPConsentData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVRPControlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpInstruction.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequestData.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRDomesticVrpRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRPeriodicLimits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionTypes.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRVRPInteractionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRWriteDomesticVrpDataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/vrp/FRWriteDomesticVrpDataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtilsTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/ConversionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRReadConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRReadConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRChargeConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRChargeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRLinksConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRLinksConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRPostalAddressConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRPostalAddressConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRiskConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/common/FRRiskConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/funds/FRFundsConfirmationConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticScheduledConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteFileConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalScheduledConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVRPConsentConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVRPConsentConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVrpConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/vrp/FRDomesticVrpConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRReadConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRReadConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRChargeConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRChargeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRRiskConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/common/FRRiskConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/funds/FRFundsConfirmationConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticScheduledConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteDomesticStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteFileConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/payment/FRWriteInternationalStandingOrderConsentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRFinancialAgentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRFinancialAgentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/FRPostalAddressTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountBeneficiaryTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountBeneficiaryTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountWithBalanceTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRAccountWithBalanceTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRCashBalanceTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRCashBalanceTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRDirectDebitDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRDirectDebitDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRFinancialAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRFinancialAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FROfferDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FROfferDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRPartyDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRPartyDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRScheduledPaymentDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRScheduledPaymentDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStandingOrderDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStandingOrderDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStatementDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRStatementDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRTransactionDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/account/FRTransactionDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRPaymentRiskTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRPaymentRiskTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRWriteDomesticDataInitiationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/payment/FRWriteDomesticDataInitiationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/tpp/TppTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/tpp/TppTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRFinancialAgentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRFinancialAgentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRFrequencyTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRFrequencyTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRLocalAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRLocalAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRMandateRelatedInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRMandateRelatedInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRProxyTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRProxyTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRTotalValueTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/FRTotalValueTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRAccountBeneficiaryTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRAccountBeneficiaryTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRAccountIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRAccountIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRCashBalanceTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRCashBalanceTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRCreditLineTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRCreditLineTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRDirectDebitDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRDirectDebitDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRFinancialAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRFinancialAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRPartyDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRPartyDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRScheduledPaymentDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRScheduledPaymentDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStandingOrderDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStandingOrderDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStatementDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStatementDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStatementFrequencyAndFormatTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRStatementFrequencyAndFormatTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRTransactionDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/testsupport/v4/account/FRTransactionDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/pom.xml
+++ b/secure-api-gateway-ob-uk-common-error/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmp.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/FileParseException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/FileParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorResponseException.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBErrorResponseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorResponseCategory.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorResponseCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-error/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/error/OBRIErrorTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-error/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmpTest.java
+++ b/secure-api-gateway-ob-uk-common-error/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/error/ErrorResponseTmpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBStandardErrorCodes1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBStandardErrorCodes1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/StandardErrorCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/StandardErrorCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtil.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/AgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/AgreementPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ApplicationFrequency5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/BankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/BankInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/BankInterestRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/BankInterestRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationFrequency5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CalculationMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CappingPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CappingPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CappingPeriod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CappingPeriod1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CreditInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/CreditInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/DepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/DepositInterestAppliedCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/DepositInterestAppliedCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/DepositInterestAppliedCoverage1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Destination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Destination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Destination1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Destination1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeCategory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeCapInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeChargeDetailInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeFreeLengthPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeRateType3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2Inner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2Inner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType2Inner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType4Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeType4Inner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FixedVariableInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/FixedVariableInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/MinMaxType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/MinMaxType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/MinMaxType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/MinMaxType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Model.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6AccountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6AccountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccount6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccountStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBAccountStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount8.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount9.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBActiveOrHistoricCurrencyAndAmount9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBalanceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBalanceType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiary5Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiaryType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBeneficiaryType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification62.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBranchAndFinancialInstitutionIdentification62.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCashAccount61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCreditDebitCode2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCurrencyExchange5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCurrencyExchange5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCurrencyExchange5InstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBCurrencyExchange5InstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBEntryStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBEntryStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalAccountSubType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalAccountSubType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalDirectDebitStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalDirectDebitStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalPartyType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalPartyType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalScheduleType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalScheduleType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStandingOrderStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStandingOrderStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStatementAmountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStatementAmountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStatementType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBExternalStatementType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeCategory1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeCategory1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeFrequency1Code4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestCalculationMethod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestCalculationMethod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestFixedVariableType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestFixedVariableType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestRateType1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestRateType1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestRateType1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBInterestRateType1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBMerchantDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBMerchantDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBMinMaxType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBMinMaxType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType12.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType13.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType14.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType15.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType16.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType17.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType17.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType18.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherCodeType18.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherFeeChargeDetailType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOtherFeeChargeDetailType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOverdraftFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBOverdraftFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBParty2AddressInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBParty2AddressInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPartyRelationships1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPartyRelationships1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPartyRelationships1Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPartyRelationships1Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPeriod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBPeriod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadAccount6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadAccount6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBeneficiary5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadBeneficiary5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDataStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDataStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDataTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDataTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2DataDirectDebitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadDirectDebit2DataDirectDebitInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerFee.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerOfferType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadOffer1DataOfferInnerOfferType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadParty3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadProduct2DataProductInnerProductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadScheduledPayment3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadScheduledPayment3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStandingOrder6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStandingOrder6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBReadTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBRisk2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBRisk2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBScheduledPayment3Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStandingOrder6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementAmountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementAmountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementBenefitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementBenefitInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementDateTimeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementDateTimeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementFeeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementFeeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementInterestInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementInterestInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementRateInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementRateInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementValueInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBStatement2StatementValueInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransaction6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1AuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1AuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1CardSchemeName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCardInstrument1CardSchemeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCashBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCashBalanceAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionCashBalanceAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionMutability1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBTransactionMutability1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherApplicationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherCalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherCalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherCalculationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeCategoryType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeCategoryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Overdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Overdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Overdraft1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/Overdraft1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeCapInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeeChargeDetailInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftFeesChargesInner3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftInterestChargingCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftInterestChargingCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftInterestChargingCoverage1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftTierBandSetInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OverdraftType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProprietaryBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/ProprietaryBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/SegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/SegmentInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/SegmentInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/SegmentInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandMethod3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/TierBandSetInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/Links.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/Meta.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBActiveOrHistoricCurrencyAndAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBAddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBBranchAndFinancialInstitutionIdentification6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBBranchAndFinancialInstitutionIdentification6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBCashAccountCreditor3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBCashAccountCreditor3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBChargeBearerType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBChargeBearerType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalAccountIdentification4Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalAccountIdentification4Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalPaymentContext1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalPaymentContext1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalPermissions1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalPermissions1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalRequestStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBExternalRequestStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBPostalAddress6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBPostalAddress6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBRisk1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBRisk1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBRisk1DeliveryAddress.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBRisk1DeliveryAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBSupplementaryData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBSupplementaryData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBVRPAuthenticationMethods.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBVRPAuthenticationMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBVRPConsentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/common/OBVRPConsentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/AddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/AddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/CustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/CustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/CustomerInfoAddress.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/CustomerInfoAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/ReadCustomerInfo.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/customerinfo/ReadCustomerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/GenericOBDiscoveryAPILinks.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/GenericOBDiscoveryAPILinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscovery.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPI.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinks.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksAccount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksEventNotification3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksEventNotification3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksEventNotification4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksEventNotification4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksFundsConfirmation3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksFundsConfirmation3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksPayment4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksVrpPayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryAPILinksVrpPayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/discovery/OBDiscoveryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/error/OBError1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/error/OBError1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/error/OBErrorResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/error/OBErrorResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEvent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEvent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventLink1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventLink1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventNotification1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventNotification1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPolling1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPolling1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPolling1SetErrsValue.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPolling1SetErrsValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPollingResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventPollingResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventResourceUpdate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventResourceUpdate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubject1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubject1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscription1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscription1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscription1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscription1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1DataInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmation1DataInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/fund/OBFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/ConverterHelper.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/ConverterHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBAccountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBAccountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBAmountConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBAmountConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBCashAccountDebtor4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBCashAccountDebtor4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBExchangeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBExchangeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBExternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBExternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBInternationalIdentifierConverter.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBInternationalIdentifierConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBPaymentConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBPaymentConsentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1AppliedAuthenticationApproach.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1AppliedAuthenticationApproach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1RequestedSCAExemptionType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBSCASupportData1RequestedSCAExemptionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4DataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4DataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4DataAuthorisationAuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsent4DataAuthorisationAuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataMultiAuthorisationStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataMultiAuthorisationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduled2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4DataPermission.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsent4DataPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticScheduledResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteDomesticStandingOrderResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFile2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileConsentResponse4DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFileResponse3DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationInstructionPriority.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternational3DataInitiationInstructionPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefundAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalResponse5DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduled3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalScheduledResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsent6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsent6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsent6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsent6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWriteInternationalStandingOrderResponse7DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/payment/OBWritePaymentDetailsResponse1DataPaymentStatusInnerStatusDetailStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBCashAccountDebtorWithName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBCashAccountDebtorWithName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseDataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseDataDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseDataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPConsentResponseDataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInnerPeriodAlignment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInnerPeriodAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInnerPeriodType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPControlParametersPeriodicLimitsInnerPeriodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetailStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetailStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInitiationRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInitiationRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInstruction.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseDataChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseDataChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseDataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBDomesticVRPResponseDataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalPaymentChargeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalPaymentChargeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalStatus2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBExternalStatus2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPAFundsAvailableResult1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPAFundsAvailableResult1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPAFundsAvailableResult1FundsAvailable.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPAFundsAvailableResult1FundsAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPeriodAlignment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPeriodAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPeriodType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBPeriodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPFundsConfirmationResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPInteractionTypes.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPInteractionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/vrp/OBVRPRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/AgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/AgreementPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ApplicationFrequency5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/BankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/BankInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/BankInterestRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/BankInterestRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationFrequency5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CalculationMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CappingPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CappingPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CappingPeriod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CappingPeriod1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CreditInterest1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/CreditInterest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/DepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/DepositInterestAppliedCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/DepositInterestAppliedCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/DepositInterestAppliedCoverage1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Destination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Destination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Destination1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Destination1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ExternalEntryStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ExternalEntryStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ExternalMandateStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ExternalMandateStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeCategory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeCapInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeChargeDetailInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeFreeLengthPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeRateType3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2Inner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2Inner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType2Inner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType4Inner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeType4Inner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FixedVariableInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/FixedVariableInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/MinMaxType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/MinMaxType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/MinMaxType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/MinMaxType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Model.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Model.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6AccountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6AccountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6DetailAccountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBAccount6DetailAccountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount8.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount9.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBActiveOrHistoricCurrencyAndAmount9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBalanceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBalanceType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBeneficiary5Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification62.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBranchAndFinancialInstitutionIdentification62.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount50.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount51.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount51.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount61.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCashAccount61.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCommunicationMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCommunicationMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCreditDebitCode2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCurrencyExchange5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCurrencyExchange5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCurrencyExchange5InstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBCurrencyExchange5InstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExtendedProprietaryBankTransactionCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExtendedProprietaryBankTransactionCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalAccountSubType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalAccountSubType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalBalanceSubType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalBalanceSubType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalMandateClassification1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalMandateClassification1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalPurpose1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBExternalPurpose1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeCategory1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeCategory1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeFrequency1Code4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFileFormat.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFileFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency6Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequency6Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequencyPeriodType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBFrequencyPeriodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestCalculationMethod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestCalculationMethod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestFixedVariableType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestFixedVariableType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestRateType1Code0.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestRateType1Code0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestRateType1Code1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInterestRateType1Code1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountIdentification4Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountIdentification4Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountStatus1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountStatus1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalBeneficiaryType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalBeneficiaryType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalPartyType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalPartyType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalPermissions1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalPermissions1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalScheduleType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalScheduleType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalStatementType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalStatementType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalTransactionMutability1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBInternalTransactionMutability1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMandateRelatedInformation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMandateRelatedInformation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMerchantDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMerchantDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMinMaxType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBMinMaxType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType10.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType11.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType12.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType13.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType14.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType15.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType16.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType17.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType17.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType18.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherCodeType18.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherFeeChargeDetailType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOtherFeeChargeDetailType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOverdraftFeeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBOverdraftFeeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPCAData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPCAData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPartyRelationships1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPartyRelationships1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPartyRelationships1Account.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPartyRelationships1Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPeriod1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBPeriod1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadAccount6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadAccount6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadAccount6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadAccount6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerAmountSubType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerAmountSubType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerCreditLineInnerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerLocalAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerLocalAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerLocalAmountSubType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataBalanceInnerLocalAmountSubType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataTotalValue.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBalance1DataTotalValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBeneficiary5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBeneficiary5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBeneficiary5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadBeneficiary5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadConsentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDataStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDataStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDataTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDataTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2DataDirectDebitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadDirectDebit2DataDirectDebitInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerFee.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerOfferType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadOffer1DataOfferInnerOfferType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadParty3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerBankInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerCalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerDepositInterestAppliedCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandInnerOtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeCreditInterestTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeCapInnerFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanInterestFeesChargesInnerLoanInterestFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerLoanProviderInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMaxTermPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerMinTermPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerLoanInterestTierBandInnerOtherLoanProviderInterestRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeLoanInterestLoanInterestTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeApplicableRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerFeeChargeDetailInnerFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerOtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOtherFeesChargesInnerTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerAgreementPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeCapInnerOtherFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftFeesChargesInnerOverdraftFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftTierBandInnerOverdraftInterestChargingCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerOverdraftType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeOverdraftOverdraftTierBandSetInnerTierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsFeeFreeLengthPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeProductDetailsSegmentInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepayment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentAmountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherAmountType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentOtherRepaymentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentHolidayInnerMaxHolidayPeriod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerOtherProductTypeRepaymentRepaymentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerProductType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadProduct2DataProductInnerProductType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadScheduledPayment3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadScheduledPayment3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStandingOrder6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStandingOrder6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReadTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReferredDocumentInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBReferredDocumentInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformation2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformation2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformationStructured.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformationStructured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformationStructuredCreditorReferenceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBRemittanceInformationStructuredCreditorReferenceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBScheduledPayment3Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStandingOrder6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2DetailStatementAmountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2DetailStatementAmountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerAmountSubType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerAmountSubType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerLocalAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerLocalAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerLocalAmountSubType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementAmountInnerLocalAmountSubType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementBenefitInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementBenefitInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementDateTimeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementDateTimeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementFeeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementFeeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementInterestInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementInterestInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementRateInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementRateInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementValueInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBStatement2StatementValueInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6Basic.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6Detail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransaction6Detail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1AuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1AuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1CardSchemeName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCardInstrument1CardSchemeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCashBalance.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCashBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCashBalanceAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBTransactionCashBalanceAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherApplicationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherApplicationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherApplicationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherApplicationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherBankInterestType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherBankInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherCalculationFrequency.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherCalculationFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherCalculationFrequency1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherCalculationFrequency1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeCategoryType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeCategoryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeRateType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeRateType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeTypeInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeeTypeInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeesCharges.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeesCharges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherTariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OtherTariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Overdraft.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Overdraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Overdraft1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/Overdraft1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCap.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCapInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCapInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCapInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeCapInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeDetailInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeeChargeDetailInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftFeesChargesInner3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftInterestChargingCoverage.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftInterestChargingCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftInterestChargingCoverage1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftInterestChargingCoverage1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftTierBandSetInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftType1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OverdraftType1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProductDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProductDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProductDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProductDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProprietaryBankTransactionCodeStructure1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/ProprietaryBankTransactionCodeStructure1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/SegmentInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/SegmentInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/SegmentInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/SegmentInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/StatementFrequencyAndFormatInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/StatementFrequencyAndFormatInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TariffType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TariffType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandMethod3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandSetInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandSetInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandSetInner1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/TierBandSetInner1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalCategoryPurpose1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalCategoryPurpose1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalCreditorReferenceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalCreditorReferenceType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalDocumentType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalDocumentType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalProxyAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalProxyAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalPurpose1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/ExternalPurpose1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Links.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Meta.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/Meta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBActiveOrHistoricCurrencyAndAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressType2Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressType2Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressTypeCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBAddressTypeCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBBranchAndFinancialInstitutionIdentification60.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBCashAccountCreditor3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBCashAccountCreditor3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBInternalChargeBearerType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBInternalChargeBearerType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBInternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBInternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBPostalAddress7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBPostalAddress7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBProxy1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBProxy1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1PaymentContextCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBRisk1PaymentContextCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBUltimateCreditor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBUltimateCreditor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBUltimateDebtor1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/common/OBUltimateDebtor1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/error/OBError1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/error/OBError1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/error/OBErrorResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/error/OBErrorResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEvent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEvent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventLink1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventLink1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventNotification1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventNotification1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1SetErrsValue.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPolling1SetErrsValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPollingResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventPollingResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventResourceUpdate1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventResourceUpdate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubject1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubject1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscription1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/event/OBEventSubscriptionsResponse1DataEventSubscriptionInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1DataInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmation1DataInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1DataDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentResponse1DataDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationConsentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/fund/OBFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBCashAccountDebtor4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBCashAccountDebtor4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBExchangeRateType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBExchangeRateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBExternalMandateClassification1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBExternalMandateClassification1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBFrequency6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBFrequency6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBFrequency6Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBFrequency6Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBMandateRelatedInformation1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBMandateRelatedInformation1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBPaymentConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBPaymentConsentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBPaymentStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBPaymentStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBReferredDocumentInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBReferredDocumentInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryAuthority2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryAuthority2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryReporting1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryReporting1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryReporting1DebitCreditReportingIndicator.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRegulatoryReporting1DebitCreditReportingIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformation2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformation2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformationStructured.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformationStructured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformationStructuredCreditorReferenceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBRemittanceInformationStructuredCreditorReferenceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1AppliedAuthenticationApproach.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1AppliedAuthenticationApproach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1RequestedSCAExemptionType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBSCASupportData1RequestedSCAExemptionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBStructuredRegulatoryReporting3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBStructuredRegulatoryReporting3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4DataAuthorisationAuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsent4DataAuthorisationAuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentDataAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentDataAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataAuthorisationAuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataAuthorisationAuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticConsentResponse5DataReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataMultiAuthorisationStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataMultiAuthorisationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduled2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4DataPermission.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsent4DataPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledConsentResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataMultiAuthorisationStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataMultiAuthorisationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticScheduledResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsent5DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6DataAuthorisationAuthorisationType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6DataAuthorisationAuthorisationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteDomesticStandingOrderResponse6DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFile2DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsent3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsent3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsent3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsent3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileConsentResponse4DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataMultiAuthorisation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataMultiAuthorisation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataMultiAuthorisationStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataMultiAuthorisationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFileResponse3DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationInstructionPriority.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternational3DataInitiationInstructionPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5DataReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsent5DataReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalConsentResponse6DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalResponse5DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduled3DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataPermission.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsent5DataPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalScheduledResponse6DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsent6DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWriteInternationalStandingOrderResponse7DataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatusStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatusStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatusStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1PaymentStatusStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1Status.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1StatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1StatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1StatusDetailStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetails1StatusDetailStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1Data.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/payment/OBWritePaymentDetailsResponse1Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBCashAccountDebtorWithName.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBCashAccountDebtorWithName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBCharge2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBCharge2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequestDataReadRefundAccount.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentRequestDataReadRefundAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPConsentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParameters.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParametersPeriodicLimitsInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPControlParametersPeriodicLimitsInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetails.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataPaymentStatusInnerStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStausDetailInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStausDetailInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStausDetailInnerStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPDetailsDataStausDetailInnerStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPInitiation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPInitiation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPInstruction.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPInstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseDataChargesInner.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseDataChargesInner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseDataStatus.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBDomesticVRPResponseDataStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalCreditorReferenceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalCreditorReferenceType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalPurpose1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBExternalPurpose1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBInternalExtendedAccountType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBInternalExtendedAccountType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBInternalPaymentChargeType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBInternalPaymentChargeType1Code.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPAFundsAvailableResult1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPAFundsAvailableResult1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPAFundsAvailableResult1FundsAvailable.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPAFundsAvailableResult1FundsAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPaymentStatusReason.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPaymentStatusReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPeriodAlignment.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPeriodAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPeriodType.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBPeriodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBReferredDocumentInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBReferredDocumentInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryAuthority2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryAuthority2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryReporting1.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryReporting1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryReporting1DebitCreditReportingIndicator.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRegulatoryReporting1DebitCreditReportingIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformation2.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformation2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformationStructured.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformationStructured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformationStructuredCreditorReferenceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBRemittanceInformationStructuredCreditorReferenceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBStructuredRegulatoryReporting3.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBStructuredRegulatoryReporting3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationRequest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationRequestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationRequestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationResponse.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationResponseData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPFundsConfirmationResponseData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPInteractionTypes.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPInteractionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPRemittanceInformation.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/vrp/OBVRPRemittanceInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/DateTimeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateDeserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateFormat.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateSerializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/LocalDateSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/account/OBRisk2Deserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/account/OBRisk2Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/account/OBRisk2Serializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/account/OBRisk2Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/common/OBSupplementaryData1Deserializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/common/OBSupplementaryData1Deserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/common/OBSupplementaryData1Serializer.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/jackson/v3/common/OBSupplementaryData1Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/account/AccountOBRisk2FieldTests.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/account/AccountOBRisk2FieldTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityBigDecimalUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtilTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/utils/EqualityVerificationUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/VRPOBSupplementaryDataFieldTests.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/datamodel/vrp/VRPOBSupplementaryDataFieldTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBConsentAuthorisationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBConsentAuthorisationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBExchangeRateTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBExchangeRateTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBInternationalIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBInternationalIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBPostalAddress6TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBPostalAddress6TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBRisk1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBRisk1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteFileConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteFileConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/ConstantsVrpTestData.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/ConstantsVrpTestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpCommonTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpCommonTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBDomesticVrpRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v3/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBAccountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBAccountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBAmountTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBAmountTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBConsentAuthorisationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBConsentAuthorisationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBExchangeRateTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBExchangeRateTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBInternationalIdentifierTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBInternationalIdentifierTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBMandateRelatedInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBMandateRelatedInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRegulatoryReporting1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRegulatoryReporting1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRemittanceInformationTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRemittanceInformationTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRisk1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBRisk1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBUltimateCreditor1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBUltimateCreditor1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBUltimateDebtor1TestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBUltimateDebtor1TestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticScaSupportDataTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteFileConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteFileConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVRPConsentResponseTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpCommonTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpCommonTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpConsentRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBDomesticVrpRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/v4/vrp/OBVrpFundsConfirmationRequestTestDataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/pom.xml
+++ b/secure-api-gateway-ob-uk-common-shared/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequency.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyCode6.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyCode6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRQuarterType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRQuarterType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBConstants.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBGroupName.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBGroupName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBHeaders.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBJoseHeaderClaims.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBJoseHeaderClaims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersion.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/share/IntentType.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/share/IntentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claim.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claims.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/Claims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtils.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/JodaTimeConverters.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/JodaTimeConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/main/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/forgerock/FRFrequencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersionTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/api/meta/obie/OBVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtilsTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/claim/JwsClaimsUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/fapi/FapiInteractionIdContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/JodaTimeConvertersTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/converter/JodaTimeConvertersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
+++ b/secure-api-gateway-ob-uk-common-shared/src/test/java/com/forgerock/sapi/gateway/uk/common/shared/spring/web/filter/FapiInteractionIdFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update Parent to 4.0.4-SNAPSHOT and run build-java

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1654