### PR TITLE
OPENIG-10374 Fix FRBalanceTypeConverter missing mappings for OBBalanceType1Code

### DIFF
--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverter.java
@@ -34,13 +34,16 @@ public class FRBalanceTypeConverter {
         final Map<String, String> consentBalanceTypeTransalations = new HashMap<>();
         consentBalanceTypeTransalations.put("ClosingAvailable", "CLAV");
         consentBalanceTypeTransalations.put("ClosingBooked", "CLBD");
+        consentBalanceTypeTransalations.put("ClosingCleared", "CLCL");
         consentBalanceTypeTransalations.put("Expected", "XPCD");
         consentBalanceTypeTransalations.put("ForwardAvailable", "FWAV");
         consentBalanceTypeTransalations.put("Information", "INFO");
         consentBalanceTypeTransalations.put("InterimAvailable", "ITAV");
         consentBalanceTypeTransalations.put("InterimBooked", "ITBD");
+        consentBalanceTypeTransalations.put("InterimCleared", "ITCL");
         consentBalanceTypeTransalations.put("OpeningAvailable", "OPAV");
         consentBalanceTypeTransalations.put("OpeningBooked", "OPBD");
+        consentBalanceTypeTransalations.put("OpeningCleared", "OPCL");
         consentBalanceTypeTransalations.put("PreviouslyClosedBooked", "PRCD");
 
         v3tov4BalanceType = Collections.unmodifiableMap(consentBalanceTypeTransalations);
@@ -56,14 +59,17 @@ public class FRBalanceTypeConverter {
         return switch (balanceType) {
             case CLOSINGAVAILABLE -> OBBalanceType1Code.CLAV;
             case CLOSINGBOOKED -> OBBalanceType1Code.CLBD;
+            case CLOSINGCLEARED -> OBBalanceType1Code.CLCL;
             case EXPECTED -> OBBalanceType1Code.XPCD;
             case FORWARDAVAILABLE -> OBBalanceType1Code.FWAV;
             case INFORMATION -> OBBalanceType1Code.INFO;
+            case INTERIMAVAILABLE -> OBBalanceType1Code.ITAV;
             case INTERIMBOOKED -> OBBalanceType1Code.ITBD;
+            case INTERIMCLEARED -> OBBalanceType1Code.ITCL;
             case OPENINGAVAILABLE -> OBBalanceType1Code.OPAV;
             case OPENINGBOOKED -> OBBalanceType1Code.OPBD;
+            case OPENINGCLEARED -> OBBalanceType1Code.OPCL;
             case PREVIOUSLYCLOSEDBOOKED -> OBBalanceType1Code.PRCD;
-            default -> OBBalanceType1Code.ITAV;
         };
     }
 
@@ -80,6 +86,4 @@ public class FRBalanceTypeConverter {
         }
         throw new IllegalArgumentException("Unknown balanceType: " + balanceType);
     }
-
-    //TODO - add for other balance Types
 }

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2020-2026 Ping Identity Corporation (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v4.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRBalanceType;
+
+import uk.org.openbanking.datamodel.v4.account.OBBalanceType1Code;
+
+class FRBalanceTypeConverterTest {
+
+    static Stream<Arguments> frBalanceTypeToOBBalanceType1CodeMappings() {
+        return Stream.of(
+                Arguments.of(FRBalanceType.CLOSINGAVAILABLE,      OBBalanceType1Code.CLAV),
+                Arguments.of(FRBalanceType.CLOSINGBOOKED,         OBBalanceType1Code.CLBD),
+                Arguments.of(FRBalanceType.CLOSINGCLEARED,        OBBalanceType1Code.CLCL),
+                Arguments.of(FRBalanceType.EXPECTED,              OBBalanceType1Code.XPCD),
+                Arguments.of(FRBalanceType.FORWARDAVAILABLE,      OBBalanceType1Code.FWAV),
+                Arguments.of(FRBalanceType.INFORMATION,           OBBalanceType1Code.INFO),
+                Arguments.of(FRBalanceType.INTERIMAVAILABLE,      OBBalanceType1Code.ITAV),
+                Arguments.of(FRBalanceType.INTERIMBOOKED,         OBBalanceType1Code.ITBD),
+                Arguments.of(FRBalanceType.INTERIMCLEARED,        OBBalanceType1Code.ITCL),
+                Arguments.of(FRBalanceType.OPENINGAVAILABLE,      OBBalanceType1Code.OPAV),
+                Arguments.of(FRBalanceType.OPENINGBOOKED,         OBBalanceType1Code.OPBD),
+                Arguments.of(FRBalanceType.OPENINGCLEARED,        OBBalanceType1Code.OPCL),
+                Arguments.of(FRBalanceType.PREVIOUSLYCLOSEDBOOKED, OBBalanceType1Code.PRCD)
+        );
+    }
+
+    static Stream<Arguments> longFormToOBBalanceType1CodeMappings() {
+        return Stream.of(
+                Arguments.of("ClosingAvailable",       OBBalanceType1Code.CLAV),
+                Arguments.of("ClosingBooked",          OBBalanceType1Code.CLBD),
+                Arguments.of("ClosingCleared",         OBBalanceType1Code.CLCL),
+                Arguments.of("Expected",               OBBalanceType1Code.XPCD),
+                Arguments.of("ForwardAvailable",       OBBalanceType1Code.FWAV),
+                Arguments.of("Information",            OBBalanceType1Code.INFO),
+                Arguments.of("InterimAvailable",       OBBalanceType1Code.ITAV),
+                Arguments.of("InterimBooked",          OBBalanceType1Code.ITBD),
+                Arguments.of("InterimCleared",         OBBalanceType1Code.ITCL),
+                Arguments.of("OpeningAvailable",       OBBalanceType1Code.OPAV),
+                Arguments.of("OpeningBooked",          OBBalanceType1Code.OPBD),
+                Arguments.of("OpeningCleared",         OBBalanceType1Code.OPCL),
+                Arguments.of("PreviouslyClosedBooked", OBBalanceType1Code.PRCD)
+        );
+    }
+
+    static Stream<Arguments> shortCodeToFRBalanceTypeMappings() {
+        return Stream.of(
+                Arguments.of("CLAV", FRBalanceType.CLOSINGAVAILABLE.getValue()),
+                Arguments.of("CLBD", FRBalanceType.CLOSINGBOOKED.getValue()),
+                Arguments.of("CLCL", FRBalanceType.CLOSINGCLEARED.getValue()),
+                Arguments.of("XPCD", FRBalanceType.EXPECTED.getValue()),
+                Arguments.of("FWAV", FRBalanceType.FORWARDAVAILABLE.getValue()),
+                Arguments.of("INFO", FRBalanceType.INFORMATION.getValue()),
+                Arguments.of("ITAV", FRBalanceType.INTERIMAVAILABLE.getValue()),
+                Arguments.of("ITBD", FRBalanceType.INTERIMBOOKED.getValue()),
+                Arguments.of("ITCL", FRBalanceType.INTERIMCLEARED.getValue()),
+                Arguments.of("OPAV", FRBalanceType.OPENINGAVAILABLE.getValue()),
+                Arguments.of("OPBD", FRBalanceType.OPENINGBOOKED.getValue()),
+                Arguments.of("OPCL", FRBalanceType.OPENINGCLEARED.getValue()),
+                Arguments.of("PRCD", FRBalanceType.PREVIOUSLYCLOSEDBOOKED.getValue())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("frBalanceTypeToOBBalanceType1CodeMappings")
+    void toOBBalanceType1Code_mapsAllFRBalanceTypesToExpectedCode(FRBalanceType frBalanceType,
+                                                                   OBBalanceType1Code expectedCode) {
+        assertThat(FRBalanceTypeConverter.toOBBalanceType1Code(frBalanceType)).isEqualTo(expectedCode);
+    }
+
+    @ParameterizedTest
+    @MethodSource("longFormToOBBalanceType1CodeMappings")
+    void toOBBalanceType1CodeV4_mapsAllLongFormStringsToExpectedCode(String longForm,
+                                                                      OBBalanceType1Code expectedCode) {
+        assertThat(FRBalanceTypeConverter.toOBBalanceType1CodeV4(longForm)).isEqualTo(expectedCode);
+    }
+
+    @ParameterizedTest
+    @MethodSource("shortCodeToFRBalanceTypeMappings")
+    void toFRBalanceTypeV3_mapsAllShortCodesToExpectedLongForm(String shortCode, String expectedLongForm) {
+        assertThat(FRBalanceTypeConverter.toFRBalanceTypeV3(shortCode).getValue()).isEqualTo(expectedLongForm);
+    }
+
+    @Test
+    void toOBBalanceType1Code_returnsNullForNullInput() {
+        assertNull(FRBalanceTypeConverter.toOBBalanceType1Code(null));
+    }
+
+    @Test
+    void toOBBalanceType1CodeV4_throwsIllegalArgumentExceptionForUnknownValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FRBalanceTypeConverter.toOBBalanceType1CodeV4("UnknownBalanceType"));
+    }
+
+    @Test
+    void toFRBalanceTypeV3_throwsIllegalArgumentExceptionForUnknownValue() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FRBalanceTypeConverter.toFRBalanceTypeV3("XXXX"));
+    }
+}

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBalanceType1Code.java
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBalanceType1Code.java
@@ -31,6 +31,8 @@ public enum OBBalanceType1Code {
 
     CLBD("CLBD"),
 
+    CLCL("CLCL"),
+
     FWAV("FWAV"),
 
     INFO("INFO"),
@@ -39,9 +41,13 @@ public enum OBBalanceType1Code {
 
     ITBD("ITBD"),
 
+    ITCL("ITCL"),
+
     OPAV("OPAV"),
 
     OPBD("OPBD"),
+
+    OPCL("OPCL"),
 
     PRCD("PRCD"),
 

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r2.yaml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r2.yaml
@@ -5198,12 +5198,15 @@ components:
       enum:
         - CLAV
         - CLBD
+        - CLCL
         - FWAV
         - INFO
         - ITAV
         - ITBD
+        - ITCL
         - OPAV
         - OPBD
+        - OPCL
         - PRCD
         - XPCD
     OBBankTransactionCodeStructure1:

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r3.yaml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r3.yaml
@@ -5198,12 +5198,15 @@ components:
       enum:
         - CLAV
         - CLBD
+        - CLCL
         - FWAV
         - INFO
         - ITAV
         - ITBD
+        - ITCL
         - OPAV
         - OPBD
+        - OPCL
         - PRCD
         - XPCD
     OBBankTransactionCodeStructure1:

--- a/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r4.yaml
+++ b/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/resources/specification/4.0.0/account-info-openapi-4r4.yaml
@@ -5207,12 +5207,15 @@ components:
       enum:
         - CLAV
         - CLBD
+        - CLCL
         - FWAV
         - INFO
         - ITAV
         - ITBD
+        - ITCL
         - OPAV
         - OPBD
+        - OPCL
         - PRCD
         - XPCD
     OBBankTransactionCodeStructure1:


### PR DESCRIPTION
The branch is pushed with 3 commits:
  - fe32d534 — Add CLCL, ITCL, OPCL to OBBalanceType1Code v4 enum and YAML specs
  - 43c2380e — Fix FRBalanceTypeConverter static map and switch for all 13 balance types
  - 8946434a — Add FRBalanceTypeConverterTest for all 13 balance type mappings
  
One thing worth noting in the PR description: the reviewer spotted a pre-existing latent bug in `FRCashBalanceConverter.java`:61 where
  `OBBalanceType1Code.valueOf(type.name())` would fail at runtime (enum name mismatch). It's out of scope for this fix but worth a follow-up ticket.

