### PR TITLE
OPENIG-10455 fix v4 converter classes enum conversion fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 release.properties
 pom.xml.releaseBackup
 pom.xml.tag
+.polaris/

--- a/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverter.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverter.java
@@ -57,10 +57,6 @@ public class FRCashBalanceConverter {
                 .creditLine(toOBReadBalance1DataCreditLineList(balance.getCreditLines()));
     }
 
-    public static OBBalanceType1Code toOBBalanceType1Code(FRBalanceType type) {
-        return type == null ? null : OBBalanceType1Code.valueOf(type.name());
-    }
-
     public static List<OBReadBalance1DataBalanceInnerCreditLineInner> toOBReadBalance1DataCreditLineList(List<FRCreditLine> creditLines) {
         return creditLines == null ? null : creditLines.stream()
                 .map(FRCashBalanceConverter::toOBReadBalance1DataCreditLine)

--- a/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverterTest.java
+++ b/secure-api-gateway-ob-uk-common-datamodel/src/test/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020-2026 Ping Identity Corporation (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v4.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.forgerock.sapi.gateway.ob.uk.common.datamodel.account.FRCreditLine.FRLimitType;
+
+import uk.org.openbanking.datamodel.v4.account.OBReadBalance1DataBalanceInnerCreditLineInnerType;
+
+class FRCashBalanceConverterTest {
+
+    static Stream<Arguments> frLimitTypeToOBCreditLineTypeMappings() {
+        return Stream.of(
+                Arguments.of(FRLimitType.AVAILABLE,  OBReadBalance1DataBalanceInnerCreditLineInnerType.AVAILABLE),
+                Arguments.of(FRLimitType.CREDIT,     OBReadBalance1DataBalanceInnerCreditLineInnerType.CREDIT),
+                Arguments.of(FRLimitType.EMERGENCY,  OBReadBalance1DataBalanceInnerCreditLineInnerType.EMERGENCY),
+                Arguments.of(FRLimitType.PRE_AGREED, OBReadBalance1DataBalanceInnerCreditLineInnerType.PRE_AGREED),
+                Arguments.of(FRLimitType.TEMPORARY,  OBReadBalance1DataBalanceInnerCreditLineInnerType.TEMPORARY)
+        );
+    }
+
+    static Stream<Arguments> obCreditLineTypeToFRLimitTypeMappings() {
+        return Stream.of(
+                Arguments.of(OBReadBalance1DataBalanceInnerCreditLineInnerType.AVAILABLE,  FRLimitType.AVAILABLE),
+                Arguments.of(OBReadBalance1DataBalanceInnerCreditLineInnerType.CREDIT,     FRLimitType.CREDIT),
+                Arguments.of(OBReadBalance1DataBalanceInnerCreditLineInnerType.EMERGENCY,  FRLimitType.EMERGENCY),
+                Arguments.of(OBReadBalance1DataBalanceInnerCreditLineInnerType.PRE_AGREED, FRLimitType.PRE_AGREED),
+                Arguments.of(OBReadBalance1DataBalanceInnerCreditLineInnerType.TEMPORARY,  FRLimitType.TEMPORARY)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("frLimitTypeToOBCreditLineTypeMappings")
+    void toOBReadBalance1DataCreditLineType_mapsAllFRLimitTypesToExpectedOBType(FRLimitType frLimitType,
+                                                                                OBReadBalance1DataBalanceInnerCreditLineInnerType expectedType) {
+        assertThat(FRCashBalanceConverter.toOBReadBalance1DataCreditLineType(frLimitType)).isEqualTo(expectedType);
+    }
+
+    @ParameterizedTest
+    @MethodSource("obCreditLineTypeToFRLimitTypeMappings")
+    void toFRLimitType_mapsAllOBCreditLineTypesToExpectedFRLimitType(OBReadBalance1DataBalanceInnerCreditLineInnerType obType,
+                                                                      FRLimitType expectedFRLimitType) {
+        assertThat(FRCashBalanceConverter.toFRLimitType(obType)).isEqualTo(expectedFRLimitType);
+    }
+
+    @Test
+    void toOBReadBalance1DataCreditLineType_returnsNullForNullInput() {
+        assertNull(FRCashBalanceConverter.toOBReadBalance1DataCreditLineType(null));
+    }
+
+    @Test
+    void toFRLimitType_returnsNullForNullInput() {
+        assertNull(FRCashBalanceConverter.toFRLimitType(null));
+    }
+}


### PR DESCRIPTION
## OPENIG-10455 
Remove unsafe dead `toOBBalanceType1Code(FRBalanceType)`from `FRCashBalanceConverter` and add `FRCashBalanceConverterTest`

I've checked downstream repos and it's actually dead code. So, even though there is a bug there, the code isn't ever used. It looks like it was migrated from v3 to v4 and just left, even though no longer relevant. It's the only occurrence of this type of bug in the ob-uk-common codebase.
  
The `oOBBalanceType1Code(FRBalanceType)` method in the v4 `FRCashBalanceConverter` was dead code (live path routes through `FRBalanceTypeConverter.toOBBalanceType1CodeV4)` and unsafe (FR constant names diverge from OB v4 constant names, so a runtime call would throw `IllegalArgumentException`). The method is removed.

A new `FRCashBalanceConverterTest` is added covering the two remaining safe `valueOf(name())` conversions — `toOBReadBalance1DataCreditLineType` and `toFRLimitType` — with parameterised round-trip tests for all five `FRLimitType` constants and null-input guards.

### Detailed description of the bug, and why `v3` is not affected

#### OB v3

[v3/account/FRCashBalanceConverter.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRCashBalanceConverter.java) impl as follows:
```
    public static OBBalanceType1Code toOBBalanceType1Code(FRBalanceType type) {
        return type == null ? null : OBBalanceType1Code.valueOf(type.name());
    }
```
- Not a bug because v3 `OBBalanceType1Code` and `FRBalanceType` type names are aligned:
- [v3/account/OBBalanceType1Code.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v3/account/OBBalanceType1Code.java):
```
public enum OBBalanceType1Code {

    CLOSINGAVAILABLE("ClosingAvailable"),
    CLOSINGBOOKED("ClosingBooked"),
    ...
```
  - [account/FRBalanceType.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java#L23):
```
public enum FRBalanceType {
    CLOSINGAVAILABLE("ClosingAvailable"),
    CLOSINGBOOKED("ClosingBooked"),
    ...
```
- Note that the names are aligned between these two types - insulating FT type from OB type (v3 version)
So, no bug in this implementation.


#### OB v4

[v4/account/FRCashBalanceConverter.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/82ed133e376d46dbc5196bf7d33cd594790055cf/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRCashBalanceConverter.java#L34) impl as follows:
- the buggy version...
```
    public static OBBalanceType1Code toOBBalanceType1Code(FRBalanceType type) {
        return type == null ? null : OBBalanceType1Code.valueOf(type.name());
    }
```
- implementation delegated to [FRBalanceTypeConverter](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/b016ebfdbc1d1d4917009a702a80a9ccf1582bc2/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRBalanceTypeConverter.java) (this is a v4 specific class):
```
    public static OBBalanceType1Code toOBBalanceType1CodeV4(String balanceType) {
        if (v3tov4BalanceType.containsKey(balanceType)) {
            return OBBalanceType1Code.fromValue(v3tov4BalanceType.get(balanceType));
        }
        throw new IllegalArgumentException("Unknown balanceType: " + balanceType);
    }
```
- [v4/account/OBBalanceType1Code.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/b016ebfdbc1d1d4917009a702a80a9ccf1582bc2/secure-api-gateway-ob-uk-common-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/v4/account/OBBalanceType1Code.java#L26-L25):
```
public enum OBBalanceType1Code {
    CLAV("CLAV"),
    CLBD("CLBD"),
    ...
```
- [account/FRBalanceType.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/account/FRBalanceType.java#L23) (same as above for v3):
```
public enum FRBalanceType {
    CLOSINGAVAILABLE("ClosingAvailable"),
    CLOSINGBOOKED("ClosingBooked"),
    ...
```
- Note that the names are no longer aligned between these two types (`ClosingAvailable` => `CLAV`). Just as well for the `FRBalanceType` layer to insulate SAPIG. The converter needs to be smarter though now.

#### Usage comparison:

##### v3 FRTransactionConverter:
Class [v3/account/FRTransactionConverter.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v3/account/FRTransactionConverter.java#L40):
- see imports:
```
import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v3.account.FRCashBalanceConverter.toFRBalanceType;
import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v3.account.FRCashBalanceConverter.toOBBalanceType1Code;
```
  - v3 implementation is using our method `FRCashBalanceConverter#toOBBalanceType1Code`
- Here's the precise usage:
```
    public static OBTransactionCashBalance toOBTransactionCashBalance(FRTransactionData.FRTransactionCashBalance balance) {
        return balance == null ? null : new OBTransactionCashBalance()
                .amount(FRAmountConverter.toOBTransactionCashBalanceAmount(balance.getAmount()))
                .creditDebitIndicator(FRCreditDebitIndicatorConverter.toOBCreditDebitCode2(balance.getCreditDebitIndicator()))
                .type(toOBBalanceType1Code(balance.getType()));   // <--- HERE IT IS ***
    }
```

##### v4 FRTransactionConverter:
Class [v4/account/FRTransactionConverter.java](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-common/blob/aced8dc154d5272da1b8e912a289344ee74324c0/secure-api-gateway-ob-uk-common-datamodel/src/main/java/com/forgerock/sapi/gateway/ob/uk/common/datamodel/converter/v4/account/FRTransactionConverter.java#L31-L30):
- Note import differences
```
import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v4.account.FRBalanceTypeConverter.toOBBalanceType1CodeV4;
import static com.forgerock.sapi.gateway.ob.uk.common.datamodel.converter.v4.account.FRCashBalanceConverter.toFRBalanceType;
```
  - v4 is using generic `FRBalanceTypeConverter#toOBBalanceType1CodeV4` (note also the `V4` method suffix).
- Precise usage as follows:
```
public static OBTransactionCashBalance toOBTransactionCashBalance(FRTransactionData.FRTransactionCashBalance balance) {
    return balance == null ? null : new OBTransactionCashBalance()
            .amount(FRAmountConverter.toOBTransactionCashBalanceAmount(balance.getAmount()))
            .creditDebitIndicator(FRCreditDebitIndicatorConverter.toOBCreditDebitCode2(balance.getCreditDebitIndicator()))
            .type(toOBBalanceType1CodeV4(String.valueOf(balance.getType())));  <--- HERE ***
}
```
  - Uses generic `toOBBalanceType1CodeV4` - that `toOBBalanceType1Code` is no longer used for v4.
It's also not used at all downstream (RCS).